### PR TITLE
fix: issue with tabbing on tree

### DIFF
--- a/src/components/tree/__workshop__/index.ts
+++ b/src/components/tree/__workshop__/index.ts
@@ -11,5 +11,11 @@ export default defineScope({
       component: lazy(() => import('./basic')),
       // options: {perfTests: () => import('./basic.perf')},
     },
+    {
+      name: 'tab',
+      title: 'Tab',
+      component: lazy(() => import('./tabFromElement')),
+      // options: {perfTests: () => import('./basic.perf')},
+    },
   ],
 })

--- a/src/components/tree/__workshop__/tabFromElement.tsx
+++ b/src/components/tree/__workshop__/tabFromElement.tsx
@@ -28,7 +28,7 @@ export default function BasicStory() {
       </Box>
       <Wrapper>
         <TextInput />
-        <Tree ref={ref} space={1}>
+        <Tree ref={ref} space={1} onFocus={() => console.log("I'm focus!")}>
           <TreeItem onClick={handleClick} expanded text="Fruit">
             <TreeItem
               data-testid="oranges"

--- a/src/components/tree/__workshop__/tabFromElement.tsx
+++ b/src/components/tree/__workshop__/tabFromElement.tsx
@@ -17,6 +17,10 @@ export default function BasicStory() {
     if (testid) setId(testid)
   }, [])
 
