### PR TITLE
fix(dialog): drag events in modals are applied to underlying elements

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -84,6 +84,10 @@ function isTargetWithinScope(
   )
 }
 
+function onDragEnter(event: React.DragEvent<HTMLDivElement>) {
+  return event.stopPropagation()
+}
+
 const Root = styled(Layer)<ResponsiveDialogPositionStyleProps & ResponsivePaddingStyleProps>(
   responsivePaddingStyle,
   dialogStyle,
@@ -402,6 +406,7 @@ export const Dialog = forwardRef(function Dialog(
         id={id}
         onActivate={onActivate}
         onClick={handleRootClick}
+        onDragEnter={onDragEnter}
         onFocus={handleFocus}
         ref={ref}
         role="dialog"


### PR DESCRIPTION
Contain onDragEnter event to the modal only, as it's propagating to the elements behind it causing unexpected behaviours in the elements.

## With error

https://github.com/sanity-io/ui/assets/46196328/c2661532-44de-4fd5-bef9-a693e34eb224

## Fixed:

https://github.com/sanity-io/ui/assets/46196328/c6b317b1-cd5e-42a8-997b-93263ede1c06






