### PR TITLE
feat: update avatar styles

### DIFF
--- a/src/primitives/avatar/avatar.tsx
+++ b/src/primitives/avatar/avatar.tsx
@@ -15,6 +15,8 @@ export interface AvatarProps {
   arrowPosition?: AvatarPosition
   as?: React.ElementType | keyof JSX.IntrinsicElements
   color?: ThemeColorSpotKey
+  /** @beta */
+  hideInnerStroke?: boolean
   initials?: string
   onImageLoadError?: (event: Error) => void
   size?: AvatarSize | AvatarSize[]
@@ -58,6 +60,7 @@ export const Avatar = forwardRef(function Avatar(
     onImageLoadError,
     arrowPosition: arrowPositionProp,
     animateArrowFrom,
+    hideInnerStroke,
     status = 'online',
     size: sizeProp = 0,
     ...restProps
@@ -142,13 +145,15 @@ export const Avatar = forwardRef(function Avatar(
           </defs>
 
           <circle cx={_radius} cy={_radius} r={_radius} fill={`url(#${imageId})`} />
-          <BgStroke
-            cx={_radius}
-            cy={_radius}
-            rx={_radius}
-            ry={_radius}
-            vectorEffect="non-scaling-stroke"
-          />
+          {!hideInnerStroke && (
+            <BgStroke
+              cx={_radius}
+              cy={_radius}
+              rx={_radius}
+              ry={_radius}
+              vectorEffect="non-scaling-stroke"
+            />
+          )}
           <Stroke
             cx={_radius}
             cy={_radius}
@@ -163,8 +168,8 @@ export const Avatar = forwardRef(function Avatar(
       {(imageFailed || !src) && initials && (
         <>
           <Initials>
-            <Text as="span" size={initialsSize}>
-              <strong>{initials}</strong>
+            <Text as="span" size={initialsSize} weight="medium">
+              {initials}
             </Text>
           </Initials>
         </>

--- a/src/primitives/avatar/avatarCounter.tsx
+++ b/src/primitives/avatar/avatarCounter.tsx
@@ -36,7 +36,7 @@ function _avatarCounterBaseStyle(props: ThemeProps) {
     background: var(--card-bg-color);
     box-shadow:
       0 0 0 1px var(--card-bg-color),
-      inset 0 0 0 1.5px var(--card-hairline-hard-color);
+      inset 0 0 0 1px var(--card-hairline-hard-color);
     padding: 0 ${rem(theme.sanity.space[2])};
 
     &:not([hidden]) {
@@ -73,8 +73,8 @@ export const AvatarCounter = forwardRef(function AvatarCounter(
 
   return (
     <Root $size={size} data-ui="AvatarCounter" ref={ref}>
-      <Text as="span" size={counterSize}>
-        <strong>{count}</strong>
+      <Text as="span" size={counterSize} weight="medium">
+        {count}
       </Text>
     </Root>
   )

--- a/src/primitives/avatar/styles.ts
+++ b/src/primitives/avatar/styles.ts
@@ -152,7 +152,7 @@ function avatarBgStrokeStyle(): CSSObject {
 
 function avatarStrokeStyle(): CSSObject {
   return {
-    strokeWidth: '3px',
+    strokeWidth: '2px',
 
     '[data-status="editing"] &': {
       strokeDasharray: '2 4',

--- a/src/theme/lib/theme/avatar.ts
+++ b/src/theme/lib/theme/avatar.ts
@@ -5,7 +5,9 @@ import {FocusRing} from '../../types'
  */
 export interface ThemeAvatar {
   sizes: {
+    /** Distance between avatars in an <AvatarStack> component (px) */
     distance: number
+    /** Diameter (px) */
     size: number
   }[]
   focusRing: FocusRing

--- a/src/theme/studioTheme/theme.ts
+++ b/src/theme/studioTheme/theme.ts
@@ -8,11 +8,11 @@ import {fonts} from './fonts'
 export const studioTheme: RootTheme = {
   avatar: {
     sizes: [
-      {distance: -3, size: 25},
-      {distance: -6, size: 35},
-      {distance: -9, size: 55},
+      {distance: -3, size: 23},
+      {distance: -6, size: 33},
+      {distance: -9, size: 53},
     ],
-    focusRing: {offset: 1, width: 1},
+    focusRing: {offset: 0, width: 1},
   },
   button: {
     textWeight: 'medium',

--- a/stories/constants.ts
+++ b/stories/constants.ts
@@ -9,6 +9,9 @@ import {
   Radius,
 } from '../src/types'
 
+export const AVATAR_SRC =
+  'https://avatars3.githubusercontent.com/u/406933?s=400&u=af898b0a50ef2ef1248be32dfa1410ccb55f6f65&v=4'
+
 export const BADGE_MODES: BadgeMode[] = ['default', 'outline']
 
 export const BADGE_TONES: BadgeTone[] = ['default', 'primary', 'positive', 'caution', 'critical']

--- a/stories/primitives/Avatar.stories.tsx
+++ b/stories/primitives/Avatar.stories.tsx
@@ -1,10 +1,12 @@
 import type {Meta, StoryObj} from '@storybook/react'
 import {Avatar, Flex, Stack} from '../../src/primitives'
+import {AVATAR_SRC} from '../constants'
 import {getAvatarSizeControls} from '../controls'
 
 const meta: Meta<typeof Avatar> = {
   args: {
     initials: 'AB',
+    src: AVATAR_SRC,
   },
   argTypes: {
     size: getAvatarSizeControls(),
@@ -17,6 +19,13 @@ export default meta
 type Story = StoryObj<typeof Avatar>
 
 export const Default: Story = {
+  render: (props) => <Avatar {...props} />,
+}
+
+export const NoSrc: Story = {
+  args: {
+    src: undefined,
+  },
   render: (props) => <Avatar {...props} />,
 }
 
@@ -36,7 +45,7 @@ export const AsButton: Story = {
 export const Colors: Story = {
   parameters: {
     controls: {
-      include: ['initials', 'size', 'status'],
+      exclude: ['color'],
     },
   },
   render: (props) => (
@@ -58,7 +67,7 @@ export const Colors: Story = {
 export const Sizes: Story = {
   parameters: {
     controls: {
-      include: ['color', 'initials', 'status'],
+      exclude: ['size'],
     },
   },
   render: (props) => (
@@ -66,6 +75,9 @@ export const Sizes: Story = {
       <Avatar {...props} size={0} />
       <Avatar {...props} size={1} />
       <Avatar {...props} size={2} />
+      <Avatar {...props} size={0} src={undefined} />
+      <Avatar {...props} size={1} src={undefined} />
+      <Avatar {...props} size={2} src={undefined} />
     </Stack>
   ),
 }

--- a/stories/primitives/AvatarCounter.stories.tsx
+++ b/stories/primitives/AvatarCounter.stories.tsx
@@ -1,0 +1,28 @@
+import type {Meta, StoryFn, StoryObj} from '@storybook/react'
+import {AvatarCounter, AvatarStack} from '../../src/primitives'
+import {getAvatarSizeControls} from '../controls'
+
+const meta: Meta<typeof AvatarCounter> = {
+  args: {
+    count: 10,
+  },
+  argTypes: {
+    size: getAvatarSizeControls(),
+  },
+  component: AvatarCounter,
+  decorators: [
+    (Story: StoryFn): JSX.Element => (
+      <AvatarStack>
+        <Story />
+      </AvatarStack>
+    ),
+  ],
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof AvatarCounter>
+
+export const Default: Story = {
+  render: (props) => <AvatarCounter {...props} />,
+}

--- a/stories/primitives/AvatarStack.stories.tsx
+++ b/stories/primitives/AvatarStack.stories.tsx
@@ -1,0 +1,28 @@
+import type {Meta, StoryObj} from '@storybook/react'
+import {Avatar, AvatarCounter, AvatarStack} from '../../src/primitives'
+import {AVATAR_SRC} from '../constants'
+import {getAvatarSizeControls} from '../controls'
+
+const meta: Meta<typeof AvatarStack> = {
+  args: {
+    children: [
+      <AvatarCounter count={2} key="avatar-1" />,
+      <Avatar color="magenta" initials="uq" key="avatar-2" />,
+      <Avatar color="magenta" initials="uq" key="avatar-3" />,
+      <Avatar color="purple" key="avatar-4" src={AVATAR_SRC} />,
+      <Avatar color="blue" key="avatar-5" src={AVATAR_SRC} />,
+    ],
+  },
+  argTypes: {
+    size: getAvatarSizeControls(),
+  },
+  component: AvatarStack,
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof AvatarStack>
+
+export const Default: Story = {
+  render: (props) => <AvatarStack {...props} />,
+}


### PR DESCRIPTION
### Description

This PR updates `<Avatar>`:
- adds support for a `hideInnerStroke` prop, which conditionally hides the outline between avatar images and the outer border
- tweaks avatar sizes: reducing diameter, reduces stroke width and tightens the focus ring
- uses medium weight for `<AvatarCounter>` (and also reduces stroke width)

Storybook updates:
- New stories for `<AvatarStack>` and `<AvatarCounter>`