### PR TITLE
fix(components): add maxwidth to tabs

### DIFF
--- a/src/components/tab/__workshop__/example.tsx
+++ b/src/components/tab/__workshop__/example.tsx
@@ -1,9 +1,14 @@
 import {OkHandIcon, RocketIcon, SunIcon} from '@sanity/icons'
 import {Box, Card, Tab, TabList, TabPanel, Text} from '@sanity/ui'
+import {useBoolean} from '@sanity/ui-workshop'
 import {useState} from 'react'
 
 export default function ExampleStory() {
   const [tab, setTab] = useState('foo')
+  const useLongTitle = useBoolean('Use long title', false, 'Props') || false
+
+  const longTitle =
+    "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
 
   return (
     <Box padding={[4, 5, 6]}>
@@ -28,7 +33,7 @@ export default function ExampleStory() {
           aria-controls="example-panel-baz"
           icon={OkHandIcon}
           id="example-tab-baz"
-          label="Baz"
+          label={useLongTitle ? longTitle : 'Baz'}
           onClick={() => setTab('baz')}
           selected={tab === 'baz'}
         />

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -1,4 +1,5 @@
 import {forwardRef, useCallback, useEffect, useRef} from 'react'
+import styled from 'styled-components'
 import {useForwardedRef} from '../../hooks'
 import {Button} from '../../primitives'
 import {ButtonTone} from '../../types'
@@ -20,6 +21,10 @@ export interface TabProps {
   selected?: boolean
   tone?: ButtonTone
 }
+
+const CustomButton = styled(Button)`
+  max-width: 100%;
+`
 
 /**
  * @public
@@ -71,7 +76,7 @@ export const Tab = forwardRef(function Tab(
   }
 
   return (
-    <Button
+    <CustomButton
       data-ui="Tab"
       {...restProps}
       aria-selected={selected ? 'true' : 'false'}

--- a/src/components/tab/tabList.tsx
+++ b/src/components/tab/tabList.tsx
@@ -1,4 +1,5 @@
 import {cloneElement, forwardRef, useCallback, useMemo, useState} from 'react'
+import styled from 'styled-components'
 import {Inline, InlineProps} from '../../primitives'
 
 /**
@@ -11,6 +12,16 @@ export interface TabListProps extends Omit<InlineProps, 'as' | 'height'> {
 function _isReactElement(node: unknown): node is React.ReactElement {
   return Boolean(node)
 }
+
+//Limits the width of tabs in tablist
+const CustomInline = styled(Inline)`
+  & > div {
+    display: inline-block;
+    vertical-align: middle;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+`
 
 /**
  * @public
@@ -52,8 +63,14 @@ export const TabList = forwardRef(function TabList(
   )
 
   return (
-    <Inline data-ui="TabList" {...restProps} onKeyDown={handleKeyDown} ref={ref} role="tablist">
+    <CustomInline
+      data-ui="TabList"
+      {...restProps}
+      onKeyDown={handleKeyDown}
+      ref={ref}
+      role="tablist"
+    >
       {tabs}
-    </Inline>
+    </CustomInline>
   )
 })


### PR DESCRIPTION
Tabs had horizontal scroll when the title is very long, there was no limit to the width. This pr customise the `Inline` component for the `tabList` to prevent the tabs to overflow the width of the parent container. 

![Screenshot 2023-07-24 at 15 21 36](https://github.com/sanity-io/ui/assets/44635000/eb5f70fd-b66c-4c21-9371-b5c4a1667f6b)

Note: should the children of the inline object always have a maxWidth of 100%? This would make sense in most cases, but not sure if it should be added to every case.. 