### PR TITLE
fix(primitives): close tooltip on button click

### DIFF
--- a/src/primitives/tooltip/__workshop__/props.tsx
+++ b/src/primitives/tooltip/__workshop__/props.tsx
@@ -12,6 +12,7 @@ export default function PropsStory() {
   const placement = useSelect('Placement', WORKSHOP_PLACEMENT_OPTIONS, 'top')
   const portal = useBoolean('Portal', true)
   const shadow = useSelect('Shadow', WORKSHOP_SHADOW_OPTIONS, 2)
+  const closeOnClick = useBoolean('Close on click', true)
 
   return (
     <Card height="fill">
@@ -22,6 +23,7 @@ export default function PropsStory() {
           placement={placement}
           portal={portal}
           shadow={shadow}
+          closeOnClick={closeOnClick}
         >
           <Button mode="bleed" text="Hover me" />
         </Tooltip>

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -36,6 +36,7 @@ export interface TooltipProps extends Omit<LayerProps, 'as'> {
   allowedAutoPlacements?: Placement[]
   boundaryElement?: HTMLElement | null
   children?: React.ReactElement
+  closeOnClick?: boolean
   content?: React.ReactNode
   disabled?: boolean
   fallbackPlacements?: Placement[]
@@ -62,6 +63,7 @@ export const Tooltip = forwardRef(function Tooltip(
   const {
     boundaryElement = boundaryElementContext?.element,
     children: childProp,
+    closeOnClick = false,
     content,
     disabled,
     fallbackPlacements: fallbackPlacementsProp,
@@ -148,7 +150,11 @@ export const Tooltip = forwardRef(function Tooltip(
   const handleFocus = useCallback(() => setIsOpen(true), [])
   const handleMouseEnter = useCallback(() => setIsOpen(true), [])
   const handleMouseLeave = useCallback(() => setIsOpen(false), [])
-  const handleOnClick = useCallback(() => setIsOpen(false), [])
+  const handleOnClick = useCallback(() => {
+    if (closeOnClick) {
+      setIsOpen(false)
+    }
+  }, [closeOnClick])
 
   // Detect whether the mouse is moving outside of the reference element. This is sometimes
   // necessary, because the tooltip might not always close as it should (e.g. when clicking
@@ -229,17 +235,20 @@ export const Tooltip = forwardRef(function Tooltip(
       onFocus: handleFocus,
       onMouseEnter: handleMouseEnter,
       onMouseLeave: handleMouseLeave,
-      onClick: handleOnClick,
+      onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+        handleOnClick()
+        childProp.props.onClick?.(e)
+      },
       ref: setReference,
     })
   }, [
     childProp,
+    handleOnClick,
     handleBlur,
     handleFocus,
     handleMouseEnter,
     handleMouseLeave,
     setReference,
-    handleOnClick,
   ])
 
   if (!child) return <></>

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -148,6 +148,7 @@ export const Tooltip = forwardRef(function Tooltip(
   const handleFocus = useCallback(() => setIsOpen(true), [])
   const handleMouseEnter = useCallback(() => setIsOpen(true), [])
   const handleMouseLeave = useCallback(() => setIsOpen(false), [])
+  const handleOnClick = useCallback(() => setIsOpen(false), [])
 
   // Detect whether the mouse is moving outside of the reference element. This is sometimes
   // necessary, because the tooltip might not always close as it should (e.g. when clicking
@@ -228,9 +229,18 @@ export const Tooltip = forwardRef(function Tooltip(
       onFocus: handleFocus,
       onMouseEnter: handleMouseEnter,
       onMouseLeave: handleMouseLeave,
+      onClick: handleOnClick,
       ref: setReference,
     })
-  }, [childProp, handleBlur, handleFocus, handleMouseEnter, handleMouseLeave, setReference])
+  }, [
+    childProp,
+    handleBlur,
+    handleFocus,
+    handleMouseEnter,
+    handleMouseLeave,
+    setReference,
+    handleOnClick,
+  ])
 
   if (!child) return <></>
 

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -235,7 +235,7 @@ export const Tooltip = forwardRef(function Tooltip(
       onFocus: handleFocus,
       onMouseEnter: handleMouseEnter,
       onMouseLeave: handleMouseLeave,
-      onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+      onClick: (e: React.MouseEvent<HTMLElement>) => {
         handleOnClick()
         childProp.props.onClick?.(e)
       },


### PR DESCRIPTION
If a tooltip was added to a button that opened a popover for instance, the tooltip would show underneath the popover. This pr adds a a `closeOnClick` prop that closes the tooltip when the child element is clicked. 

<img width="294" alt="Clipboard 2023-26-06 at 11 08 18 AM" src="https://github.com/sanity-io/ui/assets/44635000/dfd8d1d1-1d10-4e7e-98ab-2e206e9253c1">
