### PR TITLE
feat(hotkeys): platform aware keys (alt => option, option => alt)

### DIFF
--- a/src/components/hotkeys/__workshop__/plain.tsx
+++ b/src/components/hotkeys/__workshop__/plain.tsx
@@ -1,9 +1,21 @@
-import {Flex, Hotkeys} from '@sanity/ui'
+import {Flex, Hotkeys, Label, Stack} from '@sanity/ui'
 
 export default function PlainStory() {
   return (
     <Flex align="center" height="fill" justify="center">
-      <Hotkeys keys={['Ctrl', 'Shift', 'P']} />
+      <Stack space={3}>
+        <Label>Default font size</Label>
+        <Hotkeys keys={['Shift', 'Tab']} />
+
+        <Label>Larger</Label>
+        <Hotkeys fontSize={2} keys={['Ctrl', 'Shift', 'P']} />
+
+        <Label>Ctrl+Alt+I input, shows platform-appropriate</Label>
+        <Hotkeys fontSize={3} keys={['Ctrl', 'Alt', 'I']} />
+
+        <Label>Ctrl+Option+I input, shows platform-appropriate</Label>
+        <Hotkeys fontSize={3} keys={['Ctrl', 'Option', 'I']} />
+      </Stack>
     </Flex>
   )
 }

--- a/src/components/hotkeys/hotkeys.tsx
+++ b/src/components/hotkeys/hotkeys.tsx
@@ -1,5 +1,6 @@
 import {forwardRef} from 'react'
 import styled from 'styled-components'
+import {IS_APPLE_DEVICE} from '../../constants'
 import {useArrayProp} from '../../hooks'
 import {Inline, KBD} from '../../primitives'
 
@@ -46,10 +47,51 @@ export const Hotkeys = forwardRef(function Hotkeys(
       <Inline as="span" space={space}>
         {keys.map((key, i) => (
           <Key fontSize={fontSize} key={i} padding={padding} radius={radius}>
-            {key}
+            {platformifyKey(key)}
           </Key>
         ))}
       </Inline>
     </Root>
   )
 })
+
+/**
+ * Given key 'Alt', or 'Option' (case-insensitive), return the platform-appropriate key name
+ * (eg 'Alt' on non-Apple devices, 'Option' on Apple devices).
+ *
+ * @param key - Key to platformify
+ * @returns Platform-appropriate key name
+ * @internal
+ */
+function platformifyKey(key: string): string {
+  const lowerKey = key.toLowerCase()
+
+  if (lowerKey === 'alt' && IS_APPLE_DEVICE) {
+    return matchCase(key, 'option')
+  }
+
+  if (lowerKey === 'option' && !IS_APPLE_DEVICE) {
+    return matchCase(key, 'alt')
+  }
+
+  return key
+}
+
+/**
+ * Apply the case (lowercase/uppercase) of `original` to `target`, character by character,
+ * eg matching ALL CAPS, all lowercase or Mixed Case.
+ *
+ * @param original - The original string to match case of
+ * @param target - The target string to apply case to
+ * @returns Target string with case applied from original
+ * @internal
+ */
+function matchCase(original: string, target: string): string {
+  const orgLength = original.length
+
+  return target.replace(/./g, (char, i) => {
+    // Replace character by character matching case of original
+    // If running out of original, just return the target case as-is
+    return i < orgLength && original[i] === original[i].toUpperCase() ? char.toUpperCase() : char
+  })
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,3 +17,11 @@ export const FLOATING_STATIC_SIDES: Record<string, 'bottom' | 'left' | 'top' | '
   bottom: 'top',
   left: 'right',
 }
+
+/**
+ * @internal
+ */
+export const IS_APPLE_DEVICE =
+  typeof navigator === 'undefined' || typeof navigator.platform !== 'string'
+    ? false
+    : /Mac|iPod|iPhone|iPad/.test(navigator.platform || '')


### PR DESCRIPTION
When rendering hotkeys such as `Ctrl + Alt + I`, it would be ideal if we showed the platform-specific hotkeys, eg `Option` instead of `Alt` on Windows/Linux. Similarly, when specifying `Ctrl + Option + I`, it should adjust according to platform.

I wasn't quite sure if we should also add "Opt" as a case, but decided against it for now - open to input.

Theoretically a user can of course have a Mac keyboard connected to a Windows/Linux computer and vice versa, but my gut feeling that it is an edge case not worth considering given we can't actually detect the situation.