### PR TITLE
feat: allow hovered styles to be applied via the `data-hovered` attr

### DIFF
--- a/src/primitives/_selectable/style.ts
+++ b/src/primitives/_selectable/style.ts
@@ -65,6 +65,7 @@ export function selectableColorStyle(
 
         @media (hover: hover) {
           &:not([data-selected]) {
+            &[data-hovered],
             &:hover {
               ${_colorVarsStyle(base, tone.hovered)}
             }
@@ -94,6 +95,7 @@ export function selectableColorStyle(
 
         @media (hover: hover) {
           &:not([data-selected]) {
+            &[data-hovered],
             &:hover {
               ${_colorVarsStyle(base, tone.hovered)}
             }

--- a/src/primitives/button/styles.ts
+++ b/src/primitives/button/styles.ts
@@ -72,6 +72,7 @@ export function buttonColorStyles(
         '@media (hover: hover)': {
           '&:hover': _colorVarsStyle(base, color.hovered),
           '&:active': _colorVarsStyle(base, color.pressed),
+          '&[data-hovered]': _colorVarsStyle(base, color.hovered),
         },
         '&[data-selected]': _colorVarsStyle(base, color.pressed),
       },

--- a/src/primitives/card/styles.ts
+++ b/src/primitives/card/styles.ts
@@ -81,6 +81,7 @@ export function cardColorStyle(props: CardStyleProps & ThemeProps): FlattenSimpl
 
         @media (hover: hover) {
           &:not([data-pressed]):not([data-selected]) {
+            &[data-hovered],
             &:hover {
               ${_colorVarsStyle(base, card.hovered, $checkered)}
             }
@@ -123,6 +124,7 @@ export function cardColorStyle(props: CardStyleProps & ThemeProps): FlattenSimpl
 
         @media (hover: hover) {
           &:not([data-pressed]):not([data-selected]) {
+            &[data-hovered],
             &:hover {
               ${_colorVarsStyle(base, card.hovered, $checkered)}
             }


### PR DESCRIPTION
## Description
This PR enables hover styles for `<Button>`, `<Card>` and _selectable_ components (`<MenuGroup>`, `<MenuItem>`) to be displayed when `data-hovered` is set. This is similar to how `data-selected` works on these components.

Also similar to `data-selected`, the presence of `data-disabled` will override this behaviour, and these styles will also not be displayed if no hover support is detected.

This is in service of command lists in the studio that want to ergonomically set hover state on list items when navigating via the keyboard (e.g. global search).

## What to review
Setting `data-hovered` on any of the above components should display their hover styles.