### PR TITLE
fix(tooltip): update tooltip position middleware

### DIFF
--- a/src/primitives/tooltip/__workshop__/index.ts
+++ b/src/primitives/tooltip/__workshop__/index.ts
@@ -15,5 +15,10 @@ export default defineScope({
       title: 'Resizable Boundary',
       component: lazy(() => import('./resizableBoundary')),
     },
+    {
+      name: 'overflowBoundary',
+      title: 'Overflowing Boundary',
+      component: lazy(() => import('./overflowingBoundary')),
+    },
   ],
 })

--- a/src/primitives/tooltip/__workshop__/index.ts
+++ b/src/primitives/tooltip/__workshop__/index.ts
@@ -10,5 +10,10 @@ export default defineScope({
       title: 'Props',
       component: lazy(() => import('./props')),
     },
+    {
+      name: 'resizableBoundary',
+      title: 'Resizable Boundary',
+      component: lazy(() => import('./resizableBoundary')),
+    },
   ],
 })

--- a/src/primitives/tooltip/__workshop__/overflowingBoundary.tsx
+++ b/src/primitives/tooltip/__workshop__/overflowingBoundary.tsx
@@ -15,7 +15,7 @@ export default function OverflowingBoundaryStory() {
   const [boundaryElement, setBoundaryElement] = useState<HTMLDivElement | null>(null)
 
   return (
-    <Flex align="center" height="fill" justify="center">
+    <Flex align="center" height="fill" justify="center" style={{height: '200vh'}}>
       <BoundaryElementProvider element={useBoundaryElement ? boundaryElement : null}>
         <Card
           border

--- a/src/primitives/tooltip/__workshop__/overflowingBoundary.tsx
+++ b/src/primitives/tooltip/__workshop__/overflowingBoundary.tsx
@@ -3,13 +3,13 @@ import {useBoolean, useSelect, useText} from '@sanity/ui-workshop'
 import {useState} from 'react'
 import {WORKSHOP_PLACEMENT_OPTIONS} from '../../../__workshop__/constants'
 
-export default function ResizableBoundaryStory() {
+export default function OverflowingBoundaryStory() {
   const content = useText(
     'Content',
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mollis consectetur malesuada. Sed lobortis est dolor, eget imperdiet velit placerat et. Aenean posuere mi non aliquet iaculis. Donec fermentum pulvinar purus at sagittis. Ut tincidunt massa odio, sed finibus justo ullamcorper id. Nam venenatis justo non ligula elementum cursus. Pellentesque laoreet justo in mollis sagittis. In lacinia ornare ultrices. Suspendisse potenti.',
   )
-  const placement = useSelect('Placement', WORKSHOP_PLACEMENT_OPTIONS, 'right')
-  const portal = useBoolean('Portal', true)
+  const placement = useSelect('Placement', WORKSHOP_PLACEMENT_OPTIONS, 'top')
+  const portal = useBoolean('Portal', false)
   const useBoundaryElement = useBoolean('Use boundary element', true)
 
   const [boundaryElement, setBoundaryElement] = useState<HTMLDivElement | null>(null)
@@ -40,41 +40,9 @@ export default function ResizableBoundaryStory() {
             placement={placement}
             portal={portal}
           >
-            <Button mode="bleed" style={{position: 'absolute', top: 10, left: 10}} text="Tooltip" />
-          </Tooltip>
-          <Tooltip
-            content={<Text size={1}>{content}</Text>}
-            padding={2}
-            placement={placement}
-            portal={portal}
-          >
             <Button
               mode="bleed"
               style={{position: 'absolute', top: 10, right: 10}}
-              text="Tooltip"
-            />
-          </Tooltip>
-          <Tooltip
-            content={<Text size={1}>{content}</Text>}
-            padding={2}
-            placement={placement}
-            portal={portal}
-          >
-            <Button
-              mode="bleed"
-              style={{position: 'absolute', bottom: 10, left: 10}}
-              text="Tooltip"
-            />
-          </Tooltip>
-          <Tooltip
-            content={<Text size={1}>{content}</Text>}
-            padding={2}
-            placement={placement}
-            portal={portal}
-          >
-            <Button
-              mode="bleed"
-              style={{position: 'absolute', bottom: 10, right: 10}}
               text="Tooltip"
             />
           </Tooltip>

--- a/src/primitives/tooltip/__workshop__/resizableBoundary.tsx
+++ b/src/primitives/tooltip/__workshop__/resizableBoundary.tsx
@@ -1,0 +1,84 @@
+import {BoundaryElementProvider, Button, Card, Code, Flex, Text, Tooltip} from '@sanity/ui'
+import {useBoolean, useSelect, useText} from '@sanity/ui-workshop'
+import {useState} from 'react'
+import {WORKSHOP_PLACEMENT_OPTIONS} from '../../../__workshop__/constants'
+
+export default function PropsStory() {
+  const content = useText(
+    'Content',
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mollis consectetur malesuada. Sed lobortis est dolor, eget imperdiet velit placerat et. Aenean posuere mi non aliquet iaculis. Donec fermentum pulvinar purus at sagittis. Ut tincidunt massa odio, sed finibus justo ullamcorper id. Nam venenatis justo non ligula elementum cursus. Pellentesque laoreet justo in mollis sagittis. In lacinia ornare ultrices. Suspendisse potenti.',
+  )
+  const placement = useSelect('Placement', WORKSHOP_PLACEMENT_OPTIONS, 'right')
+  const portal = useBoolean('Portal', true)
+
+  const [boundaryElement, setBoundaryElement] = useState<HTMLDivElement | null>(null)
+
+  return (
+    <Flex align="center" height="fill" justify="center">
+      <BoundaryElementProvider element={boundaryElement}>
+        <Card
+          border
+          ref={setBoundaryElement}
+          style={{
+            height: 'calc(100vh - 100px)',
+            overflow: 'hidden',
+            position: 'relative',
+            resize: 'both',
+            width: '500px',
+          }}
+        >
+          <Flex align="center" height="fill" justify="center">
+            <Flex justify="center">
+              <Code size={1}>Placement: {placement}</Code>
+            </Flex>
+          </Flex>
+
+          <Tooltip
+            content={<Text size={1}>{content}</Text>}
+            padding={2}
+            placement={placement}
+            portal={portal}
+          >
+            <Button mode="bleed" style={{position: 'absolute', top: 10, left: 10}} text="Tooltip" />
+          </Tooltip>
+          <Tooltip
+            content={<Text size={1}>{content}</Text>}
+            padding={2}
+            placement={placement}
+            portal={portal}
+          >
+            <Button
+              mode="bleed"
+              style={{position: 'absolute', top: 10, right: 10}}
+              text="Tooltip"
+            />
+          </Tooltip>
+          <Tooltip
+            content={<Text size={1}>{content}</Text>}
+            padding={2}
+            placement={placement}
+            portal={portal}
+          >
+            <Button
+              mode="bleed"
+              style={{position: 'absolute', bottom: 10, left: 10}}
+              text="Tooltip"
+            />
+          </Tooltip>
+          <Tooltip
+            content={<Text size={1}>{content}</Text>}
+            padding={2}
+            placement={placement}
+            portal={portal}
+          >
+            <Button
+              mode="bleed"
+              style={{position: 'absolute', bottom: 10, right: 10}}
+              text="Tooltip"
+            />
+          </Tooltip>
+        </Card>
+      </BoundaryElementProvider>
+    </Flex>
+  )
+}

--- a/src/primitives/tooltip/__workshop__/resizableBoundary.tsx
+++ b/src/primitives/tooltip/__workshop__/resizableBoundary.tsx
@@ -10,12 +10,13 @@ export default function PropsStory() {
   )
   const placement = useSelect('Placement', WORKSHOP_PLACEMENT_OPTIONS, 'right')
   const portal = useBoolean('Portal', true)
+  const useBoundaryElement = useBoolean('Use boundary element', true)
 
   const [boundaryElement, setBoundaryElement] = useState<HTMLDivElement | null>(null)
 
   return (
     <Flex align="center" height="fill" justify="center">
-      <BoundaryElementProvider element={boundaryElement}>
+      <BoundaryElementProvider element={useBoundaryElement ? boundaryElement : undefined}>
         <Card
           border
           ref={setBoundaryElement}

--- a/src/primitives/tooltip/constants.ts
+++ b/src/primitives/tooltip/constants.ts
@@ -1,5 +1,6 @@
 import {Placement} from '@floating-ui/react-dom'
 
+export const DEFAULT_TOOLTIP_PADDING = 4
 export const DEFAULT_FALLBACK_PLACEMENTS: Record<Placement, Placement[]> = {
   top: ['bottom', 'left', 'right'],
   'top-start': ['bottom-start', 'left-start', 'right-start'],

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -8,6 +8,7 @@ import {
   useFloating,
   Middleware,
   RootBoundary,
+  size,
 } from '@floating-ui/react-dom'
 import {
   cloneElement,
@@ -109,6 +110,17 @@ export const Tooltip = forwardRef(function Tooltip(
     )
     // Define distance between reference and floating element
     ret.push(offset({mainAxis: 3}))
+
+    ret.push(
+      size({
+        apply({availableWidth, elements}) {
+          Object.assign(elements.floating.style, {
+            maxWidth: `${availableWidth - 4 * 2}px`, // the padding is `4px`
+          })
+        },
+      }),
+    )
+
     // Shift the tooltip so its sits with the boundary element
     ret.push(
       shift({

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -8,7 +8,6 @@ import {
   useFloating,
   Middleware,
   RootBoundary,
-  size,
 } from '@floating-ui/react-dom'
 import {
   cloneElement,
@@ -75,7 +74,7 @@ export const Tooltip = forwardRef(function Tooltip(
   const boundaryElementContext = useBoundaryElement()
   const theme = useTheme()
   const {
-    boundaryElement = boundaryElementContext?.element,
+    boundaryElement,
     children: childProp,
     content,
     disabled,
@@ -106,29 +105,14 @@ export const Tooltip = forwardRef(function Tooltip(
         fallbackPlacements,
         padding: 4,
         rootBoundary,
-        mainAxis: false,
       }),
     )
-
     // Define distance between reference and floating element
     ret.push(offset({mainAxis: 3}))
-
-    // Set width and height on the floating element
-    ret.push(
-      size({
-        apply({availableWidth, availableHeight, elements}) {
-          Object.assign(elements.floating.style, {
-            maxWidth: `${availableWidth - 4 * 2}px`, // the padding is `4px`
-            maxHeight: `${availableHeight - 4 * 2}px`, // the padding is `4px`
-          })
-        },
-      }),
-    )
-
-    // Shift the tooltip so its sits with the boundary eleement
+    // Shift the tooltip so its sits with the boundary element
     ret.push(
       shift({
-        boundary: boundaryElement || undefined,
+        boundary: boundaryElement || boundaryElementContext?.element || undefined,
         rootBoundary,
         padding: 4,
       }),
@@ -138,7 +122,7 @@ export const Tooltip = forwardRef(function Tooltip(
     ret.push(arrow({element: arrowRef, padding: 2}))
 
     return ret
-  }, [boundaryElement, fallbackPlacements])
+  }, [boundaryElement, fallbackPlacements, boundaryElementContext?.element])
 
   const {floatingStyles, placement, middlewareData, refs, update} = useFloating({
     middleware,

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -36,6 +36,8 @@ import {DEFAULT_FALLBACK_PLACEMENTS} from './constants'
 import {TooltipArrow} from './tooltipArrow'
 import {useTooltipDelayGroup} from './tooltipDelayGroup'
 
+const TOOLTIP_PADDING = 4 // px
+
 /**
  * @public
  */
@@ -64,7 +66,7 @@ export interface TooltipProps extends Omit<LayerProps, 'as'> {
 
 const Root = styled(Layer)`
   pointer-events: none;
-  max-width: calc(100vw - 8px);
+  max-width: calc(100vw - ${TOOLTIP_PADDING * 2}px);
 `
 
 /**
@@ -107,7 +109,7 @@ export const Tooltip = forwardRef(function Tooltip(
       flip({
         boundary: isConstrainedToBoundary ? boundaryElement || undefined : undefined,
         fallbackPlacements,
-        padding: 4,
+        padding: TOOLTIP_PADDING,
         rootBoundary,
       }),
     )
@@ -119,7 +121,7 @@ export const Tooltip = forwardRef(function Tooltip(
         size({
           apply({availableWidth, elements}) {
             Object.assign(elements.floating.style, {
-              maxWidth: `${availableWidth - 4 * 2}px`, // the padding is `4px`
+              maxWidth: `${availableWidth - TOOLTIP_PADDING * 2}px`,
             })
           },
         }),
@@ -133,7 +135,7 @@ export const Tooltip = forwardRef(function Tooltip(
           ? boundaryElement || boundaryElementContext?.element || undefined
           : undefined,
         rootBoundary,
-        padding: 4,
+        padding: TOOLTIP_PADDING,
       }),
     )
 


### PR DESCRIPTION
Updates how the tooltip position middleware works.

- Updates the Portal to be created into `body` when using `portal=true` in tooltips. Allow for tooltip to show on top of panes
- Removes the size function, as it was adding a maxHeight and width to the tooltip element, making it behave in unexpected ways when the available space was smaller than the needed space.
- Removes the `mainAxis=false` from the flip, as it produces tooltips to not flip in the main axis, so if you have a tooltip with `position="top"` and it doesn't fit in the top position, it won't flip as it's disabled by this flag. https://floating-ui.com/docs/flip#combining-with-shift
- Removes the contextBoundary when flipping the tooltip, as it made the library understand that it has more space to show the elements than the actual available space, the contextBoundary receives the entire pain.

### Before
<img width="400" alt="Screenshot 2023-10-25 at 14 16 55" src="https://github.com/sanity-io/ui/assets/46196328/cf65dfe3-1b4f-492d-8d94-15caf8c84382">

<img width="200" alt="Screenshot 2023-10-25 at 14 16 55" src="https://github.com/sanity-io/ui/assets/46196328/446f21a9-89c6-4f12-8a74-e97df5a64c55">



### After
<img width="400" alt="Screenshot 2023-10-25 at 14 17 17" src="https://github.com/sanity-io/ui/assets/46196328/79d670d5-85cb-483b-beaa-c67f931c2aaa">

<img width="199" alt="Screenshot 2023-10-25 at 14 21 41" src="https://github.com/sanity-io/ui/assets/46196328/fd3e5fc4-9619-4433-b8ed-bb354fea4c4b">


### Some other cases:

https://github.com/sanity-io/ui/assets/46196328/9b18a69d-f772-4640-b14c-c67e779a66d5


In comments branch the fallbackPlacement prop needs to be removed. Will add file reference and notify the team about it. 