### PR TITLE
fix: allow for more granular `focusRing` definition on inputs

### DIFF
--- a/cypress/e2e/ui/textInput.cy.ts
+++ b/cypress/e2e/ui/textInput.cy.ts
@@ -7,7 +7,7 @@ context('Primitives/TextInput', () => {
     cy.get('#text-input-example + span').should(
       'have.css',
       'boxShadow',
-      'rgb(206, 210, 217) 0px 0px 0px 1px inset, rgb(242, 243, 245) 0px 0px 0px 1px, rgb(34, 118, 252) 0px 0px 0px 3px',
+      'rgb(34, 118, 252) 0px 0px 0px 1px inset, rgb(206, 210, 217) 0px 0px 0px 1px inset',
     )
   })
 })

--- a/src/primitives/checkbox/styles.ts
+++ b/src/primitives/checkbox/styles.ts
@@ -13,7 +13,7 @@ export function inputElementStyles(props: ThemeProps): ReturnType<typeof css> {
   const {theme} = props
   const color = theme.sanity.color.input
   const {input, radius} = theme.sanity
-  const {focusRing} = input
+  const {focusRing} = input.checkbox
 
   return css`
     position: absolute;

--- a/src/primitives/radio/styles.ts
+++ b/src/primitives/radio/styles.ts
@@ -19,7 +19,7 @@ export function radioBaseStyle(): ReturnType<typeof css> {
 export function inputElementStyle(props: ThemeProps): ReturnType<typeof css> {
   const {theme} = props
   const {input} = theme.sanity
-  const {focusRing} = theme.sanity.input.radio
+  const {focusRing} = input.radio
   const color = theme.sanity.color.input
   const dist = (input.radio.size - input.radio.markSize) / 2
 

--- a/src/primitives/radio/styles.ts
+++ b/src/primitives/radio/styles.ts
@@ -19,7 +19,7 @@ export function radioBaseStyle(): ReturnType<typeof css> {
 export function inputElementStyle(props: ThemeProps): ReturnType<typeof css> {
   const {theme} = props
   const {input} = theme.sanity
-  const {focusRing} = input
+  const {focusRing} = theme.sanity.input.radio
   const color = theme.sanity.color.input
   const dist = (input.radio.size - input.radio.markSize) / 2
 

--- a/src/primitives/select/styles.ts
+++ b/src/primitives/select/styles.ts
@@ -44,7 +44,7 @@ function inputBaseStyle(props: ThemeProps): ReturnType<typeof css> {
 function inputColorStyle(props: ThemeProps) {
   const {theme} = props
   const {input} = theme.sanity
-  const {focusRing} = input
+  const {focusRing} = input.select
   const color = theme.sanity.color.input
 
   return css`

--- a/src/primitives/switch/__workshop__/props.tsx
+++ b/src/primitives/switch/__workshop__/props.tsx
@@ -8,8 +8,8 @@ export default function PropsStory() {
   const indeterminate = useBoolean('Indeterminate', false)
   const readOnly = useBoolean('Read only', false)
   const theme = useTheme()
-  const focusRingOffset = useNumber('Focus ring offset', theme.sanity.input.focusRing.offset)
-  const focusRingWidth = useNumber('Focus ring width', theme.sanity.input.focusRing.width)
+  const focusRingOffset = useNumber('Focus ring offset', theme.sanity.input.switch.focusRing.offset)
+  const focusRingWidth = useNumber('Focus ring width', theme.sanity.input.switch.focusRing.width)
   const handleChange = useCallback(() => undefined, [])
 
   const customTheme = useMemo(
@@ -18,8 +18,8 @@ export default function PropsStory() {
       sanity: {
         ...theme.sanity,
         focusRing: {
-          offset: focusRingOffset || theme.sanity.input.focusRing.offset,
-          width: focusRingWidth || theme.sanity.input.focusRing.width,
+          offset: focusRingOffset || theme.sanity.input.switch.focusRing.offset,
+          width: focusRingWidth || theme.sanity.input.switch.focusRing.width,
         },
       },
     }),

--- a/src/primitives/switch/styles.ts
+++ b/src/primitives/switch/styles.ts
@@ -37,7 +37,7 @@ export function switchInputStyles(): ReturnType<typeof css> {
 export function switchRepresentationStyles(props: ThemeProps): ReturnType<typeof css> {
   const {theme} = props
   const {input} = theme.sanity
-  const {focusRing} = input
+  const {focusRing} = input.switch
   const color = theme.sanity.color.button.default
 
   return css`

--- a/src/styles/input/textInputStyle.ts
+++ b/src/styles/input/textInputStyle.ts
@@ -131,7 +131,7 @@ export function textInputRepresentationStyle(
 ): ReturnType<typeof css> {
   const {$hasPrefix, $hasSuffix, $scheme, $tone, theme} = props
   const {input} = theme.sanity
-  const {focusRing} = input
+  const {focusRing} = input.text
   const color = theme.sanity.color.input
 
   return css`

--- a/src/theme/lib/theme/input.ts
+++ b/src/theme/lib/theme/input.ts
@@ -6,10 +6,12 @@ import {FocusRing} from '../../types'
 export interface ThemeInput {
   checkbox: {
     size: number
+    focusRing: FocusRing
   }
   radio: {
     size: number
     markSize: number
+    focusRing: FocusRing
   }
   switch: {
     width: number
@@ -17,9 +19,15 @@ export interface ThemeInput {
     padding: number
     transitionDurationMs: number
     transitionTimingFunction: string
+    focusRing: FocusRing
   }
   border: {
     width: number
   }
-  focusRing: FocusRing
+  select: {
+    focusRing: FocusRing
+  }
+  text: {
+    focusRing: FocusRing
+  }
 }

--- a/src/theme/studioTheme/theme.ts
+++ b/src/theme/studioTheme/theme.ts
@@ -12,14 +12,14 @@ export const studioTheme: RootTheme = {
       {distance: -6, size: 35},
       {distance: -9, size: 55},
     ],
-    focusRing: {offset: 1, width: 2},
+    focusRing: {offset: 1, width: 1},
   },
   button: {
     textWeight: 'medium',
-    focusRing: {offset: 1, width: 2},
+    focusRing: {offset: -1, width: 1},
   },
   card: {
-    focusRing: {offset: 1, width: 2},
+    focusRing: {offset: -1, width: 1},
   },
   color,
   container: [320, 640, 960, 1280, 1600, 1920],
@@ -38,10 +38,12 @@ export const studioTheme: RootTheme = {
   input: {
     checkbox: {
       size: 17,
+      focusRing: {offset: 1, width: 1},
     },
     radio: {
       size: 17,
       markSize: 9,
+      focusRing: {offset: 1, width: 1},
     },
     switch: {
       width: 33,
@@ -49,11 +51,17 @@ export const studioTheme: RootTheme = {
       padding: 4,
       transitionDurationMs: 150,
       transitionTimingFunction: 'ease-out',
+      focusRing: {offset: 1, width: 1},
     },
     border: {
       width: 1,
     },
-    focusRing: {offset: 1, width: 2},
+    select: {
+      focusRing: {offset: -1, width: 1},
+    },
+    text: {
+      focusRing: {offset: -1, width: 1},
+    },
   },
   // styles: {
   //   button: {

--- a/stories/README.mdx
+++ b/stories/README.mdx
@@ -22,3 +22,4 @@ _This is a work in progress_
 - Scheme (dark / light mode) toggles should be removed on non-applicable pages (such as non-story pages like this one).
 - We may want to reconsider whether scheme toggling impacts the 'manager' (or general interface) as well.
 - This Storybook should not load the Nunito Sans font, which is not being used in this current theme.
+- Custom components in _unattached_ MDX docs need to be wrapped with an `<Unstyled>` [component](https://storybook.js.org/docs/react/api/doc-block-unstyled) to ensure they render correctly. (There may be a more idiomatic way to have custom components ignore MDX text styles).

--- a/stories/colors/Overview.mdx
+++ b/stories/colors/Overview.mdx
@@ -1,8 +1,0 @@
-import {Meta} from '@storybook/blocks'
-import {ColorPalette} from './ColorPalette'
-
-{/* <Meta title="Colors/Overview" /> */}
-
-Full `@sanity/color` palette
-
-<ColorPalette />

--- a/stories/primitives/Avatar.stories.tsx
+++ b/stories/primitives/Avatar.stories.tsx
@@ -20,6 +20,19 @@ export const Default: Story = {
   render: (props) => <Avatar {...props} />,
 }
 
+/**
+ * Displays focus ring and receives focus events. Unlike `<Card>` components, no hover states are displayed.
+ */
+export const AsButton: Story = {
+  render: (props) => (
+    <Flex gap={3}>
+      <Avatar {...props} as="button" />
+      <Avatar {...props} as="button" />
+      <Avatar {...props} as="button" />
+    </Flex>
+  ),
+}
+
 export const Colors: Story = {
   parameters: {
     controls: {

--- a/stories/primitives/Card.stories.tsx
+++ b/stories/primitives/Card.stories.tsx
@@ -29,6 +29,25 @@ export const Default: Story = {
   },
 }
 
+/**
+ * Displays focus ring, hover styles and receives focus events. Requires `__unstable_focusRing`.
+ */
+export const AsButton: Story = {
+  args: {
+    __unstable_focusRing: true,
+    as: 'button',
+    children: <Text>Card as a button</Text>,
+    tone: 'transparent',
+  },
+  render: (props) => (
+    <Flex gap={2}>
+      <Card {...props} />
+      <Card {...props} />
+      <Card {...props} />
+    </Flex>
+  ),
+}
+
 export const Borders: Story = {
   args: {
     tone: 'transparent',

--- a/stories/primitives/Select.stories.tsx
+++ b/stories/primitives/Select.stories.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import type {Meta, StoryObj} from '@storybook/react'
+import {Select} from '../../src/primitives'
+import {FONT_SIZE_CONTROLS, RADIUS_CONTROLS, SPACE_CONTROLS} from '../constants'
+
+const meta: Meta<typeof Select> = {
+  args: {
+    children: (
+      <>
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+        <option value="c">Option C</option>
+        <option value="d">Option D</option>
+        <option value="e">Option E</option>
+      </>
+    ),
+  },
+  argTypes: {
+    fontSize: FONT_SIZE_CONTROLS,
+    padding: SPACE_CONTROLS,
+    radius: RADIUS_CONTROLS,
+    space: SPACE_CONTROLS,
+  },
+  component: Select,
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof Select>
+
+export const Default: Story = {
+  render: (props) => <Select {...props} />,
+}
+
+export const ReadOnly: Story = {
+  render: (props) => <Select {...props} readOnly />,
+}
+
+export const Disabled: Story = {
+  render: (props) => <Select {...props} disabled />,
+}

--- a/stories/tests/FocusRings.mdx
+++ b/stories/tests/FocusRings.mdx
@@ -1,0 +1,6 @@
+import {Meta, Unstyled} from '@storybook/blocks'
+import {FocusRings} from './FocusRings'
+
+<Unstyled>
+  <FocusRings />
+</Unstyled>

--- a/stories/tests/FocusRings.tsx
+++ b/stories/tests/FocusRings.tsx
@@ -1,0 +1,141 @@
+import {ReactNode} from 'react'
+import {
+  Avatar,
+  Button,
+  Card,
+  Checkbox,
+  Flex,
+  Heading,
+  Radio,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  TextArea,
+  TextInput,
+} from '../../src/primitives'
+import {ThemeProvider, studioTheme} from '../../src/theme'
+
+const Wrapper = ({children, title}: {children: ReactNode; title: string}) => {
+  return (
+    <Stack space={3}>
+      <Text size={1} weight="semibold">
+        {title}
+      </Text>
+      {children}
+    </Stack>
+  )
+}
+
+export function FocusRings(): ReactNode {
+  return (
+    <ThemeProvider scheme="light" theme={studioTheme}>
+      <Card padding={5}>
+        <Stack space={6}>
+          <Heading>Primitives</Heading>
+          <Wrapper title="Avatar (as button)">
+            <Avatar as="button" initials="AB" />
+          </Wrapper>
+          <Wrapper title="Buttons">
+            <Flex gap={3} wrap="wrap">
+              <Button text="Button" />
+              <Button mode="bleed" text="Button" />
+              <Button mode="ghost" text="Button" />
+            </Flex>
+            <Flex gap={3} wrap="wrap">
+              <Button text="Button" tone="primary" />
+              <Button mode="bleed" text="Button" tone="primary" />
+              <Button mode="ghost" text="Button" tone="primary" />
+            </Flex>
+            <Flex gap={3} wrap="wrap">
+              <Button text="Button" tone="positive" />
+              <Button mode="bleed" text="Button" tone="positive" />
+              <Button mode="ghost" text="Button" tone="positive" />
+            </Flex>
+            <Flex gap={3} wrap="wrap">
+              <Button text="Button" tone="caution" />
+              <Button mode="bleed" text="Button" tone="caution" />
+              <Button mode="ghost" text="Button" tone="caution" />
+            </Flex>
+            <Flex gap={3} wrap="wrap">
+              <Button text="Button" tone="critical" />
+              <Button mode="bleed" text="Button" tone="critical" />
+              <Button mode="ghost" text="Button" tone="critical" />
+            </Flex>
+          </Wrapper>
+          <Wrapper title="Card (as button)">
+            <Flex gap={3} wrap="wrap">
+              <Card __unstable_focusRing as="button" padding={3} tone="transparent">
+                <Text>Transparent</Text>
+              </Card>
+              <Card __unstable_focusRing as="button" padding={3} tone="primary">
+                <Text>Primary</Text>
+              </Card>
+              <Card __unstable_focusRing as="button" padding={3} tone="positive">
+                <Text>Positive</Text>
+              </Card>
+              <Card __unstable_focusRing as="button" padding={3} tone="caution">
+                <Text>Caution</Text>
+              </Card>
+              <Card __unstable_focusRing as="button" padding={3} tone="critical">
+                <Text>Critical</Text>
+              </Card>
+            </Flex>
+          </Wrapper>
+          <Wrapper title="Checkboxes">
+            <Flex gap={3} wrap="wrap">
+              <Checkbox />
+              <Checkbox indeterminate />
+              <Checkbox defaultChecked />
+              <Checkbox disabled />
+            </Flex>
+          </Wrapper>
+          <Wrapper title="Radios">
+            <Flex gap={3} wrap="wrap">
+              <Radio />
+              <Radio defaultChecked />
+              <Radio disabled />
+            </Flex>
+          </Wrapper>
+          <Wrapper title="Selects">
+            <Flex gap={3} wrap="wrap">
+              <Select>
+                <option>Select...</option>
+              </Select>
+              <Select readOnly>
+                <option>Select...</option>
+              </Select>
+              <Select disabled>
+                <option>Select...</option>
+              </Select>
+            </Flex>
+          </Wrapper>
+          <Wrapper title="Switches">
+            <Flex gap={3} wrap="wrap">
+              <Switch />
+              <Switch indeterminate />
+              <Switch defaultChecked />
+              <Switch disabled />
+            </Flex>
+          </Wrapper>
+          <Wrapper title="Text areas">
+            <Flex gap={3} wrap="wrap">
+              <TextArea placeholder="Default" />
+              <TextArea placeholder="Read-only" readOnly />
+              <TextArea customValidity="error" placeholder="With error" />
+              <TextArea disabled placeholder="Disabled" />
+            </Flex>
+          </Wrapper>
+          <Wrapper title="Text inputs">
+            <Flex gap={3} wrap="wrap">
+              <TextInput placeholder="Default" />
+              <TextInput placeholder="Read-only" readOnly />
+              <TextInput customValidity="error" placeholder="With error" />
+              <TextInput disabled placeholder="Disabled" />
+            </Flex>
+          </Wrapper>
+        </Stack>
+      </Card>
+    </ThemeProvider>
+  )
+}

--- a/stories/tokens/ColorPalette.tsx
+++ b/stories/tokens/ColorPalette.tsx
@@ -11,11 +11,13 @@ function ucfirst(str: string) {
 export function ColorPalette(): ReactNode {
   return (
     <ThemeProvider theme={studioTheme}>
-      <Grid columns={[1, 1, 2, 3]} gapX={[4, 4, 5]} gapY={[5, 5, 6]} padding={[4, 5, 6]}>
-        {COLOR_HUES.map((hueKey) => (
-          <ColorHuePreview tints={hues[hueKey]} hueKey={hueKey} key={hueKey} />
-        ))}
-      </Grid>
+      <Card scheme="light">
+        <Grid columns={[1, 1, 2, 3]} gapX={[4, 4, 5]} gapY={[5, 5, 6]} padding={[4, 5, 6]}>
+          {COLOR_HUES.map((hueKey) => (
+            <ColorHuePreview tints={hues[hueKey]} hueKey={hueKey} key={hueKey} />
+          ))}
+        </Grid>
+      </Card>
     </ThemeProvider>
   )
 }

--- a/stories/tokens/Colors.mdx
+++ b/stories/tokens/Colors.mdx
@@ -1,0 +1,8 @@
+import {Meta, Unstyled} from '@storybook/blocks'
+import {ColorPalette} from './ColorPalette'
+
+Full `@sanity/color` palette
+
+<Unstyled>
+  <ColorPalette />
+</Unstyled>


### PR DESCRIPTION
### Description

This PR adds support for defining `focusRing` settings for individual input types.

Previously, all inputs (text inputs, switches, checkboxes, radios, selects) would use the single `focusRing` value defined within `input` – however, new styling requires different focus ring values for text inputs vs other inputs. (i.e. text inputs have 'inline' rings that render on the border, whilst other inputs render these as external borders)

(Side note: this does add complexity to the theme object. Ideally, we could have consistent focus ring behaviour across all components like we do currently – may be worth a further discussion? @mikolajdobrucki)

**Storybook additions:**
- A basic `<Select>` story
- 'As button' stories for both `<Avatar>` and `<Card>`
- Moved `Color/Overview` to `Tokens/Colors`
- A (non-exhaustive) Focus Ring test page has been set up which contains most (but not all) focusable Sanity UI components, which can used to easily view focus ring behaviour across the board.