### PR TITLE
fix(theme): update container width size

### DIFF
--- a/src/theme/defaults/config.ts
+++ b/src/theme/defaults/config.ts
@@ -24,7 +24,7 @@ export const defaultThemeConfig: Omit<RootTheme_v2, 'color' | 'font'> = {
     focusRing: {offset: -1, width: 1},
     shadow: {outline: OUTLINE_WIDTH},
   },
-  container: [480, 640, 960, 1280, 1600, 1920],
+  container: [320, 640, 960, 1280, 1600, 1920],
   media: [360, 600, 900, 1200, 1800, 2400],
   layer: {
     dialog: {zOffset: 600},


### PR DESCRIPTION
Container size = 0 is 320 in current facelift branch. 
This changed to 480 when the theme was updated, but it makes some popovers to have an extra width which is not intended. 
Changing default back to 320.

Some of the affected components:
- Free trial popover.
- Desk rename popover

<img width="1120" alt="Screenshot 2023-12-17 at 11 27 54" src="https://github.com/sanity-io/ui/assets/46196328/e7a556fa-ef22-491f-92ff-f2d58ca7e7b2">



<img width="1006" alt="Screenshot 2023-12-17 at 11 27 41" src="https://github.com/sanity-io/ui/assets/46196328/d69debfe-c168-4edc-b1ce-3486616af430">

