### PR TITLE
fix(tooltip): use floatingStyles to prevent rerenders of tooltip

### DIFF
--- a/src/primitives/tooltip/__workshop__/props.tsx
+++ b/src/primitives/tooltip/__workshop__/props.tsx
@@ -7,10 +7,7 @@ import {
 } from '../../../__workshop__/constants'
 
 export default function PropsStory() {
-  const text =
-    "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like)."
-
-  const content = useText('Content', text)
+  const content = useText('Content', 'Tooltip content')
   const padding = useSelect('Padding', WORKSHOP_SPACE_OPTIONS, 2, 'Props')
   const placement = useSelect('Placement', WORKSHOP_PLACEMENT_OPTIONS, 'top')
   const portal = useBoolean('Portal', true)

--- a/src/primitives/tooltip/__workshop__/props.tsx
+++ b/src/primitives/tooltip/__workshop__/props.tsx
@@ -7,7 +7,10 @@ import {
 } from '../../../__workshop__/constants'
 
 export default function PropsStory() {
-  const content = useText('Content', 'Tooltip content')
+  const text =
+    "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like)."
+
+  const content = useText('Content', text)
   const padding = useSelect('Padding', WORKSHOP_SPACE_OPTIONS, 2, 'Props')
   const placement = useSelect('Placement', WORKSHOP_PLACEMENT_OPTIONS, 'top')
   const portal = useBoolean('Portal', true)

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -57,7 +57,7 @@ const Root = styled(Layer)`
  */
 export const Tooltip = forwardRef(function Tooltip(
   props: TooltipProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content'>,
-  ref: React.ForwardedRef<HTMLDivElement>
+  ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   const boundaryElementContext = useBoundaryElement()
   const theme = useTheme()
@@ -92,7 +92,7 @@ export const Tooltip = forwardRef(function Tooltip(
         padding: 4,
         rootBoundary,
         mainAxis: false,
-      })
+      }),
     )
 
     // Define distance between reference and floating element
@@ -107,7 +107,7 @@ export const Tooltip = forwardRef(function Tooltip(
             maxHeight: `${availableHeight}px`,
           })
         },
-      })
+      }),
     )
 
     // Shift the tooltip so its sits with the boundary eleement
@@ -116,7 +116,7 @@ export const Tooltip = forwardRef(function Tooltip(
         boundary: boundaryElement || undefined,
         rootBoundary,
         padding: 4,
-      })
+      }),
     )
 
     // Place arrow
@@ -199,7 +199,7 @@ export const Tooltip = forwardRef(function Tooltip(
       arrowRef.current = arrowEl
       update()
     },
-    [update]
+    [update],
   )
 
   const setFloating = useCallback(
@@ -207,7 +207,7 @@ export const Tooltip = forwardRef(function Tooltip(
       forwardedRef.current = node
       refs.setFloating(node)
     },
-    [forwardedRef, refs]
+    [forwardedRef, refs],
   )
 
   const childRef: ForwardedRef<HTMLElement | null> = (childProp as any)?.ref
@@ -223,7 +223,7 @@ export const Tooltip = forwardRef(function Tooltip(
       // childRef.current = node
       setReferenceElement(node)
     },
-    [childRef]
+    [childRef],
   )
 
   const child = useMemo(() => {

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -103,8 +103,8 @@ export const Tooltip = forwardRef(function Tooltip(
       size({
         apply({availableWidth, availableHeight, elements}) {
           Object.assign(elements.floating.style, {
-            maxWidth: `${availableWidth}px`,
-            maxHeight: `${availableHeight}px`,
+            maxWidth: `${availableWidth - 4 * 2}px`, // the padding is `4px`
+            maxHeight: `${availableHeight - 4 * 2}px`, // the padding is `4px`
           })
         },
       }),

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -8,6 +8,7 @@ import {
   useFloating,
   Middleware,
   RootBoundary,
+  size,
 } from '@floating-ui/react-dom'
 import {
   cloneElement,
@@ -56,7 +57,7 @@ const Root = styled(Layer)`
  */
 export const Tooltip = forwardRef(function Tooltip(
   props: TooltipProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content'>,
-  ref: React.ForwardedRef<HTMLDivElement>,
+  ref: React.ForwardedRef<HTMLDivElement>
 ) {
   const boundaryElementContext = useBoundaryElement()
   const theme = useTheme()
@@ -90,11 +91,24 @@ export const Tooltip = forwardRef(function Tooltip(
         fallbackPlacements,
         padding: 4,
         rootBoundary,
-      }),
+        mainAxis: false,
+      })
     )
 
     // Define distance between reference and floating element
     ret.push(offset({mainAxis: 3}))
+
+    // Set width and height on the floating element
+    ret.push(
+      size({
+        apply({availableWidth, availableHeight, elements}) {
+          Object.assign(elements.floating.style, {
+            maxWidth: `${availableWidth}px`,
+            maxHeight: `${availableHeight}px`,
+          })
+        },
+      })
+    )
 
     // Shift the tooltip so its sits with the boundary eleement
     ret.push(
@@ -102,7 +116,7 @@ export const Tooltip = forwardRef(function Tooltip(
         boundary: boundaryElement || undefined,
         rootBoundary,
         padding: 4,
-      }),
+      })
     )
 
     // Place arrow
