### PR TITLE
fix: re-pin `@floating-ui/react-dom` to `1.1.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "workshop:start": "http-server -a localhost -c-0 -p 1337 -s -P http://localhost:1337/index.html? dist"
   },
   "dependencies": {
-    "@floating-ui/react-dom": "1.3.0",
+    "@floating-ui/react-dom": "1.1.1",
     "@sanity/color": "^2.2.3",
     "@sanity/icons": "^2.2.2",
     "csstype": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ specifiers:
   '@babel/preset-typescript': ^7.18.6
   '@commitlint/cli': ^17.4.4
   '@commitlint/config-conventional': ^17.4.4
-  '@floating-ui/react-dom': 1.3.0
+  '@floating-ui/react-dom': 1.1.1
   '@juggle/resize-observer': ^3.4.0
   '@sanity/color': ^2.2.3
   '@sanity/icons': ^2.2.2
@@ -64,7 +64,7 @@ specifiers:
   typescript: ^4.9.5
 
 dependencies:
-  '@floating-ui/react-dom': 1.3.0_biqbaboplfbrettd7655fr4n2y
+  '@floating-ui/react-dom': 1.1.1_biqbaboplfbrettd7655fr4n2y
   '@sanity/color': 2.2.3
   '@sanity/icons': 2.2.2_react@18.2.0
   csstype: 3.1.1
@@ -2124,8 +2124,8 @@ packages:
       '@floating-ui/core': 1.2.1
     dev: false
 
-  /@floating-ui/react-dom/1.3.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==}
+  /@floating-ui/react-dom/1.1.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-F27E+7SLB5NZvwF9Egqx/PlvxOhMnA6k/yNMQUqaQ9BPZdr4fQgSW6J6AKNIrBQElBT8IRDtv9j6h7FDkgp3dA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sanity-io/renovate-presets//ecosystem/auto", ":ignoreModulesAndTests"]
+  "extends": ["github>sanity-io/renovate-presets//ecosystem/auto", ":ignoreModulesAndTests"],
+  "ignoreDeps": ["@floating-ui/react-dom"]
 }


### PR DESCRIPTION
## Description

This PR re-pins `@floating-ui/react-dom` to `1.1.1` (originally added in 1eb56ef3411cc72ae9096aa3a20c3e5cc7b76602)

It also adds it to renovate's ignore list, so it hopefully shouldn't be automatically overridden in future.

As a reminder: we currently pin to this version to avoid placement issues with `<Popover>` content when `open` is true on mount.