### PR TITLE
fix(dialog): update dialog design

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -48,7 +48,6 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
   position?: DialogPosition | DialogPosition[]
   scheme?: ThemeColorSchemeKey
   zOffset?: number | number[]
-  children?: React.ReactNode
 }
 
 interface DialogCardProps extends ResponsiveWidthProps {

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -48,6 +48,7 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
   position?: DialogPosition | DialogPosition[]
   scheme?: ThemeColorSchemeKey
   zOffset?: number | number[]
+  children?: React.ReactNode
 }
 
 interface DialogCardProps extends ResponsiveWidthProps {
@@ -128,7 +129,7 @@ const DialogLayout = styled(Flex)`
   width: 100%;
 `
 
-const DialogHeader = styled(Card)<DialogHeaderProps>`
+const DialogHeader = styled(Box)<DialogHeaderProps>`
   position: relative;
   z-index: 2;
 
@@ -309,9 +310,10 @@ const DialogCard = forwardRef(function DialogCard(
             <DialogHeader
               $isContentScrollable={isContentScrollable}
               $hasScrolledFromTop={hasScrolledFromTop}
+              padding={3}
             >
-              <Flex>
-                <Box flex={1} padding={4}>
+              <Flex align="center">
+                <Box flex={1} padding={3}>
                   {header && (
                     <Text id={labelId} size={1} weight="medium">
                       {header}
@@ -319,16 +321,14 @@ const DialogCard = forwardRef(function DialogCard(
                   )}
                 </Box>
                 {showCloseButton && (
-                  <Box padding={2}>
-                    <Button
-                      aria-label="Close dialog"
-                      disabled={!onClose}
-                      icon={CloseIcon}
-                      mode="bleed"
-                      onClick={onClose}
-                      padding={3}
-                    />
-                  </Box>
+                  <Button
+                    aria-label="Close dialog"
+                    disabled={!onClose}
+                    icon={CloseIcon}
+                    mode="bleed"
+                    onClick={onClose}
+                    padding={3}
+                  />
                 )}
               </Flex>
             </DialogHeader>

--- a/src/theme/studioTheme/theme.ts
+++ b/src/theme/studioTheme/theme.ts
@@ -28,7 +28,7 @@ export const studioTheme: RootTheme = {
     // @ts-ignore This is necessary until workshop is updated.
     base: {bg: '#fffff'},
   },
-  container: [360, 600, 960, 1280, 1600, 1920],
+  container: [320, 640, 960, 1280, 1600, 1920],
   focusRing: {
     offset: 1,
     width: 2,

--- a/src/theme/studioTheme/theme.ts
+++ b/src/theme/studioTheme/theme.ts
@@ -28,7 +28,7 @@ export const studioTheme: RootTheme = {
     // @ts-ignore This is necessary until workshop is updated.
     base: {bg: '#fffff'},
   },
-  container: [320, 640, 960, 1280, 1600, 1920],
+  container: [360, 600, 960, 1280, 1600, 1920],
   focusRing: {
     offset: 1,
     width: 2,

--- a/stories/components/Dialog.stories.tsx
+++ b/stories/components/Dialog.stories.tsx
@@ -194,3 +194,38 @@ export const Positioning: Story = {
     )
   },
 }
+
+export const DeleteDocumentDialog: Story = {
+  render: (props) => {
+    const [open, setOpen] = useState(true)
+    const onClose = useCallback(() => setOpen(false), [])
+    const onOpen = useCallback(() => setOpen(true), [])
+
+    return (
+      <>
+        <Button onClick={onOpen} text="Open dialog" />
+        {open && (
+          <Dialog
+            {...props}
+            onClose={onClose}
+            header="Delete document"
+            padding={3}
+            footer={
+              <Flex width="full" gap={3} justify={'flex-end'} padding={3}>
+                <Button onClick={onClose} mode="bleed" text="Cancel" tone="default" />
+                <Button onClick={onClose} mode="default" text="Close" tone="critical" />
+              </Flex>
+            }
+            open={open}
+          >
+            <Box paddingX={3}>
+              <Box paddingX={3} paddingY={5}>
+                <Text size={1}>Are you sure you want to delete “Untitled”?</Text>
+              </Box>
+            </Box>
+          </Dialog>
+        )}
+      </>
+    )
+  },
+}


### PR DESCRIPTION
- Updates dialog default padding values in body and footer.
- Updates header padding and structure. 
- Added story with example for the delete document.
<img width="600" alt="Screenshot 2023-10-19 at 17 34 01" src="https://github.com/sanity-io/ui/assets/46196328/3b4c34b9-a154-4c8d-a6b0-371a77ff9fde">
