### PR TITLE
fix(a11y): add `aria-label` to `TextInput` clear button

### DIFF
--- a/src/primitives/textInput/textInput.tsx
+++ b/src/primitives/textInput/textInput.tsx
@@ -292,6 +292,7 @@ export const TextInput = forwardRef(function TextInput(
           tone={customValidity ? 'critical' : 'inherit'}
         >
           <Button
+            aria-label="Clear"
             data-qa="clear-button"
             fontSize={fontSize}
             icon={CloseIcon}


### PR DESCRIPTION
### Description

Simply adds an accessible `aria-label` to the `TextInput` component's clear button, similar to what's on `Autocomplete`. That's it!