### PR TITLE
Revert "build: temporarily skip actions on current node version (21.0.0)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        node-version: [lts/*]
+        node-version: [lts/*, current]
         include:
           - platform: macos-latest
             node-version: lts/*


### PR DESCRIPTION
This reverts commit c8fa2a9ac62a3bf9b0ab0f5626e46a90f968f301.