@@ -111,20 +125,11 @@ export const Tooltip = forwardRef(function Tooltip(
     return ret
   }, [boundaryElement, fallbackPlacements])
 
-  const {x, y, placement, middlewareData, refs, update, strategy} = useFloating({
+  const {floatingStyles, placement, middlewareData, refs, update} = useFloating({
     middleware,
     placement: placementProp,
     whileElementsMounted: autoUpdate,
   })
-
-  const rootStyle: CSSProperties = useMemo(
-    () => ({
-      position: strategy,
-      top: y ?? 0,
-      left: x ?? 0,
-    }),
-    [strategy, x, y],
-  )
 
   const staticSide = placement && FLOATING_STATIC_SIDES[placement.split('-')[0]]
 
@@ -194,7 +199,7 @@ export const Tooltip = forwardRef(function Tooltip(
       arrowRef.current = arrowEl
       update()
     },
-    [update],
+    [update]
   )
 
   const setFloating = useCallback(
@@ -202,7 +207,7 @@ export const Tooltip = forwardRef(function Tooltip(
       forwardedRef.current = node
       refs.setFloating(node)
     },
-    [forwardedRef, refs],
+    [forwardedRef, refs]
   )
 
   const childRef: ForwardedRef<HTMLElement | null> = (childProp as any)?.ref
@@ -218,7 +223,7 @@ export const Tooltip = forwardRef(function Tooltip(
       // childRef.current = node
       setReferenceElement(node)
     },
-    [childRef],
+    [childRef]
   )
 
   const child = useMemo(() => {
@@ -238,7 +243,13 @@ export const Tooltip = forwardRef(function Tooltip(
   if (disabled) return child
 
   const root = (
-    <Root data-ui="Tooltip" {...restProps} ref={setFloating} style={rootStyle} zOffset={zOffset}>
+    <Root
+      data-ui="Tooltip"
+      {...restProps}
+      ref={setFloating}
+      style={floatingStyles}
+      zOffset={zOffset}
+    >
       <Card
         data-ui="Tooltip__card"
         data-placement={placement}


### PR DESCRIPTION
The tooltip would rerender unnecessarily when hovering over it. 

The `x` positioning used in `rootstyles` was most likely the reason for this, as the `x` position would be recalculated several times, causing the tooltip placement to "jump". 
By using the `floatingStyles` from `floating-ui', this was fixed. The size of the tooltip is calculated using the `size` from `floating-ui`. 