### PR TITLE
fix: improve scale transitions for non-retina screens

### DIFF
--- a/src/core/components/toast/toastProvider.tsx
+++ b/src/core/components/toast/toastProvider.tsx
@@ -134,7 +134,7 @@ export function ToastProvider(props: ToastProviderProps): React.ReactElement {
                   <motion.div
                     animate={{opacity: 1, y: 0, scale: 1}}
                     exit={{opacity: 0, scale: 0.5, transition: {duration: 0.2}}}
-                    initial={{opacity: 0, y: 32, scale: 0.25}}
+                    initial={{opacity: 0, y: 32, scale: 0.25, willChange: 'transform'}}
                     key={id}
                     layout="position"
                     transition={{type: 'spring', damping: 30, stiffness: 400}}

--- a/src/core/primitives/popover/popoverCard.tsx
+++ b/src/core/primitives/popover/popoverCard.tsx
@@ -99,9 +99,10 @@ export const PopoverCard = memo(
         top: y,
         width,
         zIndex,
+        willChange: animate ? 'transform' : undefined,
         ...style,
       }),
-      [originX, originY, strategy, style, width, x, y, zIndex],
+      [animate, originX, originY, strategy, style, width, x, y, zIndex],
     )
 
     const arrowStyle: CSSProperties = useMemo(

--- a/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/src/core/primitives/tooltip/tooltipCard.tsx
@@ -57,9 +57,10 @@ export const TooltipCard = memo(
       () => ({
         originX,
         originY,
+        willChange: animate ? 'transform' : undefined,
         ...style,
       }),
-      [originX, originY, style],
+      [animate, originX, originY, style],
     )
 
     const arrowStyle: CSSProperties = useMemo(


### PR DESCRIPTION
Fixes scale transitions that struggle with text aliasing, this is particularly visible if your monitor doesn't have a retina resolution:


https://github.com/sanity-io/ui/assets/81981/64a9a353-4000-4366-848b-a97c0832f7ba

The above shows the problem for popovers, but it's also affecting tooltips and toasts.

After the fix in this PR is applied:


https://github.com/sanity-io/ui/assets/81981/d97e4224-0751-4225-b5ef-641d3f8db903

