### PR TITLE
fix: allow for enter to close / open items in treeItem

### DIFF
--- a/src/components/tree/treeItem.tsx
+++ b/src/components/tree/treeItem.tsx
@@ -89,7 +89,7 @@ export const TreeItem = memo(function TreeItem(
 
       if (
         target instanceof HTMLElement &&
-        (target.getAttribute('data-ui') === 'TreeItem__box' ||
+        (target.getAttribute('data-ui') === 'TreeItem' ||
           target.closest('[data-ui="TreeItem__box"]'))
       ) {
         event.stopPropagation()


### PR DESCRIPTION
👋 
There was an issue where when using the keyboard to navigate through a item list you weren't able to close the item tree. I'm unsure if this is something that should be currently allowed but it made sense especially while we were trying to transverse large multiple item lists (that they themselves have tree items that can close / open)

You can see the current issue [here](https://www.sanity.io/ui/arcade?mode=jsx&jsx=eJztkM0KwjAQhM%2FmKQbPQrHnNKA3bx58gWhWLWgS0i0tlL67tf4U6w960JO5ZNl8M9kdOXUlvDYmtZukims1D5Rl4C0htT5nrNOQ8ejYsNDMtPcMdmC9RAQdgitgXGHhbCviQCSjxlQJISc5u5Xb%2Bx0xIVJCLppXJYC2mDVmoNJra8gkFYecajCVnFRDvVwN6yP5Bju%2BkMD56iSdXdxRkNEFUD9UvGny8a9XQR8XGNy2RM%2FjSaDxP9Cn%2Bd2H92jc17v0p%2Fgm3dvhVKtBew7YFyaR&title=TreeItem) 

https://github.com/sanity-io/ui/assets/6951139/55c3cd60-ae2f-4c0d-892a-659e74852bda

This will fix it (follows the same actions as the "onClick" 
