### PR TITLE
fix(menu-button): close menus containing selected items when re-clicking the menu button

### DIFF
--- a/cypress/e2e/ui/menuButton.cy.ts
+++ b/cypress/e2e/ui/menuButton.cy.ts
@@ -77,4 +77,23 @@ context('Components/MenuButton', () => {
     cy.get('#menu-item-2').focus()
     cy.get('#menu-button[aria-expanded="true"]').should('exist')
   })
+
+  it('clicking should open/close menu (with selected items)', () => {
+    cy.visit('/frame/?path=/components/menu/selected-item')
+
+    // click button
+    cy.get('#menu-button').click()
+    cy.get('#menu-button[aria-expanded="true"]').should('exist')
+
+    // click the same button again
+    cy.get('#menu-button').click()
+    cy.get('#menu-button[aria-expanded="false"]').should('exist')
+  })
+
+  it('should show the selected menu item when opened', () => {
+    cy.visit('/frame/?path=/components/menu/selected-item')
+
+    cy.get('#menu-button').click()
+    cy.get('#menu-item-2').should('be.focused')
+  })
 })

--- a/src/core/components/menu/__workshop__/selectedItem.tsx
+++ b/src/core/components/menu/__workshop__/selectedItem.tsx
@@ -16,8 +16,10 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
   matchReferenceWidth: true,
 }
 
