### PR TITLE
chore(storybook): remove unsightly story/docs background flashes, add favicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 node_modules
 
 /etc
+storybook-static

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,3 +1,10 @@
+<!-- prettier-ignore -->
+<link rel="icon" href="https://www.sanity.io/static/images/favicons/favicon-96x96.png" sizes="96x96" type="image/png" />
+<!-- prettier-ignore -->
+<link rel="icon" href="https://www.sanity.io/static/images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
+<!-- prettier-ignore -->
+<link rel="icon" href="https://www.sanity.io/static/images/favicons/favicon-16x16.png" sizes="16x16" type="image/png" />
+
 <style>
   @font-face {
     font-family: 'Inter';
@@ -26,5 +33,9 @@
     font-weight: 500 !important;
     letter-spacing: normal !important;
     text-transform: capitalize !important;
+  }
+  /* Suppress the preview iframe's white background */
+  #storybook-preview-iframe {
+    background-color: transparent !important;
   }
 </style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -21,4 +21,9 @@
     -webkit-tap-highlight-color: transparent;
     -webkit-font-smoothing: antialiased;
   }
+  /* Temporarily hide docs + story preloader skeletons, which currently show an unslightly flash when loading */
+  .sb-preparing-docs,
+  .sb-preparing-story {
+    display: none;
+  }
 </style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -21,7 +21,7 @@
     -webkit-tap-highlight-color: transparent;
     -webkit-font-smoothing: antialiased;
   }
-  /* Temporarily hide docs + story preloader skeletons, which currently show an unslightly flash when loading */
+  /* Temporarily hide docs + story preloader skeletons, which currently show an unsightly flash when loading */
   .sb-preparing-docs,
   .sb-preparing-story {
     display: none;

--- a/stories/README.mdx
+++ b/stories/README.mdx
@@ -23,3 +23,4 @@ _This is a work in progress_
 - We may want to reconsider whether scheme toggling impacts the 'manager' (or general interface) as well.
 - This Storybook should not load the Nunito Sans font, which is not being used in this current theme.
 - Custom components in _unattached_ MDX docs need to be wrapped with an `<Unstyled>` [component](https://storybook.js.org/docs/react/api/doc-block-unstyled) to ensure they render correctly. (There may be a more idiomatic way to have custom components ignore MDX text styles).
+- We currently override some manager + preview CSS to prevent unslightly flashes of white backgrounds on mount.

--- a/stories/README.mdx
+++ b/stories/README.mdx
@@ -16,6 +16,7 @@ _This is a work in progress_
 ## Things to note
 
 - All stories are wrapped with a [common decorator](https://storybook.js.org/docs/react/writing-stories/decorators#story-decorators) which wraps stories in both a `<ThemeProvider>` but also a `<Card>` with padding. This may change in future.
+- Currently, Storybook is deployed to a separate vercel project on all commits to `feat/facelift-mvi-2` (`ui-workshop` deployments are unaffected).
 
 ## Areas of improvement
 
@@ -23,4 +24,4 @@ _This is a work in progress_
 - We may want to reconsider whether scheme toggling impacts the 'manager' (or general interface) as well.
 - This Storybook should not load the Nunito Sans font, which is not being used in this current theme.
 - Custom components in _unattached_ MDX docs need to be wrapped with an `<Unstyled>` [component](https://storybook.js.org/docs/react/api/doc-block-unstyled) to ensure they render correctly. (There may be a more idiomatic way to have custom components ignore MDX text styles).
-- We currently override some manager + preview CSS to prevent unslightly flashes of white backgrounds on mount.
+- We currently override some manager + preview CSS to prevent unsightly flashes of white backgrounds on mount.

--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,7 @@
 {
   "version": 2,
-  "routes": [
-    {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/frame/(.*)",
-      "dest": "/frame/index.html"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
-  ]
+  "framework": "storybook",
+  "buildCommand": "storybook build",
+  "installCommand": "pnpm install",
+  "outputDirectory": "/storybook-static"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,16 @@
 {
   "version": 2,
-  "framework": "storybook",
-  "buildCommand": "storybook build",
-  "installCommand": "pnpm install",
-  "outputDirectory": "/storybook-static"
+  "routes": [
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/frame/(.*)",
+      "dest": "/frame/index.html"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
### Description

This PR hides white BG flashes on story / docs pages. It also loads our current web favicon – perhaps we may want to add a Storybook / UI specific one in future?

**Separate to this PR, but tangentially linked:** a separate Vercel project (`sanity-ui-storybook`) has been created which will build Storybook on commits to `feat/facelift-mvi-2` only. This is accomplished with a configured **Ignored Build Step** in the project and done to prevent noise on other pre-facelift-2 branches.

Build + install commands for `sanity-ui-storybook` are defined Vercel-side (rather than in `vercel.json`) to allow `ui-workshop` to continue to be built as normal.