### PR TITLE
feat(buttons): add support for width=fill prop

### DIFF
--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -31,7 +31,10 @@ const CustomButton = styled(Button)`
  */
 export const Tab = forwardRef(function Tab(
   props: TabProps &
-    Omit<React.HTMLProps<HTMLButtonElement>, 'aria-controls' | 'as' | 'id' | 'label' | 'type'>,
+    Omit<
+      React.HTMLProps<HTMLButtonElement>,
+      'aria-controls' | 'as' | 'id' | 'label' | 'type' | 'width'
+    >,
   forwardedRef: React.ForwardedRef<HTMLButtonElement>,
 ) {
   const {

--- a/src/primitives/button/button.tsx
+++ b/src/primitives/button/button.tsx
@@ -5,7 +5,7 @@ import {useArrayProp} from '../../hooks'
 import {ThemeProps} from '../../styles'
 import {responsiveRadiusStyle, ResponsiveRadiusStyleProps} from '../../styles/internal'
 import {useTheme} from '../../theme'
-import {ButtonMode, ButtonTextAlign, ButtonTone, FlexJustify} from '../../types'
+import {ButtonMode, ButtonTextAlign, ButtonTone, ButtonWidth, FlexJustify} from '../../types'
 import {Box} from '../box'
 import {Flex} from '../flex'
 import {Spinner} from '../spinner'
@@ -34,11 +34,12 @@ export interface ButtonProps extends ResponsivePaddingProps, ResponsiveRadiusPro
   text?: React.ReactNode
   tone?: ButtonTone
   type?: 'button' | 'reset' | 'submit'
-  width?: 'fill'
+  width?: ButtonWidth
 }
 
 const Root = styled.button<
-  {$mode: ButtonMode; $tone: ButtonTone; $width?: 'fill'} & ResponsiveRadiusStyleProps & ThemeProps
+  {$mode: ButtonMode; $tone: ButtonTone; $width?: ButtonWidth} & ResponsiveRadiusStyleProps &
+    ThemeProps
 >(responsiveRadiusStyle, buttonBaseStyles, buttonColorStyles)
 
 const LoadingBox = styled.div`

--- a/src/primitives/button/button.tsx
+++ b/src/primitives/button/button.tsx
@@ -34,10 +34,11 @@ export interface ButtonProps extends ResponsivePaddingProps, ResponsiveRadiusPro
   text?: React.ReactNode
   tone?: ButtonTone
   type?: 'button' | 'reset' | 'submit'
+  width?: 'fill'
 }
 
 const Root = styled.button<
-  {$mode: ButtonMode; $tone: ButtonTone} & ResponsiveRadiusStyleProps & ThemeProps
+  {$mode: ButtonMode; $tone: ButtonTone; $width?: 'fill'} & ResponsiveRadiusStyleProps & ThemeProps
 >(responsiveRadiusStyle, buttonBaseStyles, buttonColorStyles)
 
 const LoadingBox = styled.div`
@@ -86,6 +87,7 @@ export const Button = forwardRef(function Button(
     tone = 'default',
     type = 'button',
     muted = false,
+    width,
     ...restProps
   } = props
 
@@ -128,6 +130,7 @@ export const Button = forwardRef(function Button(
       disabled={Boolean(loading || disabled)}
       ref={ref}
       type={type}
+      $width={width}
     >
       {Boolean(loading) && (
         <LoadingBox>

--- a/src/primitives/button/button.tsx
+++ b/src/primitives/button/button.tsx
@@ -60,7 +60,7 @@ const LoadingBox = styled.div`
  * @public
  */
 export const Button = forwardRef(function Button(
-  props: ButtonProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as'>,
+  props: ButtonProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as' | 'width'>,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
   const {

--- a/src/primitives/button/styles.ts
+++ b/src/primitives/button/styles.ts
@@ -8,7 +8,7 @@ import {CSSObject} from '../../types/styled'
 /**
  * @internal
  */
-export function buttonBaseStyles(): ReturnType<typeof css> {
+export function buttonBaseStyles({$width}: {$width?: 'fill'}): ReturnType<typeof css> {
   return css`
     -webkit-font-smoothing: inherit;
     appearance: none;
@@ -26,6 +26,12 @@ export function buttonBaseStyles(): ReturnType<typeof css> {
     white-space: nowrap;
     text-align: left;
     position: relative;
+
+    ${$width === 'fill' &&
+    css`
+      width: -webkit-fill-available;
+      width: stretch;
+    `}
 
     & > span {
       display: block;

--- a/src/primitives/button/styles.ts
+++ b/src/primitives/button/styles.ts
@@ -2,13 +2,13 @@ import {css} from 'styled-components'
 import {ThemeProps} from '../../styles'
 import {_colorVarsStyle} from '../../styles/colorVars'
 import {focusRingBorderStyle, focusRingStyle} from '../../styles/internal'
-import {ButtonMode, ButtonTone} from '../../types'
+import {ButtonMode, ButtonTone, ButtonWidth} from '../../types'
 import {CSSObject} from '../../types/styled'
 
 /**
  * @internal
  */
-export function buttonBaseStyles({$width}: {$width?: 'fill'}): ReturnType<typeof css> {
+export function buttonBaseStyles({$width}: {$width?: ButtonWidth}): ReturnType<typeof css> {
   return css`
     -webkit-font-smoothing: inherit;
     appearance: none;

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -12,3 +12,8 @@ export type ButtonTextAlign = 'left' | 'right' | 'center'
  * @public
  */
 export type ButtonTone = 'default' | 'primary' | 'positive' | 'caution' | 'critical'
+
+/**
+ * @public
+ */
+export type ButtonWidth = 'fill'

--- a/stories/controls.ts
+++ b/stories/controls.ts
@@ -19,6 +19,17 @@ export const getAvatarSizeControls = () => {
   }
 }
 
+export const getButtonWidthControls = () => {
+  return {
+    control: {type: 'select'},
+    options: ['(none)', 'fill'],
+    mapping: {
+      '(none)': '',
+      fill: 'fill',
+    },
+  }
+}
+
 export const getContainerWidthControls = () => {
   const numContainerSizes = studioTheme.container.length
 

--- a/stories/primitives/Button.stories.tsx
+++ b/stories/primitives/Button.stories.tsx
@@ -3,6 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react'
 import {Button, Flex, Grid, Stack, Text} from '../../src/primitives'
 import {BUTTON_MODES, BUTTON_TONES, RADII} from '../constants'
 import {
+  getButtonWidthControls,
   getFontSizeControls,
   getIconControls,
   getRadiusControls,
@@ -16,6 +17,7 @@ const meta: Meta<typeof Button> = {
     text: 'Label',
   },
   argTypes: {
+    disabled: {control: 'boolean'},
     fontSize: getFontSizeControls('text'),
     icon: getIconControls(),
     iconRight: getIconControls(),
@@ -23,7 +25,7 @@ const meta: Meta<typeof Button> = {
     radius: getRadiusControls(),
     space: getSpaceControls(),
     text: {control: 'text'},
-    disabled: {control: 'boolean'},
+    width: getButtonWidthControls(),
   },
   component: Button,
   tags: ['autodocs'],

--- a/stories/primitives/Button.stories.tsx
+++ b/stories/primitives/Button.stories.tsx
@@ -275,3 +275,11 @@ export const CustomButton: Story = {
     )
   },
 }
+
+export const FullWidth: Story = {
+  args: {
+    text: 'Full width',
+    width: 'fill',
+  },
+  render: (props) => <Button {...props} />,
+}


### PR DESCRIPTION
Adds new prop `width?: "fill"` to buttons. Supporting full width buttons
