### PR TITLE
fix(textinput): correctly center <TextInput> clear button on smaller font sizes

### DIFF
--- a/src/primitives/textInput/textInput.tsx
+++ b/src/primitives/textInput/textInput.tsx
@@ -132,7 +132,7 @@ const RightCard = styled(Card)`
   right: 0;
 `
 
-const TextInputButton = styled(Button)({
+const TextInputClearButton = styled(Button)({
   '&:not([hidden])': {
     display: 'block',
   },
@@ -297,7 +297,7 @@ export const TextInput = forwardRef(function TextInput(
           style={CLEAR_BUTTON_BOX_STYLE}
           tone={customValidity ? 'critical' : 'inherit'}
         >
-          <TextInputButton
+          <TextInputClearButton
             aria-label="Clear"
             data-qa="clear-button"
             fontSize={fontSize}

--- a/src/primitives/textInput/textInput.tsx
+++ b/src/primitives/textInput/textInput.tsx
@@ -20,7 +20,6 @@ import {ThemeFontWeightKey, useRootTheme} from '../../theme'
 import {Box} from '../box'
 import {Button, ButtonProps} from '../button'
 import {Card} from '../card'
-import {Flex} from '../flex'
 import {Text} from '../text'
 
 /**
@@ -132,6 +131,12 @@ const RightCard = styled(Card)`
   top: 0;
   right: 0;
 `
+
+const TextInputButton = styled(Button)({
+  '&:not([hidden])': {
+    display: 'block',
+  },
+})
 
 /**
  * @public
@@ -292,20 +297,18 @@ export const TextInput = forwardRef(function TextInput(
           style={CLEAR_BUTTON_BOX_STYLE}
           tone={customValidity ? 'critical' : 'inherit'}
         >
-          <Flex align="center" justify="center">
-            <Button
-              aria-label="Clear"
-              data-qa="clear-button"
-              fontSize={fontSize}
-              icon={CloseIcon}
-              mode="bleed"
-              padding={clearButtonPadding}
-              radius={radius}
-              {...clearButtonProps}
-              onClick={handleClearClick}
-              onMouseDown={handleClearMouseDown}
-            />
-          </Flex>
+          <TextInputButton
+            aria-label="Clear"
+            data-qa="clear-button"
+            fontSize={fontSize}
+            icon={CloseIcon}
+            mode="bleed"
+            padding={clearButtonPadding}
+            radius={radius}
+            {...clearButtonProps}
+            onClick={handleClearClick}
+            onMouseDown={handleClearMouseDown}
+          />
         </RightCard>
       ),
     [

--- a/src/primitives/textInput/textInput.tsx
+++ b/src/primitives/textInput/textInput.tsx
@@ -133,11 +133,6 @@ const RightCard = styled(Card)`
   right: 0;
 `
 
-const RightFlex = styled(Flex)`
-  justify-content: center;
-  align-content: center;
-`
-
 /**
  * @public
  */
@@ -297,7 +292,7 @@ export const TextInput = forwardRef(function TextInput(
           style={CLEAR_BUTTON_BOX_STYLE}
           tone={customValidity ? 'critical' : 'inherit'}
         >
-          <RightFlex>
+          <Flex align="center" justify="center">
             <Button
               aria-label="Clear"
               data-qa="clear-button"
@@ -310,7 +305,7 @@ export const TextInput = forwardRef(function TextInput(
               onClick={handleClearClick}
               onMouseDown={handleClearMouseDown}
             />
-          </RightFlex>
+          </Flex>
         </RightCard>
       ),
     [

--- a/src/primitives/textInput/textInput.tsx
+++ b/src/primitives/textInput/textInput.tsx
@@ -20,6 +20,7 @@ import {ThemeFontWeightKey, useRootTheme} from '../../theme'
 import {Box} from '../box'
 import {Button, ButtonProps} from '../button'
 import {Card} from '../card'
+import {Flex} from '../flex'
 import {Text} from '../text'
 
 /**
@@ -130,6 +131,11 @@ const RightCard = styled(Card)`
   position: absolute;
   top: 0;
   right: 0;
+`
+
+const RightFlex = styled(Flex)`
+  justify-content: center;
+  align-content: center;
 `
 
 /**
@@ -291,18 +297,20 @@ export const TextInput = forwardRef(function TextInput(
           style={CLEAR_BUTTON_BOX_STYLE}
           tone={customValidity ? 'critical' : 'inherit'}
         >
-          <Button
-            aria-label="Clear"
-            data-qa="clear-button"
-            fontSize={fontSize}
-            icon={CloseIcon}
-            mode="bleed"
-            padding={clearButtonPadding}
-            radius={radius}
-            {...clearButtonProps}
-            onClick={handleClearClick}
-            onMouseDown={handleClearMouseDown}
-          />
+          <RightFlex>
+            <Button
+              aria-label="Clear"
+              data-qa="clear-button"
+              fontSize={fontSize}
+              icon={CloseIcon}
+              mode="bleed"
+              padding={clearButtonPadding}
+              radius={radius}
+              {...clearButtonProps}
+              onClick={handleClearClick}
+              onMouseDown={handleClearMouseDown}
+            />
+          </RightFlex>
         </RightCard>
       ),
     [


### PR DESCRIPTION
The clear button on a `TextInput` isn't correctly aligned at smaller font sizes (e.g. 0, 1). This PR adds a flex around the button to vertically align it. 

[Arcade](https://www.sanity.io/ui/arcade?mode=jsx&jsx=eJyzcU4sSlEoSExJycxLt602qbXjUlCwCS5JTM5WKC5ITE61rTYGiwFFQ1IrSjzzCkpLwFwFheSc1MQip9KSkvw8qEhafl5JcGYVUJNBLVSoIAdoSEZ%2BTkpqka0SSE7BQAkqVZaYUwpUCqYgyvXJsMkQt02GShAZqtpnhNs%2BI6h9BG0FS9rog4PZjstGHxQJdgCJ6G7V&hook=eJxLzs8rLlGILkvMKU3VUShOLQkDsWIVbBVKi1ODSxJLUjXU1TUBD9YNHA%3D%3D&title=TextInput+example&description=A+basic+example+of+using+the+TextInput+primitive+in+Sanity+UI.) showing the current issue across different font sizes.

**Before:**
<img width="659" alt="image" src="https://github.com/sanity-io/ui/assets/209129/688385a6-cda9-4f43-8491-a153af06691e">

**After:** 
<img width="660" alt="image" src="https://github.com/sanity-io/ui/assets/209129/7bf95e71-29bf-4544-96f7-3960e19d7347">