### PR TITLE
fix(theme): set root CSS variables directly in the document stylesheet

### DIFF
--- a/.storybook/decorators/withSanityTheme.decorator.tsx
+++ b/.storybook/decorators/withSanityTheme.decorator.tsx
@@ -5,12 +5,12 @@ import {createGlobalStyle} from 'styled-components'
 import {Box} from '../../src/primitives'
 import {studioTheme, ThemeProvider} from '../../src/theme'
 import {cssVars} from '../../src/theme/lib/theme/color/cssVariables'
-import {black, white} from '@sanity/color'
 
 const {initializeThemeState, pluckThemeFromContext, useThemeParameters} = DecoratorHelpers
 
 export const GlobalStyle = createGlobalStyle`
-  body {
+  body,
+  .docs-story {
     background-color: ${cssVars.default['base-bg-card']};
   }
 `
@@ -34,7 +34,7 @@ export const withSanityTheme = ({themes, defaultTheme}) => {
     return (
       <ThemeProvider scheme={selected} theme={studioTheme}>
         <GlobalStyle />
-        <Box padding={4} style={{background: selected === 'dark' ? black.hex : white.hex}}>
+        <Box padding={4}>
           <Story />
         </Box>
       </ThemeProvider>

--- a/src/theme/lib/theme/color/cssVariables/createCssVars.ts
+++ b/src/theme/lib/theme/color/cssVariables/createCssVars.ts
@@ -7,7 +7,6 @@ import {createSyntaxVariables, syntaxCssVariables} from './syntax'
 import {createTonesVariables, tonesCssVariables} from './tones'
 
 /**
- *
  * @beta
  */
 export const createCssVars = (
@@ -15,7 +14,7 @@ export const createCssVars = (
   tones: Record<ThemeColorName, ColorTints>,
   defaultTone: ThemeColorName = 'default',
 ): Record<string, string> => {
-  const baseBg = getColorHex(tones[defaultTone], scheme === 'dark', defaultTone, 'base-bg-card')
+  const baseBg = getColorHex(tones[defaultTone], scheme, defaultTone, 'base-bg-card')
   const tonesVars = createTonesVariables(scheme, tones, defaultTone, baseBg)
   const spotVars = createSpotVars(scheme, baseBg)
   const syntaxVars = createSyntaxVariables(scheme, baseBg)

--- a/src/theme/lib/theme/color/cssVariables/tones.ts
+++ b/src/theme/lib/theme/color/cssVariables/tones.ts
@@ -21,7 +21,7 @@ export const createTonesVariables = (
     const tint = tones[tone]
 
     colorKeys.forEach((key) => {
-      const colorHex = getColorHex(tint, scheme === 'dark', tone, key)
+      const colorHex = getColorHex(tint, scheme, tone, key)
       const varName = getToneCssVar(_tone, key)
       const willBeMixed = needsMixing && !key.startsWith('base-')
 

--- a/src/theme/lib/theme/color/types.ts
+++ b/src/theme/lib/theme/color/types.ts
@@ -34,3 +34,8 @@ export interface ThemeColorSchemes {
   // Could we update this to only return Record<ThemeColorName ,  keyof typeof hues> ? Then the function that assigns the color would search the ColorTint
   tones: Record<ThemeColorName, ColorTints>
 }
+
+/**
+ * @beta
+ */
+export type CSSVariableKey = ThemeColorName & ('spot' | 'syntax' | 'mutable')

--- a/src/theme/studioTheme/tints.ts
+++ b/src/theme/studioTheme/tints.ts
@@ -280,11 +280,11 @@ export const colorTints: Record<
 
 export const getColorValue = (
   tints: ColorTints,
-  dark: boolean,
+  scheme: ThemeColorSchemeKey,
   tone: ThemeColorName,
   key: ColorKey,
 ): ColorTint => {
-  const value = colorTints[dark ? 'dark' : 'light'][tone][key]
+  const value = colorTints[scheme][tone][key]
 
   if (typeof value === 'string') {
     return tints[value]
@@ -304,9 +304,9 @@ export const getColorValue = (
 
 export const getColorHex = (
   tints: ColorTints,
-  dark: boolean,
+  scheme: ThemeColorSchemeKey,
   tone: ThemeColorName,
   key: ColorKey,
 ): string => {
-  return getColorValue(tints, dark, tone, key).hex
+  return getColorValue(tints, scheme, tone, key).hex
 }

--- a/src/theme/themeProvider.tsx
+++ b/src/theme/themeProvider.tsx
@@ -1,12 +1,18 @@
-import {useContext, useEffect, useMemo} from 'react'
-import {ThemeProvider as StyledThemeProvider} from 'styled-components'
+import {useContext, useMemo} from 'react'
+import {ThemeProvider as StyledThemeProvider, createGlobalStyle} from 'styled-components'
 import {DEFAULT_THEME_LAYER} from './defaults'
-import {ThemeColorSchemeKey, ThemeColorName} from './lib/theme'
+import {ThemeColorName, ThemeColorSchemeKey} from './lib/theme'
 import {createCssVars} from './lib/theme/color/cssVariables'
 import {cssObjectToCssString} from './lib/theme/color/cssVariables/utils'
 import {ThemeContext} from './themeContext'
 import {ToneProvider} from './toneContext/toneProvider'
 import {RootTheme, Theme, ThemeContextValue} from './types'
+
+const GlobalVariables = createGlobalStyle<{$vars?: string}>`
+  :root {
+    ${({$vars}) => $vars}
+  }
+`
 
 /**
  * @public
@@ -40,26 +46,6 @@ export function ThemeProvider(props: ThemeProviderProps): React.ReactElement {
     return {sanity: {...restTheme, layer}}
   }, [themeProp])
 
-  useEffect(() => {
-    if (!themeProp?.color.tones) return
-    const cssVariables = cssObjectToCssString(createCssVars(scheme, themeProp?.color.tones))
-    // Add the vars to the style sheet
-    const sheet = document.styleSheets[0]
-
-    if (sheet) {
-      sheet.insertRule(`:root{${cssVariables}}`)
-    } else {
-      // Create a new sheet and add the vars to it
-      const style = document.createElement('style')
-
-      document.head.appendChild(style)
-      // Get a reference to the stylesheet object
-      const sheet = style.sheet
-
-      sheet?.insertRule(`:root{${cssVariables}}`)
-    }
-  }, [themeProp?.color.tones, scheme])
-
   const value: ThemeContextValue | null = useMemo(
     () =>
       themeProp && {
@@ -71,12 +57,19 @@ export function ThemeProvider(props: ThemeProviderProps): React.ReactElement {
     [themeProp, scheme, tone],
   )
 
+  const cssVariables = useMemo(() => {
+    if (!themeProp?.color.tones) return
+
+    return cssObjectToCssString(createCssVars(scheme, themeProp?.color.tones))
+  }, [scheme, themeProp?.color.tones])
+
   if (!theme) {
     return <pre>ThemeProvider: no "theme" property provided</pre>
   }
 
   return (
     <ThemeContext.Provider value={value}>
+      <GlobalVariables $vars={cssVariables} />
       <StyledThemeProvider theme={theme}>
         <ToneProvider tone={tone} scheme={scheme}>
           {children}

--- a/stories/primitives/Card.stories.tsx
+++ b/stories/primitives/Card.stories.tsx
@@ -374,7 +374,7 @@ export const MatrixAsButton: Story = {
   },
 }
 
-export const SchemeChanges: Story = {
+export const NestedSchemeChanges: Story = {
   render: () => {
     return (
       <Flex gap={4} wrap={'wrap'}>
@@ -410,7 +410,7 @@ export const SchemeChanges: Story = {
   },
 }
 
-export const ToneChanges: Story = {
+export const NestedToneChanges: Story = {
   render: () => {
     const TONES: (CardTone | undefined)[] = [
       'critical',

--- a/stories/primitives/Card.stories.tsx
+++ b/stories/primitives/Card.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react'
 import {Box, Button, Card, Container, Flex, Grid, Stack, Text} from '../../src/primitives'
+import {CardTone} from '../../src/types'
 import {CARD_TONES, RADII} from '../constants'
 import {getRadiusControls, getShadowControls, getSpaceControls} from '../controls'
 import {matrixBuilder} from '../helpers/matrixBuilder'
@@ -404,6 +405,47 @@ export const SchemeChanges: Story = {
             </Card>
           </Card>
         </Card>
+      </Flex>
+    )
+  },
+}
+
+export const ToneChanges: Story = {
+  render: () => {
+    const TONES: (CardTone | undefined)[] = [
+      'critical',
+      'inherit',
+      undefined,
+      'caution',
+      'inherit',
+      undefined,
+      'primary',
+      'inherit',
+      undefined,
+      'positive',
+      'inherit',
+      undefined,
+      'default',
+      'inherit',
+      undefined,
+    ]
+
+    const renderCard = (tones: (CardTone | undefined)[]) => {
+      const currentTone = tones[0]
+
+      return (
+        <Card border margin={3} padding={3} tone={currentTone}>
+          <Text muted={!currentTone} size={1}>
+            {currentTone ?? <em>(empty)</em>}
+          </Text>
+          {tones.length > 1 && renderCard(tones.slice(1))}
+        </Card>
+      )
+    }
+
+    return (
+      <Flex gap={4} wrap={'wrap'}>
+        {renderCard(TONES)}
       </Flex>
     )
   },

--- a/stories/studio/Colors.tsx
+++ b/stories/studio/Colors.tsx
@@ -1,6 +1,6 @@
 import {ReactNode} from 'react'
 import {Card, Flex, Grid, Stack, Text} from '../../src/primitives'
-import {ThemeProvider, cssVars, studioTheme} from '../../src/theme'
+import {ThemeColorSchemeKey, ThemeProvider, cssVars, studioTheme} from '../../src/theme'
 import {tones} from '../../src/theme/studioTheme/color'
 import {ColorKey, getColorHex, getColorValue, colorKeys} from '../../src/theme/studioTheme/tints'
 
@@ -25,7 +25,7 @@ export function Colors(): ReactNode {
             <Card padding={3} radius={3} border>
               <Stack space={4}>
                 {colorKeys.map((colorKey) => (
-                  <ColorPreview key={colorKey} colorKey={colorKey} theme="light" />
+                  <ColorPreview key={colorKey} colorKey={colorKey} scheme="light" />
                 ))}
               </Stack>
             </Card>
@@ -39,7 +39,7 @@ export function Colors(): ReactNode {
             <Card padding={3} radius={3} border>
               <Stack space={4}>
                 {colorKeys.map((colorKey) => (
-                  <ColorPreview key={colorKey} colorKey={colorKey} theme="dark" />
+                  <ColorPreview key={colorKey} colorKey={colorKey} scheme="dark" />
                 ))}
               </Stack>
             </Card>
@@ -50,8 +50,8 @@ export function Colors(): ReactNode {
   )
 }
 
-function ColorPreview(props: {colorKey: ColorKey; theme: 'light' | 'dark'}) {
-  const {colorKey, theme} = props
+function ColorPreview(props: {colorKey: ColorKey; scheme: ThemeColorSchemeKey}) {
+  const {colorKey, scheme} = props
 
   return (
     <Stack space={3}>
@@ -69,14 +69,9 @@ function ColorPreview(props: {colorKey: ColorKey; theme: 'light' | 'dark'}) {
                   width: '48px',
                   borderRadius: '4px',
                   boxShadow: ['Black', 'White'].includes(
-                    getColorValue(tones[tone], theme === 'dark', tone, colorKey)?.title,
+                    getColorValue(tones[tone], scheme, tone, colorKey)?.title,
                   )
-                    ? `0 0 0 1px ${getColorHex(
-                        tones['default'],
-                        theme === 'dark',
-                        'default',
-                        'border-base',
-                      )}`
+                    ? `0 0 0 1px ${getColorHex(tones['default'], scheme, 'default', 'border-base')}`
                     : undefined,
                   backgroundColor: cssVars[tone][colorKey],
                 }}
@@ -99,9 +94,7 @@ function ColorPreview(props: {colorKey: ColorKey; theme: 'light' | 'dark'}) {
                   </Text>
                 </Flex>
                 <Text size={0} muted>
-                  {getColorValue(tones[tone], theme === 'dark', tone, colorKey)
-                    .title.split(' ')
-                    .join('/')}
+                  {getColorValue(tones[tone], scheme, tone, colorKey).title.split(' ').join('/')}
                 </Text>
               </Flex>
             </Flex>

--- a/stories/studio/SpotVariables.mdx
+++ b/stories/studio/SpotVariables.mdx
@@ -1,0 +1,8 @@
+import {Meta, Unstyled} from '@storybook/blocks'
+import {SpotVariables} from './SpotVariables'
+
+## CSS spot color variables
+
+<Unstyled>
+  <SpotVariables />
+</Unstyled>

--- a/stories/studio/SpotVariables.tsx
+++ b/stories/studio/SpotVariables.tsx
@@ -1,0 +1,71 @@
+import {ReactNode, useLayoutEffect, useRef, useState} from 'react'
+import {Card, Code, Flex, Grid, Stack, Text} from '../../src/primitives'
+import {ThemeProvider, studioTheme} from '../../src/theme'
+import {ThemeColorSpotKey, spotCssVariables} from '../../src/theme/lib/theme/color/cssVariables'
+
+export function SpotVariables(): ReactNode {
+  const cssVarsKeys = Object.keys(spotCssVariables).sort() as ThemeColorSpotKey[]
+
+  return (
+    <ThemeProvider theme={studioTheme}>
+      <Stack space={5}>
+        <Card padding={3} radius={3}>
+          <Stack space={3}>
+            <Text size={0} weight="medium" muted>
+              LIGHT MODE
+            </Text>
+            <Grid columns={5} gap={2}>
+              {cssVarsKeys.map((key) => (
+                <ColorPreview key={key} spotColor={key} value={spotCssVariables[key]} />
+              ))}
+            </Grid>
+          </Stack>
+        </Card>
+        <Card padding={3} radius={3} scheme="dark">
+          <Stack space={3}>
+            <Text size={0} weight="medium" muted>
+              DARK MODE
+            </Text>
+            <Card border padding={3} radius={3}>
+              <Grid columns={5} gap={2}>
+                {cssVarsKeys.map((key) => (
+                  <ColorPreview key={key} spotColor={key} value={spotCssVariables[key]} />
+                ))}
+              </Grid>
+            </Card>
+          </Stack>
+        </Card>
+      </Stack>
+    </ThemeProvider>
+  )
+}
+
+function ColorPreview({spotColor, value}: {spotColor: ThemeColorSpotKey; value: string}) {
+  const cardRef = useRef<HTMLDivElement | null>(null)
+  const [propertyValue, setPropertyValue] = useState<string | null>()
+
+  const cssVariableKey = `--spot-${spotColor}`
+
+  useLayoutEffect(() => {
+    if (!cardRef.current) return
+    const propertyValue = getComputedStyle(cardRef.current).getPropertyValue(cssVariableKey)
+
+    setPropertyValue(propertyValue)
+  }, [spotColor, propertyValue, cssVariableKey])
+
+  return (
+    <Card ref={cardRef}>
+      <Flex align="center" gap={2}>
+        <Card border padding={1} radius={3} shadow={0} style={{flexShrink: 0}}>
+          <Card radius={2} style={{background: value, height: '75px', width: '75px'}} />
+        </Card>
+        <Stack space={2}>
+          <Text size={0} weight="medium">
+            {spotColor}
+          </Text>
+          {propertyValue && <Code size={0}>{propertyValue}</Code>}
+        </Stack>
+      </Flex>
+    </Card>
+  )
+}

--- a/stories/studio/ToneVariables.mdx
+++ b/stories/studio/ToneVariables.mdx
@@ -1,0 +1,8 @@
+import {Meta, Unstyled} from '@storybook/blocks'
+import {ToneVariables} from './ToneVariables'
+
+## CSS tone color variables
+
+<Unstyled>
+  <ToneVariables />
+</Unstyled>

--- a/stories/studio/ToneVariables.tsx
+++ b/stories/studio/ToneVariables.tsx
@@ -1,0 +1,90 @@
+import {ReactNode, useLayoutEffect, useRef, useState} from 'react'
+import {Card, Code, Flex, Grid, Stack, Text} from '../../src/primitives'
+import {ThemeColorName, ThemeProvider, studioTheme} from '../../src/theme'
+import {tonesCssVariables} from '../../src/theme/lib/theme/color/cssVariables/tones'
+
+export function ToneVariables(): ReactNode {
+  const cssVarsKeys = Object.keys(tonesCssVariables).sort() as ThemeColorName[]
+
+  return (
+    <ThemeProvider theme={studioTheme}>
+      <Stack space={5}>
+        <Card padding={3} radius={3}>
+          <Stack space={3}>
+            <Text size={0} weight="medium" muted>
+              LIGHT MODE
+            </Text>
+            <Card border padding={3} radius={3}>
+              <Grid columns={6} gap={2}>
+                {cssVarsKeys.map((key) => (
+                  <CSSVariablesPreview cssVarKey={key} key={key} />
+                ))}
+              </Grid>
+            </Card>
+          </Stack>
+        </Card>
+        <Card padding={3} radius={3} scheme="dark">
+          <Stack space={3}>
+            <Text size={0} weight="medium" muted>
+              DARK MODE
+            </Text>
+            <Card border padding={3} radius={3}>
+              <Grid columns={6} gap={2}>
+                {cssVarsKeys.map((key) => (
+                  <CSSVariablesPreview cssVarKey={key} key={key} />
+                ))}
+              </Grid>
+            </Card>
+          </Stack>
+        </Card>
+      </Stack>
+    </ThemeProvider>
+  )
+}
+
+function CSSVariablesPreview({cssVarKey}: {cssVarKey: ThemeColorName}) {
+  return (
+    <Stack space={3}>
+      <Text size={1} weight="semibold">
+        {cssVarKey}
+      </Text>
+      <Grid columns={1} gap={1}>
+        {Object.entries(tonesCssVariables[cssVarKey])
+          .sort()
+          .map(([key, value]) => {
+            const cssVariableKey = `--${cssVarKey}-${key}`
+
+            return <ColorPreview cssVariableKey={cssVariableKey} key={key} value={value} />
+          })}
+      </Grid>
+    </Stack>
+  )
+}
+
+function ColorPreview({cssVariableKey, value}: {cssVariableKey: string; value: string}) {
+  const cardRef = useRef<HTMLDivElement | null>(null)
+  const [propertyValue, setPropertyValue] = useState<string | null>()
+
+  useLayoutEffect(() => {
+    if (!cardRef.current) return
+    const propertyValue = getComputedStyle(cardRef.current).getPropertyValue(cssVariableKey)
+
+    setPropertyValue(propertyValue)
+  }, [cssVariableKey, propertyValue])
+
+  return (
+    <Card ref={cardRef}>
+      <Flex align="center" gap={2}>
+        <Card border padding={1} radius={3} shadow={0} style={{flexShrink: 0}}>
+          <Card radius={2} style={{background: value, height: '50px', width: '50px'}} />
+        </Card>
+        <Stack space={2}>
+          <Text size={0} weight="medium">
+            {cssVariableKey}
+          </Text>
+          {propertyValue && <Code size={0}>{propertyValue}</Code>}
+        </Stack>
+      </Flex>
+    </Card>
+  )
+}


### PR DESCRIPTION
### Description

This PR declares css variables directly in the document head (via styled-components' `createGlobalStyle`)

**Storybook changes:**
- Added a few storybook stories highlighting css tone vars and spot colours
- Minor refactoring: now pass `scheme` where possible and work around the assumption that there may only been two scheme types (there could be more in future)
- Minor change to the main storybook decorator to better accommodate background rendering within the docs page