### PR TITLE
feat(tooltip): allows for the tooltip to be dismissed on Escape

### DIFF
--- a/src/primitives/tooltip/tooltip.test.tsx
+++ b/src/primitives/tooltip/tooltip.test.tsx
@@ -275,4 +275,26 @@ describe('Tooltip', () => {
       jest.clearAllMocks()
     })
   })
+  it('should show the tooltip when focus, close with Escape key', () => {
+    render(
+      <Tooltip content={<Text size={1}>{'Tooltip content'}</Text>} placement={'top'}>
+        <Button mode="bleed" text="Hover me" />
+      </Tooltip>,
+    )
+
+    const button = screen.getByText('Hover me')
+
+    // Validate tooltip content is not rendered
+    expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+
+    fireEvent.focus(button)
+
+    // Validate tooltip content is rendered
+    screen.getByText('Tooltip content')
+    act(() => {
+      fireEvent.keyDown(button, {key: 'Escape', code: 'Escape'})
+    })
+    // Validate tooltip content is not rendered anymore
+    expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+  })
 })

--- a/src/primitives/tooltip/tooltip.test.tsx
+++ b/src/primitives/tooltip/tooltip.test.tsx
@@ -275,26 +275,71 @@ describe('Tooltip', () => {
       jest.clearAllMocks()
     })
   })
-  it('should show the tooltip when focus, close with Escape key', () => {
-    render(
-      <Tooltip content={<Text size={1}>{'Tooltip content'}</Text>} placement={'top'}>
-        <Button mode="bleed" text="Hover me" />
-      </Tooltip>,
-    )
+  describe('Closing the <Tooltip /> with the Escape key', () => {
+    it('Standalone tooltip closes immediately with Escape key', () => {
+      const delay = 150
 
-    const button = screen.getByText('Hover me')
+      jest.useFakeTimers()
 
-    // Validate tooltip content is not rendered
-    expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      render(
+        <Tooltip
+          content={<Text size={1}>{'Tooltip content'}</Text>}
+          placement={'top'}
+          delay={delay}
+        >
+          <Button mode="bleed" text="Hover me" />
+        </Tooltip>,
+      )
 
-    fireEvent.focus(button)
+      const button = screen.getByText('Hover me')
 
-    // Validate tooltip content is rendered
-    screen.getByText('Tooltip content')
-    act(() => {
-      fireEvent.keyDown(button, {key: 'Escape', code: 'Escape'})
+      // Validate tooltip content is not rendered
+      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      fireEvent.focus(button)
+      act(() => jest.advanceTimersByTime(delay))
+
+      // Validate tooltip content is rendered
+      screen.getByText('Tooltip content')
+
+      act(() => {
+        fireEvent.keyDown(button, {key: 'Escape', code: 'Escape'})
+      })
+      // Validate tooltip content is not rendered anymore
+      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
     })
-    // Validate tooltip content is not rendered anymore
-    expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+    it('With <TooltipDelayGroupProvider />  closes immediately with Escape key', () => {
+      const delay = 150
+
+      jest.useFakeTimers()
+
+      render(
+        <TooltipDelayGroupProvider delay={{close: delay}}>
+          <Tooltip
+            content={<Text size={1}>{'Tooltip content'}</Text>}
+            placement={'top'}
+            delay={{close: delay}}
+          >
+            <Button mode="bleed" text="Hover me" />
+          </Tooltip>
+        </TooltipDelayGroupProvider>,
+      )
+
+      const button = screen.getByText('Hover me')
+
+      // Validate tooltip content is not rendered
+      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      fireEvent.focus(button)
+
+      act(() => jest.advanceTimersByTime(delay))
+
+      // Validate tooltip content is rendered
+      screen.getByText('Tooltip content')
+
+      act(() => {
+        fireEvent.keyDown(button, {key: 'Escape', code: 'Escape'})
+      })
+      // Validate tooltip content is not rendered anymore
+      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -177,23 +177,27 @@ export const Tooltip = forwardRef(function Tooltip(
   const closeDelay = isInsideGroup ? delayGroupContext.closeDelay : closeDelayProp
 
   const handleIsOpenChange = useCallback(
-    (open: boolean) => {
+    (open: boolean, immediate?: boolean) => {
       if (isInsideGroup) {
         //  When it's inside a group, the open or close status will be handled by the group.
         if (open) {
-          delayGroupContext.setIsGroupActive(open, openDelay)
-          delayGroupContext.setOpenTooltipId(tooltipId, openDelay)
+          const groupedOpenDelay = immediate ? 0 : openDelay
+
+          delayGroupContext.setIsGroupActive(open, groupedOpenDelay)
+          delayGroupContext.setOpenTooltipId(tooltipId, groupedOpenDelay)
         } else {
           const minimumGroupDeactivateDelay = 200 // We should provide some delay to allow the user to reach the next tooltip.
           const groupDeactivateDelay =
             closeDelay > minimumGroupDeactivateDelay ? closeDelay : minimumGroupDeactivateDelay
 
           delayGroupContext.setIsGroupActive(open, groupDeactivateDelay)
-          delayGroupContext.setOpenTooltipId(null, closeDelay)
+          delayGroupContext.setOpenTooltipId(null, immediate ? 0 : closeDelay)
         }
       } else {
+        const standaloneDelay = immediate ? 0 : open ? openDelay : closeDelay
+
         // When it's not inside a group, the open or close status will be handled by the tooltip itself.
-        setIsOpen(open, open ? openDelay : closeDelay)
+        setIsOpen(open, standaloneDelay)
       }
     },
     [isInsideGroup, delayGroupContext, openDelay, tooltipId, closeDelay, setIsOpen],
@@ -249,7 +253,7 @@ export const Tooltip = forwardRef(function Tooltip(
 
     function handleWindowKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
-        handleIsOpenChange(false)
+        handleIsOpenChange(false, true)
       }
     }
 

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -243,6 +243,22 @@ export const Tooltip = forwardRef(function Tooltip(
   // Update reference
   useEffect(() => refs.setReference(referenceElement), [referenceElement, refs])
 
+  useEffect(() => {
+    // If the user clicks on escape key, close the tooltip.
+    if (!showTooltip) return
+
+    function handleWindowKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        handleIsOpenChange(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleWindowKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleWindowKeyDown)
+    }
+  }, [handleIsOpenChange, showTooltip])
   const setArrow = useCallback(
     (arrowEl: HTMLDivElement | null) => {
       arrowRef.current = arrowEl


### PR DESCRIPTION
Allows for the tooltip to be dismissed on Escape.
Requirement for WCAG 1.4.13 
https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html