### PR TITLE
chore(buttons): focus and disabled states for buttons with vars

### DIFF
--- a/src/primitives/button/styles.ts
+++ b/src/primitives/button/styles.ts
@@ -81,7 +81,15 @@ export function buttonColorStyles(
       color: $mode === 'default' ? cssVars[$tone].bg_base : cssVars[$tone].text_primary,
       boxShadow: focusRingBorderStyle(border),
       '&:disabled, &[data-disabled="true"]': {
-        opacity: 0.7,
+        '--card-fg-color': cssVars.default.text_inactive,
+        '--card-muted-fg-color': cssVars.default.border_base,
+        '--card-icon-color': cssVars.default.border_base,
+        color: cssVars.default.text_inactive,
+        background: $mode === 'default' ? cssVars.default.bg_tint : cssVars.default.bg_base,
+        boxShadow:
+          props.$mode !== 'bleed'
+            ? focusRingBorderStyle({width: 1, color: cssVars.default.border_base})
+            : undefined,
       },
       "&:not([data-disabled='true'])": {
         boxShadow: combineBoxShadow(
@@ -89,10 +97,11 @@ export function buttonColorStyles(
           shadow ? defaultBoxShadow : undefined,
         ),
         '&:focus': {
-          boxShadow: combineBoxShadow(
-            focusRingStyle({base: {bg: cssVars.positive.border_accent}, border, focusRing}),
-            shadow ? defaultBoxShadow : undefined,
-          ),
+          boxShadow: focusRingStyle({
+            base: {bg: cssVars.positive.border_accent},
+            border: {width: 2, color: cssVars.default.bg_base},
+            focusRing,
+          }),
         },
         '&:focus:not(:focus-visible)': {
           boxShadow: combineBoxShadow(

--- a/src/theme/studioTheme/tints.ts
+++ b/src/theme/studioTheme/tints.ts
@@ -11,6 +11,7 @@ export const colorKeys = [
   'text_primary',
   'text_secondary',
   'text_tertiary', // Added for placeholders, could change.
+  'text_inactive',
   'bg_base',
   'bg_base_hover',
   'bg_base_active',
@@ -34,6 +35,7 @@ const defaultTints: Record<ThemeColorSchemeKey, ColorTintsDictionary> = {
     text_primary: '900',
     text_secondary: '600',
     text_tertiary: '300',
+    text_inactive: '500',
     bg_base: white,
     bg_base_hover: '50',
     bg_base_active: '100',
@@ -52,6 +54,7 @@ const defaultTints: Record<ThemeColorSchemeKey, ColorTintsDictionary> = {
     text_primary: '50',
     text_secondary: '300',
     text_tertiary: '600',
+    text_inactive: '400',
     bg_base: black,
     bg_base_hover: '900',
     bg_base_active: '800',


### PR DESCRIPTION
Add disabled and focus state for buttons using vars

## Focused
<img width="925" alt="Screenshot 2023-10-04 at 11 11 48" src="https://github.com/sanity-io/ui/assets/46196328/5a7b5f66-5244-47b9-b292-6b89d3cb5fea">

## Disabled
<img width="935" alt="Screenshot 2023-10-04 at 11 12 17" src="https://github.com/sanity-io/ui/assets/46196328/a3c490cf-d66f-4429-9443-878e2e626b68">
