### PR TITLE
fix(theme): re-introduce base focusRing value and mark as deprecated

### DIFF
--- a/src/theme/lib/theme/theme.ts
+++ b/src/theme/lib/theme/theme.ts
@@ -18,9 +18,18 @@ export interface BaseTheme<
     textWeight: ThemeFontWeightKey
     focusRing: FocusRing
   }
+  card: {
+    focusRing: FocusRing
+  }
   color: ThemeColorSchemes
   container: number[]
+  /** @deprecated Use component-specific `focusRing` values instead */
+  focusRing: {
+    offset: number
+    width: number
+  }
   fonts: ThemeFonts
+  input: ThemeInput
   /**
    * THIS API MAY BE UNSTABLE. DO NOT USE IN PRODUCTION.
    * @beta
@@ -30,9 +39,5 @@ export interface BaseTheme<
   radius: number[]
   shadows: Array<ThemeShadow | null>
   space: number[]
-  input: ThemeInput
-  card: {
-    focusRing: FocusRing
-  }
   styles?: Styles
 }

--- a/src/theme/studioTheme/theme.ts
+++ b/src/theme/studioTheme/theme.ts
@@ -23,6 +23,10 @@ export const studioTheme: RootTheme = {
   },
   color,
   container: [320, 640, 960, 1280, 1600, 1920],
+  focusRing: {
+    offset: 1,
+    width: 2,
+  },
   fonts,
   media: [360, 600, 900, 1200, 1800, 2400],
   radius: [0, 1, 3, 6, 9, 12, 21],


### PR DESCRIPTION
### Description

This PR re-adds the removed base theme `focusRing` value and marks it as deprecated.

Whilst we are moving towards component-specific focus ring values, removing this currently breaks the studio which relies quite heavily on [exported focusRingStyle / focusRingBorderStyle functions](https://github.com/sanity-io/ui/blob/main/src/styles/focusRing/index.ts). 

Possibly an argument for deprecating the above functions too and moving to a css vars approach