### PR TITLE
fix(tooltips): update default fallback placements

### DIFF
--- a/src/primitives/tooltip/constants.ts
+++ b/src/primitives/tooltip/constants.ts
@@ -2,16 +2,16 @@ import {Placement} from '@floating-ui/react-dom'
 
 export const DEFAULT_TOOLTIP_PADDING = 4
 export const DEFAULT_FALLBACK_PLACEMENTS: Record<Placement, Placement[]> = {
-  top: ['bottom', 'left', 'right'],
-  'top-start': ['bottom-start', 'left-start', 'right-start'],
-  'top-end': ['bottom-end', 'left-end', 'right-end'],
-  bottom: ['top', 'left', 'right'],
-  'bottom-start': ['top-start', 'left-start', 'right-start'],
-  'bottom-end': ['top-end', 'left-end', 'right-end'],
-  left: ['right', 'top', 'bottom'],
-  'left-start': ['right-start', 'top-start', 'bottom-start'],
-  'left-end': ['right-end', 'top-end', 'bottom-end'],
-  right: ['left', 'top', 'bottom'],
-  'right-start': ['left-start', 'top-start', 'bottom-start'],
-  'right-end': ['left-end', 'top-end', 'bottom-end'],
+  top: ['top-end', 'top-start', 'bottom', 'left', 'right'],
+  'top-start': ['top', 'top-end', 'bottom-start', 'left-start', 'right-start'],
+  'top-end': ['top', 'top-start', 'bottom-end', 'left-end', 'right-end'],
+  bottom: ['bottom-end', 'bottom-start', 'top', 'left', 'right'],
+  'bottom-start': ['bottom', 'bottom-end', 'top-start', 'left-start', 'right-start'],
+  'bottom-end': ['bottom', 'bottom-start', 'top-end', 'left-end', 'right-end'],
+  left: ['left-end', 'left-start', 'right', 'top', 'bottom'],
+  'left-start': ['left', 'left-end', 'right-start', 'top-start', 'bottom-start'],
+  'left-end': ['left', 'left-start', 'right-end', 'top-end', 'bottom-end'],
+  right: ['right-end', 'right-start', 'left', 'top', 'bottom'],
+  'right-start': ['right', 'right-end', 'left-start', 'top-start', 'bottom-start'],
+  'right-end': ['right', 'right-start', 'left-end', 'top-end', 'bottom-end'],
 }


### PR DESCRIPTION
Update the fallback placements.
It's strange that if we want a tooltip to be positioned e.g. at the bottom, it automatically jumps to the top as a fallback. 
With this changes, it will always try to fallback to the same axis options and then change to other options.

So bottom -> bottom-end, bottom-start Then changes to top.