### PR TITLE
fix: emit ESM with `.mjs`

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
       'ae-internal-missing-underscore': 'off',
     },
   },
-  legacyExports: true,
   minify: false,
   tsconfig: 'tsconfig.dist.json',
 })

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "sideEffects": false,
   "types": "./dist/index.d.ts",
   "source": "./src/index.ts",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "main": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js",
-      "default": "./dist/index.esm.js"
+      "default": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
[Adding `type: commonjs` in the package json ](https://github.com/sanity-io/ui/commit/34f62fef6128001bdb49284b9cd280f6a1307a36) without also updating the file endings used for ESM to `mjs` broke environments such as NextJS.

See:
- https://github.com/sanity-io/nextjs-blog-cms-sanity-v3/issues/155
- https://github.com/sanity-io/nextjs-blog-cms-sanity-v3/issues/154
- https://github.com/sanity-io/nextjs-blog-cms-sanity-v3/pull/157
- https://app.renovatebot.com/package-diff?name=@sanity/ui&from=1.0.4&to=1.0.6

Reproduced build outputs: https://vercel.com/sanity-io/nextjs-blog-cms-sanity-v3/4fr81igyWY9wnyLuUY4PcfHtCNGE