+const INITIAL_INDEX = 1
+
 export default function SelectedItemStory() {
-  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [selectedIndex, setSelectedIndex] = useState(INITIAL_INDEX)
 
   return (
     <Box padding={[4, 5, 6]}>
@@ -26,12 +28,13 @@ export default function SelectedItemStory() {
 
         <MenuButton
           button={<Button text="Open menu" />}
-          id="selected-item-example"
+          id="menu-button"
           menu={
             <Menu>
               <MenuItem
                 icon={SearchIcon}
                 iconRight={selectedIndex === 0 ? CheckmarkIcon : undefined}
+                id="menu-item-1"
                 onClick={() => setSelectedIndex(0)}
                 pressed={selectedIndex === 0}
                 selected={selectedIndex === 0}
@@ -40,6 +43,7 @@ export default function SelectedItemStory() {
               <MenuItem
                 icon={ClockIcon}
                 iconRight={selectedIndex === 1 ? CheckmarkIcon : undefined}
+                id="menu-item-2"
                 onClick={() => setSelectedIndex(1)}
                 pressed={selectedIndex === 1}
                 selected={selectedIndex === 1}
@@ -49,6 +53,7 @@ export default function SelectedItemStory() {
               <MenuItem
                 icon={ExpandIcon}
                 iconRight={selectedIndex === 2 ? CheckmarkIcon : undefined}
+                id="menu-item-3"
                 onClick={() => setSelectedIndex(2)}
                 pressed={selectedIndex === 2}
                 selected={selectedIndex === 2}

--- a/src/core/components/menu/menuButton.tsx
+++ b/src/core/components/menu/menuButton.tsx
@@ -152,6 +152,7 @@ export const MenuButton = forwardRef(function MenuButton(
 
   const handleBlur = useCallback(
     (event: React.FocusEvent<HTMLButtonElement>) => {
+      // The EventTarget receiving focus
       const target = event.relatedTarget
 
       if (!(target instanceof Node)) {
@@ -164,9 +165,12 @@ export const MenuButton = forwardRef(function MenuButton(
         }
       }
 
-      setOpen(false)
+      // Only close the menu if the new target receiving focus is not the button itself
+      if (!buttonElement?.contains(target)) {
+        setOpen(false)
+      }
     },
-    [menuElements],
+    [buttonElement, menuElements],
   )
 
   const handleItemClick = useCallback(() => {

--- a/src/core/components/menu/menuButton.tsx
+++ b/src/core/components/menu/menuButton.tsx
@@ -99,6 +99,16 @@ export const MenuButton = forwardRef(function MenuButton(
     setShouldFocus(null)
   }, [])
 
+  // Prevent mouse event propagation when the menu is open.
+  // This is to ensure that `handleBlur` isn't triggered when clicking the menu button whilst open,
+  // which can lead to `setOpen` being triggered multiple times (once by `handleBlur`, and again by `handleButtonClick`).
+  const handleMouseDown = useCallback(
+    (event: PointerEvent) => {
+      if (open) event.preventDefault()
+    },
+    [open],
+  )
+
   const handleButtonKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
     // On `ArrowDown`, `Enter` and `Space`
     // - Opens menu and moves focus to first menuitem
@@ -152,7 +162,6 @@ export const MenuButton = forwardRef(function MenuButton(
 
   const handleBlur = useCallback(
     (event: React.FocusEvent<HTMLButtonElement>) => {
-      // The EventTarget receiving focus
       const target = event.relatedTarget
 
       if (!(target instanceof Node)) {
@@ -165,12 +174,9 @@ export const MenuButton = forwardRef(function MenuButton(
         }
       }
 
-      // Only close the menu if the new target receiving focus is not the button itself
-      if (!buttonElement?.contains(target)) {
-        setOpen(false)
-      }
+      setOpen(false)
     },
-    [buttonElement, menuElements],
+    [menuElements],
   )
 
   const handleItemClick = useCallback(() => {
@@ -235,13 +241,14 @@ export const MenuButton = forwardRef(function MenuButton(
             id,
             onClick: handleButtonClick,
             onKeyDown: handleButtonKeyDown,
+            onMouseDown: handleMouseDown,
             'aria-haspopup': true,
             'aria-expanded': open,
             ref: setButtonRef,
             selected: open,
           })
         : null,
-    [buttonProp, handleButtonClick, handleButtonKeyDown, id, open, setButtonRef],
+    [buttonProp, handleButtonClick, handleButtonKeyDown, handleMouseDown, id, open, setButtonRef],
   )
 
   const popoverProps: MenuButtonProps['popover'] = useMemo(

--- a/stories/components/MenuButton.stories.tsx
+++ b/stories/components/MenuButton.stories.tsx
@@ -1,11 +1,13 @@
 import {ClockIcon, CommentIcon, ExpandIcon, SearchIcon} from '@sanity/icons'
+import {expect} from '@storybook/jest'
 import type {Meta, StoryObj} from '@storybook/react'
+import {userEvent, within} from '@storybook/testing-library'
 import {Menu, MenuButton, MenuDivider, MenuGroup, MenuItem} from '../../src/core/components'
 import {Button, Flex} from '../../src/core/primitives'
 
 const meta: Meta<typeof MenuButton> = {
   args: {
-    button: <Button tone="primary" text="Open" />,
+    button: <Button text="Open" />,
     menu: (
       <Menu>
         <MenuItem icon={SearchIcon} id="menu-item-1" text="Search" />
@@ -67,5 +69,35 @@ export const WithMenuGroup: Story = {
   },
   render: (props) => {
     return <MenuButton {...props} />
+  },
+}
+
+export const WithSelectedItem: Story = {
+  args: {
+    menu: (
+      <Menu data-testid="menu">
+        <MenuItem id="menu-item-1" selected text="Search" />
+        <MenuItem id="menu-item-2" text="Clock" />
+        <MenuDivider />
+        <MenuItem id="menu-item-3" text="Comment" />
+        <MenuItem id="menu-item-4" text="Expand" />
+      </Menu>
+    ),
+  },
+  render: (props) => {
+    return <MenuButton {...props} />
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement)
+
+    const button = canvas.getByRole('button', {name: 'Open'})
+
+    await userEvent.click(button)
+    await userEvent.click(button)
+
+    const menu = within(document.documentElement).queryByTestId('menu')
+
+    // Assertion: <Menu> with a selected item should not be visible when clicking the original <MenuButton> to close
+    expect(menu).toBeNull()
   },
 }


### PR DESCRIPTION
### Description

This PR fixes a small issue with `<MenuButton>` not correctly closing a `<Menu>` containing `<MenuItem>` children with `selected=true`.

Currently, when you click the `<MenuButton>` whilst open:
- `handleBlur` is triggered, which closes the menu
- the click handler on the button itself is triggered, which currently toggles the menu boolean state
- this then causes the menu to re-open

[Example arcade showing the issue](https://www.sanity.io/ui/arcade?mode=jsx&jsx=eJzVUj0LwjAU3P0Vj%2BwltHVMMigIDs7OsQk10C%2FqKxRC%2F7tJGrXiUsHF8S7v7l6Ox%2FayV9BJpUxTcrudxAaAHSo9Qik7bvNAOOqkm2E3ILZNwACXALhlMwuoR%2BTkbPAKEm660gVqBQZ1TcC9a06K3qApZEWAiim61M6W2whijHjCSBydCRjFiZ9OvGWSklfGnByGUkLXqDOyFGVO9FCsEOdv4nyZyOhy%2F%2FmP9PsC2wE%2FO%2FxJZ39QFaP%2B%2BsSGUX%2Ba4g5Zlbly)

This fix stops propagation on the original menu button whilst the menu is open. This allows menu open state to be purely handled by `handleBlur` / `handleClickOutside`.