### PR TITLE
fix: apply display: inline to SVGs to be tailwind compatible

### DIFF
--- a/src/primitives/code/styles.ts
+++ b/src/primitives/code/styles.ts
@@ -63,6 +63,12 @@ export function codeBaseStyle(): FlattenInterpolation<StyledThemeProps<Theme>> {
       border-radius: 1px;
     }
 
+    & svg {
+      /* Certain popular CSS libraries changes the defaults for SVG display */
+      /* Make sure SVGs are rendered as inline elements */
+      display: inline;
+    }
+
     & [data-sanity-icon] {
       vertical-align: baseline;
     }

--- a/src/primitives/heading/styles.ts
+++ b/src/primitives/heading/styles.ts
@@ -44,6 +44,12 @@ export function headingBaseStyle(
       }
     }
 
+    & svg {
+      /* Certain popular CSS libraries changes the defaults for SVG display */
+      /* Make sure SVGs are rendered as inline elements */
+      display: inline;
+    }
+
     & [data-sanity-icon] {
       vertical-align: baseline;
     }

--- a/src/primitives/label/styles.ts
+++ b/src/primitives/label/styles.ts
@@ -30,6 +30,12 @@ export function labelBaseStyle(
       border-radius: 1px;
     }
 
+    & svg {
+      /* Certain popular CSS libraries changes the defaults for SVG display */
+      /* Make sure SVGs are rendered as inline elements */
+      display: inline;
+    }
+
     & [data-sanity-icon] {
       vertical-align: baseline;
     }

--- a/src/primitives/text/styles.ts
+++ b/src/primitives/text/styles.ts
@@ -52,6 +52,12 @@ export function textBaseStyle(
       font-weight: ${weights.bold};
     }
 
+    & svg {
+      /* Certain popular CSS libraries changes the defaults for SVG display */
+      /* Make sure SVGs are rendered as inline elements */
+      display: inline;
+    }
+
     & [data-sanity-icon] {
       vertical-align: baseline;
     }


### PR DESCRIPTION
This fix allows removing ugly workarounds like: https://github.com/sanity-io/next-sanity/pull/232

And still have the right SVG alignment:

  
![next sanity build_studio_desk](https://user-images.githubusercontent.com/81981/208699836-b759568f-aeb7-44a1-9c56-6245693c73ac.png)

Without this fix, libraries like `next-sanity` has to use ugly CSS workarounds to avoid this outcome on projects that uses Tailwind:
![localhost_3000_](https://user-images.githubusercontent.com/81981/208699995-58fc9846-1ebe-4373-9f15-7d15cd2b8b87.png)

