### PR TITLE
fix: avoid scroll on `overflow: hidden`

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -109,6 +109,7 @@ const DialogCardRoot = styled(Card)`
   min-height: 0;
   max-height: 100%;
   overflow: hidden;
+  overflow: clip;
 `
 
 const DialogLayout = styled(Flex)`

--- a/src/primitives/button/__workshop__/sanityUploadButton.tsx
+++ b/src/primitives/button/__workshop__/sanityUploadButton.tsx
@@ -6,6 +6,7 @@ const SanityUploadButton = styled(Button).attrs({forwardedAs: 'label'})`
   & input {
     -webkit-appearance: none;
     overflow: hidden;
+    overflow: clip;
     top: 0;
     left: 0;
     width: 100%;

--- a/src/primitives/heading/heading.tsx
+++ b/src/primitives/heading/heading.tsx
@@ -39,6 +39,7 @@ const SpanWithTextOverflow = styled.span`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  overflow: clip;
 `
 
 /**

--- a/src/primitives/label/label.tsx
+++ b/src/primitives/label/label.tsx
@@ -36,6 +36,7 @@ const SpanWithTextOverflow = styled.span`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  overflow: clip;
 `
 
 /**

--- a/src/primitives/text/text.tsx
+++ b/src/primitives/text/text.tsx
@@ -39,6 +39,7 @@ const SpanWithTextOverflow = styled.span`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  overflow: clip;
 `
 
 /**

--- a/src/utils/srOnly/srOnly.tsx
+++ b/src/utils/srOnly/srOnly.tsx
@@ -15,6 +15,7 @@ const Root = styled.div`
   height: 0;
   position: absolute;
   overflow: hidden;
+  overflow: clip;
 `
 
 /**


### PR DESCRIPTION
When `overflow: hidden` browsers turn off scrollbars and the user can no longer scroll. But it can still be scrolled if the APIs `.focus()` and `.scrollIntoView`, as well as with other native browser behaviour as browsers still consider them scrolling boxes.

This video demonstrates how `overflow: hidden` is being scrolled into breaking the Studio layout when opening an edit intent link on iOS Safari that ends up in a field inside a dialog. 

https://user-images.githubusercontent.com/81981/236252831-515d3752-6957-465d-9e25-84b7544ace06.mp4

What makes matters worse is that since `overflow: hidden` disables user scroll the user can't recover from this broken state in a lot of cases. And there are many other ways it can break the layout and UI.

The new `overflow: clip` fixes this and turns of all scrolling. By adding it after `overflow: hidden` it's applied in browsers that support it, while those who don't continue to use `overflow: hidden`.