### PR TITLE
fix(button): right button is pushed to the end

### DIFF
--- a/src/core/primitives/button/button.tsx
+++ b/src/core/primitives/button/button.tsx
@@ -149,17 +149,15 @@ export const Button = forwardRef(function Button(
             )}
 
             {text && (
-              <Box flex={iconRight ? 1 : undefined}>
-                <Text
-                  muted={muted}
-                  align={textAlign}
-                  size={fontSize}
-                  textOverflow="ellipsis"
-                  weight={button.textWeight}
-                >
-                  {text}
-                </Text>
-              </Box>
+              <Text
+                muted={muted}
+                align={textAlign}
+                size={fontSize}
+                textOverflow="ellipsis"
+                weight={button.textWeight}
+              >
+                {text}
+              </Text>
             )}
 
             {iconRight && (


### PR DESCRIPTION


Buttons with full width are pushing the `iconRight` to the end of the button and the text to the left.
Removing that as is an unexpected behaviour and same behaviour can be achieved with a the flex property `space-between`

### Previous
<img width="668" alt="Screenshot 2023-12-14 at 16 19 17" src="https://github.com/sanity-io/ui/assets/46196328/b1e6518f-b8e8-46cc-98cb-23624b6aa265">

### Now

<img width="668" alt="Screenshot 2023-12-14 at 16 18 59" src="https://github.com/sanity-io/ui/assets/46196328/6c35fcba-be1b-4497-b7d6-91ceb2353405">