+  const handleFocus = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+    console.log("I'm focused")
+  }, [])
+
   return (
     <Box padding={[4, 5, 6]}>
       <Box paddingY={3}>
@@ -28,7 +32,7 @@ export default function BasicStory() {
       </Box>
       <Wrapper>
         <TextInput />
-        <Tree ref={ref} space={1} onFocus={() => console.log("I'm focus!")}>
+        <Tree ref={ref} space={1} onFocus={handleFocus}>
           <TreeItem onClick={handleClick} expanded text="Fruit">
             <TreeItem
               data-testid="oranges"

--- a/src/components/tree/__workshop__/tabFromElement.tsx
+++ b/src/components/tree/__workshop__/tabFromElement.tsx
@@ -1,5 +1,5 @@
 import {LinkIcon} from '@sanity/icons'
-import {Box, TextInput, Tree, TreeItem} from '@sanity/ui'
+import {Box, TextInput, Tree, TreeItem, Text} from '@sanity/ui'
 import {usePerfTest} from '@sanity/ui-workshop/plugin-perf'
 import {useCallback, useState} from 'react'
 import {perfTests} from './basic.perf'
@@ -19,10 +19,12 @@ export default function BasicStory() {
 
   return (
     <Box padding={[4, 5, 6]}>
-      <Box padding={2}>
-        This example is to demonstrate that when you tab from an outside element (using the keyboard
-        to navigate), you can still access the tree and tree item. Press the input beneath and start
-        tabbing / using the arrow.
+      <Box paddingY={3}>
+        <Text>
+          This example is to demonstrate that when you tab from an outside element (using the
+          keyboard to navigate), you can still access the tree and tree item. Press the input
+          beneath and start tabbing / using the arrow.
+        </Text>
       </Box>
       <Wrapper>
         <TextInput />

--- a/src/components/tree/__workshop__/tabFromElement.tsx
+++ b/src/components/tree/__workshop__/tabFromElement.tsx
@@ -8,6 +8,7 @@ export default function BasicStory() {
   const {ref, Wrapper} = usePerfTest(perfTests[0])
 
   const [id, setId] = useState('')
+  const [focus, setFocus] = useState('')
 
   const handleClick = useCallback((event: React.MouseEvent) => {
     event.preventDefault()
@@ -18,7 +19,8 @@ export default function BasicStory() {
   }, [])
 
   const handleFocus = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
-    console.log("I'm focused")
+    const elementFocus = event.target.getAttribute('data-testid')
+    if (elementFocus) setFocus(elementFocus)
   }, [])
 
   return (
@@ -30,10 +32,13 @@ export default function BasicStory() {
           beneath and start tabbing / using the arrow.
         </Text>
       </Box>
+      <Box paddingY={3}>
+        <Text>Focus: {focus}</Text>
+      </Box>
       <Wrapper>
         <TextInput />
         <Tree ref={ref} space={1} onFocus={handleFocus}>
-          <TreeItem onClick={handleClick} expanded text="Fruit">
+          <TreeItem data-testid="fruit" onClick={handleClick} expanded text="Fruit">
             <TreeItem
               data-testid="oranges"
               onClick={handleClick}
@@ -61,52 +66,14 @@ export default function BasicStory() {
               />
               <TreeItem data-testid="apples/fuji" onClick={handleClick} text="Fuji" />
             </TreeItem>
-            <TreeItem onClick={handleClick} text="Bananas" />
-            <TreeItem onClick={handleClick} text="Pears">
-              <TreeItem onClick={handleClick} text="Anjou" />
-              <TreeItem onClick={handleClick} text="Bartlett" />
-              <TreeItem onClick={handleClick} text="Bosc" />
-              <TreeItem onClick={handleClick} text="Concorde" />
-              <TreeItem onClick={handleClick} text="Seckel" />
-              <TreeItem onClick={handleClick} text="Starkrimson" />
-            </TreeItem>
-          </TreeItem>
-          <TreeItem onClick={handleClick} text="Vegetables">
-            <TreeItem onClick={handleClick} text="Podded vegetables">
-              <TreeItem onClick={handleClick} text="Lentil" />
-              <TreeItem onClick={handleClick} text="Pea" />
-              <TreeItem onClick={handleClick} text="Peanut" />
-            </TreeItem>
-            <TreeItem onClick={handleClick} text="Bulb and stem vegetables">
-              <TreeItem onClick={handleClick} text="Asparagus" />
-              <TreeItem onClick={handleClick} text="Celery" />
-              <TreeItem onClick={handleClick} text="Leek" />
-              <TreeItem onClick={handleClick} text="Onion" />
-            </TreeItem>
-            <TreeItem onClick={handleClick} text="Root and tuberous vegetables">
-              <TreeItem onClick={handleClick} text="Carrot" />
-              <TreeItem onClick={handleClick} text="Ginger" />
-              <TreeItem onClick={handleClick} text="Parsnip" />
-              <TreeItem onClick={handleClick} text="Potato" />
-            </TreeItem>
-          </TreeItem>
-          <TreeItem onClick={handleClick} text="Grains">
-            <TreeItem onClick={handleClick} text="Cereal grains">
-              <TreeItem onClick={handleClick} text="Barley" />
-              <TreeItem onClick={handleClick} text="Oats" />
-              <TreeItem onClick={handleClick} text="Rice" />
-            </TreeItem>
-            <TreeItem onClick={handleClick} text="Pseudocereal grains">
-              <TreeItem onClick={handleClick} text="Amaranth" />
-              <TreeItem onClick={handleClick} text="Buckwheat" />
-              <TreeItem onClick={handleClick} text="Chia" />
-              <TreeItem onClick={handleClick} text="Quinoa" />
-            </TreeItem>
-            <TreeItem onClick={handleClick} text="Oilseeds">
-              <TreeItem onClick={handleClick} text="India mustard" />
-              <TreeItem onClick={handleClick} text="Safflower" />
-              <TreeItem onClick={handleClick} text="Flax seed" />
-              <TreeItem onClick={handleClick} text="Poppy seed" />
+            <TreeItem data-testid="bananas" onClick={handleClick} text="Bananas" />
+            <TreeItem data-testid="pears" onClick={handleClick} text="Pears">
+              <TreeItem data-testid="pears/anjou" onClick={handleClick} text="Anjou" />
+              <TreeItem data-testid="pears/bartlett" onClick={handleClick} text="Bartlett" />
+              <TreeItem data-testid="pears/bosc" onClick={handleClick} text="Bosc" />
+              <TreeItem data-testid="pears/concorde" onClick={handleClick} text="Concorde" />
+              <TreeItem data-testid="pears/seckel" onClick={handleClick} text="Seckel" />
+              <TreeItem data-testid="pears/starkrimson" onClick={handleClick} text="Starkrimson" />
             </TreeItem>
           </TreeItem>
         </Tree>

--- a/src/components/tree/__workshop__/tabFromElement.tsx
+++ b/src/components/tree/__workshop__/tabFromElement.tsx
@@ -1,0 +1,110 @@
+import {LinkIcon} from '@sanity/icons'
+import {Box, TextInput, Tree, TreeItem} from '@sanity/ui'
+import {usePerfTest} from '@sanity/ui-workshop/plugin-perf'
+import {useCallback, useState} from 'react'
+import {perfTests} from './basic.perf'
+
+export default function BasicStory() {
+  const {ref, Wrapper} = usePerfTest(perfTests[0])
+
+  const [id, setId] = useState('')
+
+  const handleClick = useCallback((event: React.MouseEvent) => {
+    event.preventDefault()
+
+    const testid = event.currentTarget.getAttribute('data-testid')
+
+    if (testid) setId(testid)
+  }, [])
+
+  return (
+    <Box padding={[4, 5, 6]}>
+      <Box padding={2}>
+        This example is to demonstrate that when you tab from an outside element (using the keyboard
+        to navigate), you can still access the tree and tree item. Press the input beneath and start
+        tabbing / using the arrow.
+      </Box>
+      <Wrapper>
+        <TextInput />
+        <Tree ref={ref} space={1}>
+          <TreeItem onClick={handleClick} expanded text="Fruit">
+            <TreeItem
+              data-testid="oranges"
+              onClick={handleClick}
+              selected={id === 'oranges'}
+              text="Oranges"
+            />
+            <TreeItem
+              data-testid="pineapples"
+              onClick={handleClick}
+              text="Pineapples"
+              selected={id === 'pineapples'}
+            />
+            <TreeItem data-testid="apples" onClick={handleClick} text="Apples">
+              <TreeItem
+                data-testid="apples/macintosh"
+                onClick={handleClick}
+                href="/apples/macintosh"
+                icon={LinkIcon}
+                text="Macintosh"
+              />
+              <TreeItem
+                data-testid="apples/granny-smith"
+                onClick={handleClick}
+                text="Granny Smith"
+              />
+              <TreeItem data-testid="apples/fuji" onClick={handleClick} text="Fuji" />
+            </TreeItem>
+            <TreeItem onClick={handleClick} text="Bananas" />
+            <TreeItem onClick={handleClick} text="Pears">
+              <TreeItem onClick={handleClick} text="Anjou" />
+              <TreeItem onClick={handleClick} text="Bartlett" />
+              <TreeItem onClick={handleClick} text="Bosc" />
+              <TreeItem onClick={handleClick} text="Concorde" />
+              <TreeItem onClick={handleClick} text="Seckel" />
+              <TreeItem onClick={handleClick} text="Starkrimson" />
+            </TreeItem>
+          </TreeItem>
+          <TreeItem onClick={handleClick} text="Vegetables">
+            <TreeItem onClick={handleClick} text="Podded vegetables">
+              <TreeItem onClick={handleClick} text="Lentil" />
+              <TreeItem onClick={handleClick} text="Pea" />
+              <TreeItem onClick={handleClick} text="Peanut" />
+            </TreeItem>
+            <TreeItem onClick={handleClick} text="Bulb and stem vegetables">
+              <TreeItem onClick={handleClick} text="Asparagus" />
+              <TreeItem onClick={handleClick} text="Celery" />
+              <TreeItem onClick={handleClick} text="Leek" />
+              <TreeItem onClick={handleClick} text="Onion" />
+            </TreeItem>
+            <TreeItem onClick={handleClick} text="Root and tuberous vegetables">
+              <TreeItem onClick={handleClick} text="Carrot" />
+              <TreeItem onClick={handleClick} text="Ginger" />
+              <TreeItem onClick={handleClick} text="Parsnip" />
+              <TreeItem onClick={handleClick} text="Potato" />
+            </TreeItem>
+          </TreeItem>
+          <TreeItem onClick={handleClick} text="Grains">
+            <TreeItem onClick={handleClick} text="Cereal grains">
+              <TreeItem onClick={handleClick} text="Barley" />
+              <TreeItem onClick={handleClick} text="Oats" />
+              <TreeItem onClick={handleClick} text="Rice" />
+            </TreeItem>
+            <TreeItem onClick={handleClick} text="Pseudocereal grains">
+              <TreeItem onClick={handleClick} text="Amaranth" />
+              <TreeItem onClick={handleClick} text="Buckwheat" />
+              <TreeItem onClick={handleClick} text="Chia" />
+              <TreeItem onClick={handleClick} text="Quinoa" />
+            </TreeItem>
+            <TreeItem onClick={handleClick} text="Oilseeds">
+              <TreeItem onClick={handleClick} text="India mustard" />
+              <TreeItem onClick={handleClick} text="Safflower" />
+              <TreeItem onClick={handleClick} text="Flax seed" />
+              <TreeItem onClick={handleClick} text="Poppy seed" />
+            </TreeItem>
+          </TreeItem>
+        </Tree>
+      </Wrapper>
+    </Box>
+  )
+}

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -190,7 +190,7 @@ export const Tree = memo(
         // Call the element's `focus` handler
         props.onFocus?.(event)
       },
-      [props]
+      [props.onFocus]
     )
 
     useEffect(() => {

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -23,7 +23,7 @@ export const Tree = memo(
       Omit<React.HTMLProps<HTMLDivElement>, 'align' | 'as' | 'height' | 'ref' | 'role' | 'wrap'>,
     ref: React.ForwardedRef<HTMLDivElement>
   ): React.ReactElement {
-    const {children, space = 1, ...restProps} = props
+    const {children, space = 1, onFocus, ...restProps} = props
     const forwardedRef = useForwardedRef(ref)
     const [focusedElement, setFocusedElement] = useState<HTMLElement | null>(null)
     const focusedElementRef = useRef(focusedElement)
@@ -188,9 +188,9 @@ export const Tree = memo(
         setFocusedElement(event.target)
 
         // Call the element's `focus` handler
-        props.onFocus?.(event)
+        onFocus?.(event)
       },
-      [props.onFocus]
+      [onFocus]
     )
 
     useEffect(() => {

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -183,9 +183,15 @@ export const Tree = memo(
       [itemElements]
     )
 
-    const handleOnFocus = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
-      setFocusedElement(event.target as HTMLElement)
-    }, [])
+    const handleFocus = useCallback(
+      (event: React.FocusEvent<HTMLDivElement>) => {
+        setFocusedElement(event.target)
+
+        // Call the element's `focus` handler
+        props.onFocus?.(event)
+      },
+      [props]
+    )
 
     useEffect(() => {
       if (!forwardedRef.current) return
@@ -206,7 +212,7 @@ export const Tree = memo(
           ref={forwardedRef}
           role="tree"
           space={space}
-          onFocus={handleOnFocus}
+          onFocus={handleFocus}
         >
           {children}
         </Stack>

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -183,6 +183,10 @@ export const Tree = memo(
       [itemElements]
     )
 
+    const handleOnFocus = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+      setFocusedElement(event.target as HTMLElement)
+    }, [])
+
     useEffect(() => {
       if (!forwardedRef.current) return
       const _itemElements = Array.from(
@@ -202,6 +206,7 @@ export const Tree = memo(
           ref={forwardedRef}
           role="tree"
           space={space}
+          onFocus={handleOnFocus}
         >
           {children}
         </Stack>

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -208,11 +208,11 @@ export const Tree = memo(
           as="ul"
           data-ui="Tree"
           {...restProps}
+          onFocus={handleFocus}
           onKeyDown={handleKeyDown}
           ref={forwardedRef}
           role="tree"
           space={space}
-          onFocus={handleFocus}
         >
           {children}
         </Stack>


### PR DESCRIPTION
👋 
There was an issue where when focusing on a tree element when coming from an outside element (such an input), the ref in the tree wasn't being updated (which in turn broke the navigation on the tree).

You can see the current issue [here](https://www.sanity.io/ui/arcade?mode=jsx&jsx=eJztkM0KwjAQhM%2FmKQbPQrHnNKA3bx58gWhWLWgS0i0tlL67tf4U6w960JO5ZNl8M9kdOXUlvDYmtZukims1D5Rl4C0htT5nrNOQ8ejYsNDMtPcMdmC9RAQdgitgXGHhbCviQCSjxlQJISc5u5Xb%2Bx0xIVJCLppXJYC2mDVmoNJra8gkFYecajCVnFRDvVwN6yP5Bju%2BkMD56iSdXdxRkNEFUD9UvGny8a9XQR8XGNy2RM%2FjSaDxP9Cn%2Bd2H92jc17v0p%2Fgm3dvhVKtBew7YFyaR&title=TreeItem)