### PR TITLE
feat: support passing custom component to tree item link

### DIFF
--- a/src/components/tree/treeItem.tsx
+++ b/src/components/tree/treeItem.tsx
@@ -1,7 +1,7 @@
 import {ToggleArrowRightIcon} from '@sanity/icons'
 import {createElement, memo, useCallback, useEffect, useId, useMemo, useRef} from 'react'
 import styled from 'styled-components'
-import {Box, Flex, Text} from '../../primitives'
+import {Box, BoxProps, Flex, Text} from '../../primitives'
 import {ThemeFontWeightKey} from '../../theme'
 import {
   treeItemRootStyle,
@@ -24,6 +24,10 @@ export interface TreeItemProps {
   space?: number | number[]
   text?: React.ReactNode
   weight?: ThemeFontWeightKey
+  /**
+   * Allows passing a custom element type to the link component
+   */
+  linkAs?: BoxProps['as']
 }
 
 const Root = memo(styled.li(treeItemRootStyle, treeItemRootColorStyle))
@@ -57,6 +61,7 @@ export const TreeItem = memo(function TreeItem(
     space = 2,
     text,
     weight,
+    linkAs,
     ...restProps
   } = props
   const rootRef = useRef<HTMLLIElement | null>(null)
@@ -157,6 +162,7 @@ export const TreeItem = memo(function TreeItem(
           ref={treeitemRef}
           role="treeitem"
           tabIndex={tabIndex}
+          as={linkAs}
         >
           {content}
         </TreeItemBox>

--- a/src/components/tree/treeItem.tsx
+++ b/src/components/tree/treeItem.tsx
@@ -20,14 +20,14 @@ export interface TreeItemProps {
   expanded?: boolean
   fontSize?: number | number[]
   icon?: React.ElementType
-  padding?: number | number[]
-  space?: number | number[]
-  text?: React.ReactNode
-  weight?: ThemeFontWeightKey
   /**
    * Allows passing a custom element type to the link component
    */
   linkAs?: BoxProps['as']
+  padding?: number | number[]
+  space?: number | number[]
+  text?: React.ReactNode
+  weight?: ThemeFontWeightKey
 }
 
 const Root = memo(styled.li(treeItemRootStyle, treeItemRootColorStyle))
@@ -54,6 +54,7 @@ export const TreeItem = memo(function TreeItem(
     href,
     icon,
     id: idProp,
+    linkAs,
     muted,
     onClick,
     padding = 3,
@@ -61,7 +62,6 @@ export const TreeItem = memo(function TreeItem(
     space = 2,
     text,
     weight,
-    linkAs,
     ...restProps
   } = props
   const rootRef = useRef<HTMLLIElement | null>(null)
@@ -157,12 +157,12 @@ export const TreeItem = memo(function TreeItem(
         <TreeItemBox
           $level={tree.level}
           aria-expanded={expanded}
+          as={linkAs}
           data-ui="TreeItem__box"
           href={href}
           ref={treeitemRef}
           role="treeitem"
           tabIndex={tabIndex}
-          as={linkAs}
         >
           {content}
         </TreeItemBox>


### PR DESCRIPTION
Supports passing custom link component to TreeItem, this is useful when using in a Next.js application where instead of `a` tag you can pass `Link` component from Next. 

Let me know if the naming and the API makes sense.