### PR TITLE
feat: add animate support to popovers, add custom origin middleware and animate from reference origin

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,3 +1,5 @@
+import {Transition, Variant} from 'framer-motion'
+
 /**
  * @internal
  */
@@ -7,6 +9,22 @@ export const EMPTY_ARRAY: never[] = []
  * @internal
  */
 export const EMPTY_RECORD: Record<string, never> = {}
+
+/**
+ * Shared `framer-motion` variants used by `Popover` and `Tooltip` components.
+ * @internal
+ */
+export const POPOVER_MOTION_PROPS: {
+  animate: Variant
+  initial: Variant
+  exit: Variant
+  transition: Transition
+} = {
+  initial: {opacity: 0.5, scale: 0.97},
+  animate: {opacity: 1, scale: 1},
+  exit: {opacity: 0, scale: 0.97},
+  transition: {duration: 0.4, type: 'spring'},
+}
 
 /**
  * @internal

--- a/src/core/middleware/origin.ts
+++ b/src/core/middleware/origin.ts
@@ -1,0 +1,47 @@
+import {Middleware} from '@floating-ui/react-dom'
+
+/**
+ * Custom floating-ui middleware which calculates transform-origin X + Y offsets
+ * based on the current floating rect's dimensions and shift offset.
+ *
+ * Scaling popovers with these transform-origin offsets will give the effect of
+ * popvers slightly 'growing' from the origin/reference element.
+ *
+ * This middleware must be applied after both `@sanity/ui/size` and `shift` middlewares.
+ */
+export const origin: Middleware = {
+  name: '@sanity/ui/origin',
+  fn({middlewareData, placement, rects}) {
+    const [side] = placement.split('-')
+
+    const floatingWidth = rects.floating.width
+    const floatingHeight = rects.floating.height
+
+    const shiftX = middlewareData.shift?.x || 0
+    const shiftY = middlewareData.shift?.y || 0
+
+    if (floatingWidth <= 0 || floatingHeight <= 0) {
+      return {}
+    }
+
+    const isVerticalPlacement = ['bottom', 'top'].includes(side)
+
+    const {originX, originY}: {originX: number; originY: number} = isVerticalPlacement
+      ? {
+          originX: clamp(0.5 - shiftX / floatingWidth, 0, 1),
+          originY: side === 'bottom' ? 0 : 1,
+        }
+      : {
+          originX: side === 'left' ? 1 : 0,
+          originY: clamp(0.5 - shiftY / floatingHeight, 0, 1),
+        }
+
+    return {
+      data: {originX, originY},
+    }
+  },
+}
+
+function clamp(num: number, min: number, max: number) {
+  return Math.min(Math.max(num, min), max)
+}

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -46,15 +46,41 @@ export interface PopoverProps
     ResponsiveShadowProps {
   /** @beta */
   __unstable_margins?: PopoverMargins
+  /**
+   * Whether the popover should animate in and out.
+   *
+   * @beta
+   * @defaultValue false
+   */
+  animate?: boolean
   arrow?: boolean
   /** @deprecated Use `floatingBoundary` and/or `referenceBoundary` instead */
   boundaryElement?: HTMLElement | null
   children?: React.ReactElement
+  /**
+   * When `true`, prevent overflow within the current boundary:
+   * - by flipping on its side axis
+   * - by resizing
+  /*
+   * Note that:
+   * - setting `preventOverflow` to `true` also prevents overflow on its side axis
+   * - setting `matchReferenceWidth` to `true` also causes the popover to resize
+   *
+   * @defaultValue false
+   */
   constrainSize?: boolean
   content?: React.ReactNode
   disabled?: boolean
   fallbackPlacements?: Placement[]
   floatingBoundary?: HTMLElement | null
+  /**
+   * When `true`, set the maximum width to match the reference element, and also prevent overflow within
+   * the current boundary by resizing.
+   *
+   * Note that setting `constrainSize` to `true` also causes the popover to resize
+   *
+   * @defaultValue false
+   */
   matchReferenceWidth?: boolean
   open?: boolean
   overflow?: BoxOverflow

--- a/src/core/primitives/popover/popoverCard.tsx
+++ b/src/core/primitives/popover/popoverCard.tsx
@@ -1,10 +1,12 @@
 import {Strategy} from '@floating-ui/react-dom'
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'
+import {MotionProps, motion} from 'framer-motion'
 import React, {CSSProperties, forwardRef, memo, useMemo} from 'react'
 import styled from 'styled-components'
+import {POPOVER_MOTION_PROPS} from '../../constants'
 import {BoxOverflow, CardTone, Placement, PopoverMargins, Radius} from '../../types'
 import {Arrow, useLayer} from '../../utils'
-import {Card} from '../card'
+import {Card, CardProps} from '../card'
 import {Flex} from '../flex'
 import {
   DEFAULT_POPOVER_ARROW_HEIGHT,
@@ -13,14 +15,14 @@ import {
   DEFAULT_POPOVER_MARGINS,
 } from './constants'
 
-const Root = styled(Card)({
-  '&:not([hidden])': {
-    display: 'flex',
-  },
-  flexDirection: 'column',
-  width: 'max-content',
-  minWidth: 'min-content',
-})
+const MotionCard = styled(motion(Card))`
+  &:not([hidden]) {
+    display: flex;
+  }
+  flex-direction: column;
+  width: max-content;
+  min-width: min-content;
+`
 
 /**
  * @internal
@@ -30,13 +32,16 @@ export const PopoverCard = memo(
     props: {
       /** @beta*/
       __unstable_margins?: PopoverMargins
+      animate?: boolean
       arrow: boolean
       arrowRef: React.Ref<HTMLDivElement>
       arrowX?: number
       arrowY?: number
+      originX?: number
+      originY?: number
       overflow?: BoxOverflow
       padding?: number | number[]
-      placement?: Placement
+      placement: Placement
       radius?: Radius | Radius[]
       scheme?: ThemeColorSchemeKey
       shadow?: number | number[]
@@ -50,6 +55,7 @@ export const PopoverCard = memo(
   ) {
     const {
       __unstable_margins: marginsProp,
+      animate,
       arrow,
       arrowRef,
       arrowX,
@@ -57,6 +63,8 @@ export const PopoverCard = memo(
       children,
       padding,
       placement,
+      originX,
+      originY,
       overflow,
       radius,
       scheme,
@@ -84,14 +92,16 @@ export const PopoverCard = memo(
 
     const rootStyle: CSSProperties = useMemo(
       () => ({
+        left: x,
+        originX,
+        originY,
         position: strategy,
         top: y,
-        left: x,
         width,
         zIndex,
         ...style,
       }),
-      [strategy, style, width, x, y, zIndex],
+      [originX, originY, strategy, style, width, x, y, zIndex],
     )
 
     const arrowStyle: CSSProperties = useMemo(
@@ -105,9 +115,9 @@ export const PopoverCard = memo(
     )
 
     return (
-      <Root
+      <MotionCard
         data-ui="Popover"
-        {...restProps}
+        {...(restProps as CardProps & MotionProps)}
         data-placement={placement}
         radius={radius}
         ref={ref}
@@ -116,6 +126,7 @@ export const PopoverCard = memo(
         sizing="border"
         style={rootStyle}
         tone={tone}
+        {...(animate ? POPOVER_MOTION_PROPS : {})}
       >
         <Flex data-ui="Popover__wrapper" direction="column" flex={1} overflow={overflow}>
           <Flex direction="column" flex={1} padding={padding}>
@@ -132,7 +143,7 @@ export const PopoverCard = memo(
             radius={DEFAULT_POPOVER_ARROW_RADIUS}
           />
         )}
-      </Root>
+      </MotionCard>
     )
   }),
 )

--- a/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/src/core/primitives/tooltip/tooltipCard.tsx
@@ -1,0 +1,104 @@
+import {ThemeColorSchemeKey} from '@sanity/ui/theme'
+import {MotionProps, motion} from 'framer-motion'
+import React, {CSSProperties, forwardRef, memo, useMemo} from 'react'
+import styled from 'styled-components'
+import {POPOVER_MOTION_PROPS} from '../../constants'
+import {Placement, Radius} from '../../types'
+import {Arrow} from '../../utils'
+import {Card, CardProps} from '../card'
+import {
+  DEFAULT_TOOLTIP_ARROW_HEIGHT,
+  DEFAULT_TOOLTIP_ARROW_RADIUS,
+  DEFAULT_TOOLTIP_ARROW_WIDTH,
+} from './constants'
+
+const MotionCard = styled(motion(Card))``
+
+/**
+ * @internal
+ */
+export const TooltipCard = memo(
+  forwardRef(function TooltipCard(
+    props: {
+      animate?: boolean
+      arrow: boolean
+      arrowRef: React.Ref<HTMLDivElement>
+      arrowX?: number
+      arrowY?: number
+      originX?: number
+      originY?: number
+      padding?: number | number[]
+      placement?: Placement
+      radius?: Radius | Radius[]
+      scheme?: ThemeColorSchemeKey
+      shadow?: number | number[]
+    } & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
+    ref: React.ForwardedRef<HTMLDivElement>,
+  ) {
+    const {
+      animate,
+      arrow,
+      arrowRef,
+      arrowX,
+      arrowY,
+      children,
+      originX,
+      originY,
+      padding,
+      placement,
+      radius,
+      scheme,
+      shadow,
+      style,
+      ...restProps
+    } = props
+
+    const rootStyle: CSSProperties = useMemo(
+      () => ({
+        originX,
+        originY,
+        ...style,
+      }),
+      [originX, originY, style],
+    )
+
+    const arrowStyle: CSSProperties = useMemo(
+      () => ({
+        left: arrowX !== null ? arrowX : undefined,
+        top: arrowY !== null ? arrowY : undefined,
+        right: undefined,
+        bottom: undefined,
+      }),
+      [arrowX, arrowY],
+    )
+
+    return (
+      <MotionCard
+        data-ui="Tooltip__card"
+        {...(restProps as CardProps & MotionProps)}
+        data-placement={placement}
+        padding={padding}
+        radius={radius}
+        ref={ref}
+        scheme={scheme}
+        shadow={shadow}
+        style={rootStyle}
+        {...(animate ? POPOVER_MOTION_PROPS : {})}
+      >
+        {children}
+
+        {arrow && (
+          <Arrow
+            ref={arrowRef}
+            style={arrowStyle}
+            width={DEFAULT_TOOLTIP_ARROW_WIDTH}
+            height={DEFAULT_TOOLTIP_ARROW_HEIGHT}
+            radius={DEFAULT_TOOLTIP_ARROW_RADIUS}
+          />
+        )}
+      </MotionCard>
+    )
+  }),
+)
+
+TooltipCard.displayName = 'TooltipCard'

--- a/src/core/utils/conditionalWrapper/conditionalWrapper.tsx
+++ b/src/core/utils/conditionalWrapper/conditionalWrapper.tsx
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export function ConditionalWrapper({
   children,
   condition,

--- a/src/core/utils/conditionalWrapper/index.ts
+++ b/src/core/utils/conditionalWrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './conditionalWrapper'

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './arrow'
 export * from './boundaryElement'
+export * from './conditionalWrapper'
 export * from './elementQuery'
 export * from './errorBoundary'
 export * from './layer'

--- a/stories/components/MenuButton.stories.tsx
+++ b/stories/components/MenuButton.stories.tsx
@@ -5,7 +5,7 @@ import {Button, Flex} from '../../src/core/primitives'
 
 const meta: Meta<typeof MenuButton> = {
   args: {
-    button: <Button tone="primary" text="Open" />,
+    button: <Button text="Open" />,
     menu: (
       <Menu>
         <MenuItem icon={SearchIcon} id="menu-item-1" text="Search" />
@@ -24,6 +24,15 @@ export default meta
 type Story = StoryObj<typeof MenuButton>
 
 export const Default: Story = {
+  render: (props) => {
+    return <MenuButton {...props} />
+  },
+}
+
+export const AnimatedPopover: Story = {
+  args: {
+    popover: {animate: true},
+  },
   render: (props) => {
     return <MenuButton {...props} />
   },

--- a/stories/primitives/Popover.stories.tsx
+++ b/stories/primitives/Popover.stories.tsx
@@ -2,7 +2,7 @@
 import type {Meta, StoryObj} from '@storybook/react'
 import {useState} from 'react'
 import {Button, Card, Popover, Text} from '../../src/core/primitives'
-import {RADII} from '../constants'
+import {PLACEMENT_OPTIONS, RADII} from '../constants'
 import {getRadiusControls, getShadowControls, getSpaceControls} from '../controls'
 import {rowBuilder} from '../helpers/rowBuilder'
 
@@ -67,6 +67,34 @@ export const Controlled: Story = {
         <Popover {...props} open={open}>
           <Button onClick={() => setOpen(!open)} text="Toggle popover" />
         </Popover>
+      </Card>
+    )
+  },
+}
+
+export const Placements: Story = {
+  args: {
+    animate: true,
+    content: <Text size={1}>Lorem ipsum dolor sit amet, consectetur adipiscing elit</Text>,
+    style: {
+      maxWidth: '150px',
+      wordBreak: 'break-all',
+    },
+  },
+  render: (props) => {
+    const [open, setOpen] = useState(false)
+
+    return (
+      <Card padding={7}>
+        {rowBuilder({
+          gap: 9,
+          renderItem: ({index, value}) => (
+            <Popover {...props} key={index} open={open} placement={value}>
+              <Button onClick={() => setOpen(!open)} text={value} />
+            </Popover>
+          ),
+          rows: PLACEMENT_OPTIONS,
+        })}
       </Card>
     )
   },

--- a/stories/primitives/Tooltip.stories.tsx
+++ b/stories/primitives/Tooltip.stories.tsx
@@ -1,13 +1,6 @@
 import type {Meta, StoryFn, StoryObj} from '@storybook/react'
 import {userEvent, within} from '@storybook/testing-library'
-import {
-  Button,
-  Card,
-  Flex,
-  Text,
-  Tooltip,
-  TooltipDelayGroupProvider,
-} from '../../src/core/primitives'
+import {Button, Card, Text, Tooltip, TooltipDelayGroupProvider} from '../../src/core/primitives'
 import {PLACEMENT_OPTIONS} from '../constants'
 import {getShadowControls, getSpaceControls} from '../controls'
 import {rowBuilder} from '../helpers/rowBuilder'
@@ -40,13 +33,21 @@ const meta: Meta<typeof Tooltip> = {
 export default meta
 type Story = StoryObj<typeof Tooltip>
 
-export const Basic: Story = {
+export const Default: Story = {
+  render: (props) => {
+    return <Tooltip {...props} />
+  },
+}
+
+export const Animated: Story = {
+  args: {animate: true},
   render: (props) => {
     return <Tooltip {...props} />
   },
 }
 
 export const Placements: Story = {
+  args: {animate: true},
   render: (props) => {
     return (
       <>
@@ -86,7 +87,7 @@ export const WithOpenDelay: Story = {
   },
 }
 
-export const Animated: Story = {
+export const WithDelayGroup: Story = {
   args: {
     animate: true,
     delay: {open: 200},
@@ -98,33 +99,12 @@ export const Animated: Story = {
   },
   render: (props) => {
     return (
-      <Card
-        style={{
-          height: 'calc(100vh - 100px)',
-          overflow: 'hidden',
-          position: 'relative',
-          resize: 'both',
-          width: '500px',
-          padding: '20px',
-        }}
-        border
-      >
-        <Flex direction="column" align="flex-start" gap={2}>
-          <Flex direction="column" gap={2}>
-            <Text size={1}>Standalone tooltip</Text>
-            <Tooltip {...props} />
-          </Flex>
-          <Flex direction={'column'} gap={2} width="fill">
-            <Text size={1}>Grouped tooltips</Text>
-            <Flex>
-              <TooltipDelayGroupProvider delay={{open: 200}}>
-                <Tooltip {...props} />
-                <Tooltip {...props} />
-              </TooltipDelayGroupProvider>
-            </Flex>
-          </Flex>
-        </Flex>
-      </Card>
+      <TooltipDelayGroupProvider delay={{open: 200}}>
+        <Tooltip {...props} />
+        <Tooltip {...props} />
+        <Tooltip {...props} />
+        <Tooltip {...props} />
+      </TooltipDelayGroupProvider>
     )
   },
   play: async ({canvasElement}) => {


### PR DESCRIPTION
### Description

This PR adds `animate` support for `Popover` components. 

In addition to fading in, animated popovers will now also slightly scale from the reference element's origin, giving the appearance of popovers very slightly 'growing out'. Since this is a popover prop, it's also possible to apply this animation on `<MenuButton>` components too (via the `popover` prop) too.

This is done via a custom `origin` middleware which calculates this transform origin offset from both the shifted position and final (not user supplied) floating placement.

This middleware is also applied to `<Tooltip>` components too.

Currently, there's no optionality around animation here – opting in means you get both opacity + scale transitions, though we may want to provide more fine-grained control in future.

https://github.com/sanity-io/ui/assets/209129/a4ad64ae-ca78-429a-8d0d-00335f8f6fbf
