### PR TITLE
feat(animations): add animations to dialog and tooltips.

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -54,7 +54,7 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
    * Whether the dialog should animate in on mount.
    *
    * @beta
-   * @default false
+   * @defaultValue false
    */
   animate?: boolean
 }

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -16,6 +16,8 @@ import {DialogPosition, Radius} from '../../types'
 import {Layer, LayerProps, Portal, useBoundaryElement, useLayer, usePortal} from '../../utils'
 import {BORDER_OFFSET_X} from './constants'
 import {
+  animationDialogStyle,
+  AnimationDialogStyleProps,
   dialogStyle,
   responsiveDialogPositionStyle,
   ResponsiveDialogPositionStyleProps,
@@ -48,6 +50,10 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
   position?: DialogPosition | DialogPosition[]
   scheme?: ThemeColorSchemeKey
   zOffset?: number | number[]
+  /**
+   * @beta If true, the tooltip will animate in and out. Defaults to false.
+   */
+  animate?: boolean
 }
 
 interface DialogCardProps extends ResponsiveWidthProps {
@@ -94,11 +100,9 @@ function isTargetWithinScope(
   )
 }
 
-const Root = styled(Layer)<ResponsiveDialogPositionStyleProps & ResponsivePaddingStyleProps>(
-  responsivePaddingStyle,
-  dialogStyle,
-  responsiveDialogPositionStyle,
-)
+const Root = styled(Layer)<
+  ResponsiveDialogPositionStyleProps & ResponsivePaddingStyleProps & AnimationDialogStyleProps
+>(responsivePaddingStyle, dialogStyle, responsiveDialogPositionStyle, animationDialogStyle)
 
 const DialogContainer = styled(Container)`
   &:not([hidden]) {
@@ -382,6 +386,7 @@ export const Dialog = forwardRef(function Dialog(
     scheme,
     width: widthProp = 0,
     zOffset: zOffsetProp = dialog.zOffset || theme.sanity.layer?.dialog.zOffset,
+    animate = false,
     ...restProps
   } = props
   const portal = usePortal()
@@ -470,6 +475,7 @@ export const Dialog = forwardRef(function Dialog(
         ref={ref}
         role="dialog"
         zOffset={zOffset}
+        animate={animate}
       >
         <div ref={preDivRef} tabIndex={0} />
         <DialogCard

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -51,7 +51,10 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
   scheme?: ThemeColorSchemeKey
   zOffset?: number | number[]
   /**
-   * @beta If true, the tooltip will animate in and out. Defaults to false.
+   * Whether the dialog should animate in on mount.
+   *
+   * @beta
+   * @default false
    */
   animate?: boolean
 }

--- a/src/components/dialog/styles.ts
+++ b/src/components/dialog/styles.ts
@@ -1,3 +1,4 @@
+import {css} from 'styled-components'
 import {_responsive, ThemeProps} from '../../styles'
 import {DialogPosition} from '../../types'
 import {CSSObject} from '../../types/styled'
@@ -35,4 +36,42 @@ export function responsiveDialogPositionStyle(
   const {media} = theme.sanity
 
   return _responsive(media, props.$position, (position) => ({'&&': {position}}))
+}
+
+/**
+ * @internal
+ */
+export interface AnimationDialogStyleProps {
+  animate: boolean
+}
+
+export function animationDialogStyle(props: AnimationDialogStyleProps): ReturnType<typeof css> {
+  if (!props.animate) return css``
+
+  return css`
+    @keyframes zoomIn {
+      from {
+        opacity: 0;
+        transform: scale(0.95);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    animation: fadeIn 200ms ease-out;
+    // Animates the dialog card.
+    & > [data-ui='DialogCard'] {
+      animation: zoomIn 200ms ease-out;
+    }
+  `
 }

--- a/src/primitives/tooltip/conditionalWrapper.tsx
+++ b/src/primitives/tooltip/conditionalWrapper.tsx
@@ -1,0 +1,15 @@
+export function ConditionalWrapper({
+  children,
+  condition,
+  wrapper,
+}: {
+  children: React.ReactNode
+  condition: boolean
+  wrapper: (children: React.ReactNode) => React.ReactNode
+}): React.ReactNode {
+  if (!condition) {
+    return children
+  }
+
+  return wrapper(children)
+}

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -59,15 +59,21 @@ export interface TooltipProps extends Omit<LayerProps, 'as'> {
   scheme?: ThemeColorSchemeKey
   shadow?: number | number[]
   /**
-   * @public Adds a delay to open or close the tooltip.  Defaults to 0.
+   * Adds a delay to open or close the tooltip.
    *
    * If only a `number` is passed, it will be used for both opening and closing.
    *
    * If an object `{open: number; close:number}` is passed, it can be used to set different delays for each action.
+   *
+   * @public
+   * @default 0
    */
   delay?: Delay
   /**
-   * @beta If true, the tooltip will animate in and out. Defaults to false.
+   * Whether the tooltip should animate in and out.
+   *
+   * @beta
+   * @default false
    */
   animate?: boolean
 }

--- a/src/primitives/tooltip/tooltip.tsx
+++ b/src/primitives/tooltip/tooltip.tsx
@@ -66,14 +66,14 @@ export interface TooltipProps extends Omit<LayerProps, 'as'> {
    * If an object `{open: number; close:number}` is passed, it can be used to set different delays for each action.
    *
    * @public
-   * @default 0
+   * @defaultValue 0
    */
   delay?: Delay
   /**
    * Whether the tooltip should animate in and out.
    *
    * @beta
-   * @default false
+   * @defaultValue false
    */
   animate?: boolean
 }

--- a/src/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupProvider.tsx
+++ b/src/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupProvider.tsx
@@ -10,11 +10,13 @@ import {useTooltipDelayGroup} from './useTooltipDelayGroup'
 export interface TooltipDelayGroupProviderProps {
   children?: React.ReactNode
   /**
-   * @public Handles the delays to open or close a tooltip inside a group
+   * Handles the delays to open or close a tooltip inside a group
    *
    * If only a `number` is passed, it will be used for both opening and closing.
    *
    * If an object `{open: number; close:number}` is passed, it can be used to set different delays for each action.
+   *
+   * @public
    */
   delay: Delay
 }

--- a/stories/primitives/Tooltip.stories.tsx
+++ b/stories/primitives/Tooltip.stories.tsx
@@ -111,7 +111,7 @@ export const Animated: Story = {
           <Flex direction={'column'} gap={2} width="fill">
             <Text size={1}>Grouped tooltips</Text>
             <Flex>
-              <TooltipDelayGroupProvider delay={props.delay || 0}>
+              <TooltipDelayGroupProvider delay={{open: 200}}>
                 <Tooltip {...props} />
                 <Tooltip {...props} />
               </TooltipDelayGroupProvider>

--- a/stories/primitives/Tooltip.stories.tsx
+++ b/stories/primitives/Tooltip.stories.tsx
@@ -111,7 +111,7 @@ export const Animated: Story = {
           <Flex direction={'column'} gap={2} width="fill">
             <Text size={1}>Grouped tooltips</Text>
             <Flex>
-              <TooltipDelayGroupProvider delay={{open: 200}}>
+              <TooltipDelayGroupProvider delay={props.delay || 0}>
                 <Tooltip {...props} />
                 <Tooltip {...props} />
               </TooltipDelayGroupProvider>

--- a/stories/primitives/Tooltip.stories.tsx
+++ b/stories/primitives/Tooltip.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryFn, StoryObj} from '@storybook/react'
 import {userEvent, within} from '@storybook/testing-library'
-import {Button, Card, Text, Tooltip} from '../../src/primitives'
+import {Button, Card, Flex, Text, Tooltip, TooltipDelayGroupProvider} from '../../src/primitives'
 import {PLACEMENT_OPTIONS} from '../constants'
 import {getShadowControls, getSpaceControls} from '../controls'
 import {rowBuilder} from '../helpers/rowBuilder'
@@ -9,6 +9,7 @@ const meta: Meta<typeof Tooltip> = {
   args: {
     children: <Button mode="bleed" text="Hover me" />,
     content: <Text size={1}>I'm a tooltip</Text>,
+    arrow: false,
   },
   argTypes: {
     padding: getSpaceControls(),
@@ -68,6 +69,57 @@ export const WithOpenDelay: Story = {
   },
   render: (props) => {
     return <Tooltip {...props} />
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement)
+
+    const button = canvas.getByText('Hover me')
+
+    await userEvent.hover(button)
+    await canvas.findByText('Content', undefined, {timeout: 300})
+  },
+}
+
+export const Animated: Story = {
+  args: {
+    animate: true,
+    delay: {open: 200},
+  },
+  parameters: {
+    controls: {
+      include: ['content', 'delay', 'animate'],
+    },
+  },
+  render: (props) => {
+    return (
+      <Card
+        style={{
+          height: 'calc(100vh - 100px)',
+          overflow: 'hidden',
+          position: 'relative',
+          resize: 'both',
+          width: '500px',
+          padding: '20px',
+        }}
+        border
+      >
+        <Flex direction="column" align="flex-start" gap={2}>
+          <Flex direction="column" gap={2}>
+            <Text size={1}>Standalone tooltip</Text>
+            <Tooltip {...props} />
+          </Flex>
+          <Flex direction={'column'} gap={2} width="fill">
+            <Text size={1}>Grouped tooltips</Text>
+            <Flex>
+              <TooltipDelayGroupProvider delay={{open: 200}}>
+                <Tooltip {...props} />
+                <Tooltip {...props} />
+              </TooltipDelayGroupProvider>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Card>
+    )
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement)


### PR DESCRIPTION
## Adds animation to Dialog and Tooltips.

- Tooltips include a presence animation, it means, an animation handled by framer-motion will be triggered on mount and unmount of the element.
- Dialogs only include a css enter animation, it was not possible to easily include framer motion to handle the animation as the extra wrappers break the dialog style. Also the `<AnimatePresence>` wrapper would need to be added in the consumer and not in the ui component, given that the Dialog don't receive a `show` prop, and that logic is handled in the consumers. 



https://github.com/sanity-io/ui/assets/46196328/b784c482-b033-4cfc-bca3-dbcf5debc2c6



https://github.com/sanity-io/ui/assets/46196328/8f64a1b9-14e0-4e24-988b-b6d39dcd9eb2


