### PR TITLE
fix(theme): remove internal uses of getTheme_v2

### DIFF
--- a/src/core/components/dialog/styles.ts
+++ b/src/core/components/dialog/styles.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {_responsive, ThemeProps} from '../../styles'
 import {DialogPosition} from '../../types'
@@ -11,7 +11,7 @@ export interface ResponsiveDialogPositionStyleProps {
 }
 
 export function dialogStyle({theme}: ThemeProps): CSSObject {
-  const {color} = getTheme_v2(theme)
+  const {color} = theme.sanity.v2
 
   return {
     '&:not([hidden])': {
@@ -32,7 +32,7 @@ export function dialogStyle({theme}: ThemeProps): CSSObject {
 export function responsiveDialogPositionStyle(
   props: ResponsiveDialogPositionStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$position, (position) => ({'&&': {position}}))
 }

--- a/src/core/components/skeleton/textSkeleton.tsx
+++ b/src/core/components/skeleton/textSkeleton.tsx
@@ -1,4 +1,4 @@
-import {ThemeFontKey, getTheme_v2} from '@sanity/ui/theme'
+import {ThemeFontKey} from '@sanity/ui/theme'
 import {forwardRef} from 'react'
 import styled from 'styled-components'
 import {useArrayProp} from '../../hooks'
@@ -12,7 +12,7 @@ const Root = styled(Skeleton)<{$size: number[]; $style: ThemeFontKey}>((
   } & ThemeProps,
 ) => {
   const {$size, $style} = props
-  const {font, media} = getTheme_v2(props.theme)
+  const {font, media} = props.theme.sanity.v2
   const fontStyle = font[$style]
 
   const styles = _responsive(media, $size, (sizeIndex) => {

--- a/src/core/components/tree/style.ts
+++ b/src/core/components/tree/style.ts
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {rem, ThemeProps} from '../../styles'
 import {_cardColorStyle} from '../../styles/card'
@@ -38,7 +37,7 @@ export function treeItemRootStyle(): ReturnType<typeof css> {
 
 export function treeItemRootColorStyle(props: ThemeProps): ReturnType<typeof css> {
   const $tone = 'default'
-  const {color} = getTheme_v2(props.theme)
+  const {color} = props.theme.sanity.v2
   const tone = color.selectable[$tone]
 
   return css`
@@ -92,7 +91,7 @@ export function treeItemBoxStyle(
   props: TreeItemBoxStyleProps & ThemeProps,
 ): ReturnType<typeof css> {
   const {$level} = props
-  const {space} = getTheme_v2(props.theme)
+  const {space} = props.theme.sanity.v2
 
   return css`
     padding-left: ${rem(space[2] * $level)};

--- a/src/core/hooks/useMediaIndex/useMediaIndex.test.tsx
+++ b/src/core/hooks/useMediaIndex/useMediaIndex.test.tsx
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 
-import {buildTheme} from '@sanity/ui/theme'
 import {renderToString, renderToStaticMarkup} from 'react-dom/server'
+import {buildTheme} from '../../../theme'
 import {ThemeProvider} from '../../theme'
 import {useMediaIndex} from './useMediaIndex'
 

--- a/src/core/primitives/_selectable/style.ts
+++ b/src/core/primitives/_selectable/style.ts
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {ThemeProps} from '../../styles'
 import {_cardColorStyle} from '../../styles/card'
@@ -39,7 +38,7 @@ export function selectableColorStyle(
   props: SelectableStyleProps & ThemeProps,
 ): ReturnType<typeof css> {
   const {$tone} = props
-  const {color, style} = getTheme_v2(props.theme)
+  const {color, style} = props.theme.sanity.v2
   const tone = color.selectable[$tone]
 
   return css`

--- a/src/core/primitives/avatar/avatarCounter.tsx
+++ b/src/core/primitives/avatar/avatarCounter.tsx
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {forwardRef, useMemo} from 'react'
 import styled, {css} from 'styled-components'
 import {EMPTY_RECORD} from '../../constants'
@@ -8,7 +7,7 @@ import {AvatarSize} from '../../types'
 import {Label} from '../label'
 
 function _responsiveAvatarCounterSizeStyle(props: {$size: AvatarSize[]} & ThemeProps) {
-  const {avatar, media} = getTheme_v2(props.theme)
+  const {avatar, media} = props.theme.sanity.v2
 
   return _responsive(media, props.$size, (size) => {
     const avatarSize = avatar.sizes[size]
@@ -24,7 +23,7 @@ function _responsiveAvatarCounterSizeStyle(props: {$size: AvatarSize[]} & ThemeP
 }
 
 function _avatarCounterBaseStyle(props: ThemeProps) {
-  const {space} = getTheme_v2(props.theme)
+  const {space} = props.theme.sanity.v2
 
   return css`
     align-items: center;

--- a/src/core/primitives/avatar/avatarStack.tsx
+++ b/src/core/primitives/avatar/avatarStack.tsx
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {cloneElement, forwardRef} from 'react'
 import styled, {css} from 'styled-components'
 import {EMPTY_RECORD} from '../../constants'
@@ -25,7 +24,7 @@ function avatarStackStyle() {
 }
 
 function responsiveAvatarStackSizeStyle(props: {$size: AvatarSize[]} & ThemeProps) {
-  const {avatar, media} = getTheme_v2(props.theme)
+  const {avatar, media} = props.theme.sanity.v2
 
   return _responsive(media, props.$size, (size) => {
     const avatarSize = avatar.sizes[size]

--- a/src/core/primitives/avatar/styles.ts
+++ b/src/core/primitives/avatar/styles.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {rem, _responsive, ThemeProps} from '../../styles'
 import {focusRingStyle} from '../../styles/internal'
 import {AvatarRootStyleProps, ResponsiveAvatarSizeStyleProps} from './types'
@@ -58,7 +58,7 @@ function avatarArrowStyle(): CSSObject {
 
 export function avatarRootStyle(props: AvatarRootStyleProps & ThemeProps): CSSObject {
   const {$color} = props
-  const {avatar} = getTheme_v2(props.theme)
+  const {avatar} = props.theme.sanity.v2
 
   return {
     '--avatar-bg-color': `var(--card-avatar-${$color}-bg-color)`,
@@ -107,7 +107,7 @@ export function avatarRootStyle(props: AvatarRootStyleProps & ThemeProps): CSSOb
 export function responsiveAvatarSizeStyle(
   props: ResponsiveAvatarSizeStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {avatar, media} = getTheme_v2(props.theme)
+  const {avatar, media} = props.theme.sanity.v2
 
   return _responsive(media, props.$size, (size) => {
     const avatarSize = avatar.sizes[size] || avatar.sizes[0]

--- a/src/core/primitives/button/styles.ts
+++ b/src/core/primitives/button/styles.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {ThemeProps} from '../../styles'
 import {_cardColorStyle} from '../../styles/card'
@@ -12,7 +12,7 @@ export function buttonBaseStyles(
   props: {$width?: ButtonWidth} & ThemeProps,
 ): ReturnType<typeof css> {
   const {$width} = props
-  const {style} = getTheme_v2(props.theme)
+  const {style} = props.theme.sanity.v2
 
   return css`
     ${style?.button};
@@ -67,7 +67,7 @@ export function buttonColorStyles(
   props: {$mode: ButtonMode; $tone: ButtonTone} & ThemeProps,
 ): CSSObject[] {
   const {$mode} = props
-  const {button, color: baseColor, style} = getTheme_v2(props.theme)
+  const {button, color: baseColor, style} = props.theme.sanity.v2
   const shadow = props.$mode === 'ghost'
   const mode = baseColor.button[$mode] || baseColor.button.default
   const color = mode[props.$tone] || mode.default

--- a/src/core/primitives/card/__workshop__/selected.tsx
+++ b/src/core/primitives/card/__workshop__/selected.tsx
@@ -1,6 +1,6 @@
 import {EditIcon, PublishIcon} from '@sanity/icons'
 import {Box, Card, Container, Flex, Inline, Stack, Text, ThemeProps, useRootTheme} from '@sanity/ui'
-import {ThemeColorStateToneKey, getTheme_v2} from '@sanity/ui/theme'
+import {ThemeColorStateToneKey} from '@sanity/ui/theme'
 import {useBoolean} from '@sanity/ui-workshop'
 import styled, {css} from 'styled-components'
 
@@ -10,7 +10,7 @@ const TextWithTone = styled(Text)<{$tone: ThemeColorStateToneKey}>((
   } & ThemeProps,
 ) => {
   const {$tone} = props
-  const {color} = getTheme_v2(props.theme)
+  const {color} = props.theme.sanity.v2
   const tone = color.button.default[$tone]
 
   return css`

--- a/src/core/primitives/card/styles.ts
+++ b/src/core/primitives/card/styles.ts
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {ThemeProps} from '../../styles'
 import {_cardColorStyle} from '../../styles/card'
@@ -13,7 +12,7 @@ export function cardStyle(
 
 export function cardBaseStyle(props: CardStyleProps & ThemeProps): ReturnType<typeof css> {
   const {$checkered} = props
-  const {space} = getTheme_v2(props.theme)
+  const {space} = props.theme.sanity.v2
 
   return css`
     ${$checkered &&
@@ -50,7 +49,7 @@ export function cardBaseStyle(props: CardStyleProps & ThemeProps): ReturnType<ty
 
 export function cardColorStyle(props: CardStyleProps & ThemeProps): ReturnType<typeof css> {
   const {$checkered, $focusRing} = props
-  const {card, color, style} = getTheme_v2(props.theme)
+  const {card, color, style} = props.theme.sanity.v2
   const border = {width: card.border.width, color: 'var(--card-border-color)'}
 
   return css`

--- a/src/core/primitives/checkbox/styles.ts
+++ b/src/core/primitives/checkbox/styles.ts
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {rem, ThemeProps} from '../../styles'
 import {focusRingBorderStyle, focusRingStyle} from '../../styles/internal'
@@ -11,7 +10,7 @@ export function checkboxBaseStyles(): ReturnType<typeof css> {
 }
 
 export function inputElementStyles(props: ThemeProps): ReturnType<typeof css> {
-  const {color, input, radius} = getTheme_v2(props.theme)
+  const {color, input, radius} = props.theme.sanity.v2
   const {focusRing} = input.checkbox
 
   return css`

--- a/src/core/primitives/code/styles.ts
+++ b/src/core/primitives/code/styles.ts
@@ -1,10 +1,7 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css, ExecutionContext} from 'styled-components'
 
 function codeSyntaxHighlightingStyle({theme}: ExecutionContext) {
-  const {
-    color: {syntax: color},
-  } = getTheme_v2(theme)
+  const color = theme.sanity.v2.color.syntax
 
   return {
     '&.atrule': {color: color.atrule},

--- a/src/core/primitives/container/styles.ts
+++ b/src/core/primitives/container/styles.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {rem, _responsive, ThemeProps} from '../../styles'
 import {ResponsiveWidthStyleProps} from './types'
 
@@ -14,7 +14,7 @@ export function containerBaseStyle(): CSSObject {
 export function responsiveContainerWidthStyle(
   props: ResponsiveWidthStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {container, media} = getTheme_v2(props.theme)
+  const {container, media} = props.theme.sanity.v2
 
   return _responsive(media, props.$width, (val) => ({
     maxWidth: val === 'auto' ? 'none' : rem(container[val]),

--- a/src/core/primitives/heading/styles.ts
+++ b/src/core/primitives/heading/styles.ts
@@ -1,11 +1,10 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {ThemeProps} from '../../styles'
 import {HeadingStyleProps} from './types'
 
 export function headingBaseStyle(props: HeadingStyleProps & ThemeProps): ReturnType<typeof css> {
   const {$accent, $muted} = props
-  const {font} = getTheme_v2(props.theme)
+  const {font} = props.theme.sanity.v2
 
   return css`
     ${$accent &&

--- a/src/core/primitives/inline/styles.ts
+++ b/src/core/primitives/inline/styles.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {rem, _responsive, ThemeProps} from '../../styles'
 import {ResponsiveInlineSpaceStyleProps} from './types'
 
@@ -18,7 +18,7 @@ export function inlineBaseStyle(): CSSObject {
 }
 
 export function inlineSpaceStyle(props: ResponsiveInlineSpaceStyleProps & ThemeProps): CSSObject[] {
-  const {media, space} = getTheme_v2(props.theme)
+  const {media, space} = props.theme.sanity.v2
 
   return _responsive(media, props.$space, (spaceIndex) => {
     const _space = rem(spaceIndex === 0.5 ? space[1] / 2 : space[spaceIndex])

--- a/src/core/primitives/label/styles.ts
+++ b/src/core/primitives/label/styles.ts
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {ThemeProps} from '../../styles'
 
@@ -6,7 +5,7 @@ export function labelBaseStyle(
   props: {$accent?: boolean; $muted: boolean} & ThemeProps,
 ): ReturnType<typeof css> {
   const {$accent, $muted} = props
-  const {font} = getTheme_v2(props.theme)
+  const {font} = props.theme.sanity.v2
 
   return css`
     text-transform: uppercase;

--- a/src/core/primitives/radio/styles.ts
+++ b/src/core/primitives/radio/styles.ts
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {rem, ThemeProps} from '../../styles'
 import {focusRingBorderStyle, focusRingStyle} from '../../styles/internal'
@@ -18,7 +17,7 @@ export function radioBaseStyle(): ReturnType<typeof css> {
 }
 
 export function inputElementStyle(props: ThemeProps): ReturnType<typeof css> {
-  const {color, input} = getTheme_v2(props.theme)
+  const {color, input} = props.theme.sanity.v2
   const dist = (input.radio.size - input.radio.markSize) / 2
 
   return css`

--- a/src/core/primitives/select/styles.ts
+++ b/src/core/primitives/select/styles.ts
@@ -1,4 +1,4 @@
-import {ThemeFontSize, getTheme_v2} from '@sanity/ui/theme'
+import {ThemeFontSize} from '@sanity/ui/theme'
 import {CSSObject} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {rem, _responsive, ThemeProps} from '../../styles'
@@ -24,7 +24,7 @@ function rootStyle(): ReturnType<typeof css> {
 }
 
 function inputBaseStyle(props: ThemeProps): ReturnType<typeof css> {
-  const {font} = getTheme_v2(props.theme)
+  const {font} = props.theme.sanity.v2
 
   return css`
     -webkit-font-smoothing: antialiased;
@@ -43,7 +43,7 @@ function inputBaseStyle(props: ThemeProps): ReturnType<typeof css> {
 }
 
 function inputColorStyle(props: ThemeProps) {
-  const {color, input} = getTheme_v2(props.theme)
+  const {color, input} = props.theme.sanity.v2
 
   return css`
     /* enabled */
@@ -102,7 +102,7 @@ function textSize(size: ThemeFontSize) {
 
 function inputTextSizeStyle(props: {$fontSize: number[]} & ThemeProps) {
   const {$fontSize} = props
-  const {font, media} = getTheme_v2(props.theme)
+  const {font, media} = props.theme.sanity.v2
 
   return _responsive(media, $fontSize, (sizeIndex) =>
     textSize(font.text.sizes[sizeIndex] || font.text.sizes[2]),
@@ -129,7 +129,7 @@ function inputStyle(): Array<
 }
 
 function iconBoxStyle(props: ThemeProps): ReturnType<typeof css> {
-  const {color} = getTheme_v2(props.theme)
+  const {color} = props.theme.sanity.v2
 
   return css`
     pointer-events: none;

--- a/src/core/primitives/stack/styles.ts
+++ b/src/core/primitives/stack/styles.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {rem, _responsive, ThemeProps} from '../../styles'
 
 export interface ResponsiveStackSpaceStyleProps {
@@ -23,7 +23,7 @@ export function stackBaseStyle(): CSSObject {
 export function responsiveStackSpaceStyle(
   props: ResponsiveStackSpaceStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {media, space} = getTheme_v2(props.theme)
+  const {media, space} = props.theme.sanity.v2
 
   return _responsive(media, props.$space, (spaceIndex) => ({
     gridGap: rem(space[spaceIndex]),

--- a/src/core/primitives/switch/styles.ts
+++ b/src/core/primitives/switch/styles.ts
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {rem, ThemeProps} from '../../styles'
 import {focusRingStyle} from '../../styles/internal'
@@ -36,7 +35,7 @@ export function switchInputStyles(): ReturnType<typeof css> {
 
 /* Representation */
 export function switchRepresentationStyles(props: ThemeProps): ReturnType<typeof css> {
-  const {color, input} = getTheme_v2(props.theme)
+  const {color, input} = props.theme.sanity.v2
 
   return css`
     --switch-bg-color: ${color.input.default.enabled.border};
@@ -112,7 +111,7 @@ export function switchRepresentationStyles(props: ThemeProps): ReturnType<typeof
 
 /* Track */
 export function switchTrackStyles(props: ThemeProps): ReturnType<typeof css> {
-  const {input} = getTheme_v2(props.theme)
+  const {input} = props.theme.sanity.v2
 
   return css`
     &:not([hidden]) {
@@ -133,7 +132,7 @@ export function switchThumbStyles(
   props: {$checked?: boolean; $indeterminate?: boolean} & ThemeProps,
 ): ReturnType<typeof css> {
   const {$indeterminate} = props
-  const {input} = getTheme_v2(props.theme)
+  const {input} = props.theme.sanity.v2
   const trackWidth = input.switch.width
   const trackHeight = input.switch.height
   const trackPadding = input.switch.padding

--- a/src/core/primitives/text/__workshop__/colored.tsx
+++ b/src/core/primitives/text/__workshop__/colored.tsx
@@ -1,5 +1,5 @@
 import {Flex, Text, ThemeProps} from '@sanity/ui'
-import {ThemeColorAvatarColorKey, ThemeColorSpotKey, getTheme_v2} from '@sanity/ui/theme'
+import {ThemeColorAvatarColorKey, ThemeColorSpotKey} from '@sanity/ui/theme'
 import {useSelect} from '@sanity/ui-workshop'
 import styled, {css} from 'styled-components'
 import {WORKSHOP_SPOT_COLOR_OPTIONS} from '../../../__workshop__/constants'
@@ -9,7 +9,7 @@ const ColoredText = styled(Text)<{$color?: ThemeColorSpotKey}>((
     $color?: ThemeColorAvatarColorKey
   } & ThemeProps,
 ) => {
-  const {color} = getTheme_v2(props.theme)
+  const {color} = props.theme.sanity.v2
 
   return css`
     color: ${color.avatar[props.$color || 'gray'].bg};

--- a/src/core/primitives/text/styles.ts
+++ b/src/core/primitives/text/styles.ts
@@ -1,4 +1,3 @@
-import {getTheme_v2} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {ThemeProps} from '../../styles'
 
@@ -6,7 +5,7 @@ export function textBaseStyle(
   props: {$accent?: boolean; $muted?: boolean} & ThemeProps,
 ): ReturnType<typeof css> {
   const {$accent, $muted} = props
-  const {font} = getTheme_v2(props.theme)
+  const {font} = props.theme.sanity.v2
 
   return css`
     color: var(--card-fg-color);

--- a/src/core/styles/border/borderStyle.ts
+++ b/src/core/styles/border/borderStyle.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {_responsive} from '../helpers'
 import {ThemeProps} from '../types'
 import {ResponsiveBorderStyleProps} from './types'
@@ -10,7 +10,7 @@ export function responsiveBorderStyle(): Array<
 }
 
 function border(props: ResponsiveBorderStyleProps & ThemeProps) {
-  const {card, media} = getTheme_v2(props.theme)
+  const {card, media} = props.theme.sanity.v2
   const borderStyle = `${card.border?.width ?? 1}px solid var(--card-border-color)`
 
   return _responsive(media, props.$border, (value) =>
@@ -19,7 +19,7 @@ function border(props: ResponsiveBorderStyleProps & ThemeProps) {
 }
 
 function borderTop(props: ResponsiveBorderStyleProps & ThemeProps) {
-  const {card, media} = getTheme_v2(props.theme)
+  const {card, media} = props.theme.sanity.v2
   const borderStyle = `${card.border?.width ?? 1}px solid var(--card-border-color)`
 
   return _responsive(media, props.$borderTop, (value) =>
@@ -28,7 +28,7 @@ function borderTop(props: ResponsiveBorderStyleProps & ThemeProps) {
 }
 
 function borderRight(props: ResponsiveBorderStyleProps & ThemeProps) {
-  const {card, media} = getTheme_v2(props.theme)
+  const {card, media} = props.theme.sanity.v2
   const borderStyle = `${card.border?.width ?? 1}px solid var(--card-border-color)`
 
   return _responsive(media, props.$borderRight, (value) =>
@@ -37,7 +37,7 @@ function borderRight(props: ResponsiveBorderStyleProps & ThemeProps) {
 }
 
 function borderBottom(props: ResponsiveBorderStyleProps & ThemeProps) {
-  const {card, media} = getTheme_v2(props.theme)
+  const {card, media} = props.theme.sanity.v2
   const borderStyle = `${card.border?.width ?? 1}px solid var(--card-border-color)`
 
   return _responsive(media, props.$borderBottom, (value) =>
@@ -46,7 +46,7 @@ function borderBottom(props: ResponsiveBorderStyleProps & ThemeProps) {
 }
 
 function borderLeft(props: ResponsiveBorderStyleProps & ThemeProps) {
-  const {card, media} = getTheme_v2(props.theme)
+  const {card, media} = props.theme.sanity.v2
   const borderStyle = `${card.border?.width ?? 1}px solid var(--card-border-color)`
 
   return _responsive(media, props.$borderLeft, (value) =>

--- a/src/core/styles/box/boxStyle.ts
+++ b/src/core/styles/box/boxStyle.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {Property} from 'csstype'
 import {_responsive} from '../helpers'
 import {ThemeProps} from '../types'
@@ -36,7 +36,7 @@ export function responsiveBoxStyle(): Array<
 }
 
 function responsiveBoxDisplayStyle(props: ResponsiveBoxStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$display, (display) => ({
     '&:not([hidden])': {display},
@@ -44,7 +44,7 @@ function responsiveBoxDisplayStyle(props: ResponsiveBoxStyleProps & ThemeProps) 
 }
 
 function responsiveBoxSizingStyle(props: ResponsiveBoxStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$sizing, (sizing) => ({
     boxSizing: BOX_SIZING[sizing],
@@ -52,7 +52,7 @@ function responsiveBoxSizingStyle(props: ResponsiveBoxStyleProps & ThemeProps) {
 }
 
 function responsiveBoxHeightStyle(props: ResponsiveBoxStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$height, (height) => ({
     height: BOX_HEIGHT[height],
@@ -60,7 +60,7 @@ function responsiveBoxHeightStyle(props: ResponsiveBoxStyleProps & ThemeProps) {
 }
 
 function responsiveBoxOverflowStyle(props: ResponsiveBoxStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$overflow, (overflow) => ({
     overflow,

--- a/src/core/styles/flex/flexItemStyle.ts
+++ b/src/core/styles/flex/flexItemStyle.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {EMPTY_ARRAY} from '../../constants'
 import {_responsive} from '../helpers'
 import {ThemeProps} from '../types'
@@ -18,7 +18,7 @@ export function flexItemStyle(): Array<
 export function responsiveFlexItemStyle(
   props: ResponsiveFlexItemStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   if (!props.$flex) return EMPTY_ARRAY
 

--- a/src/core/styles/flex/flexStyle.ts
+++ b/src/core/styles/flex/flexStyle.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {rem, _responsive} from '../helpers'
 import {ThemeProps} from '../types'
 import {ResponsiveFlexStyleProps} from './types'
@@ -25,7 +25,7 @@ export function responsiveFlexStyle(): Array<
 export function responsiveFlexAlignStyle(
   props: ResponsiveFlexStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$align, (align) => {
     return {alignItems: align}
@@ -33,7 +33,7 @@ export function responsiveFlexAlignStyle(
 }
 
 function responsiveFlexGapStyle(props: ResponsiveFlexStyleProps & ThemeProps) {
-  const {media, space} = getTheme_v2(props.theme)
+  const {media, space} = props.theme.sanity.v2
 
   return _responsive(media, props.$gap, (gap) => ({
     gap: gap ? rem(space[gap]) : undefined,
@@ -41,7 +41,7 @@ function responsiveFlexGapStyle(props: ResponsiveFlexStyleProps & ThemeProps) {
 }
 
 export function responsiveFlexWrapStyle(props: ResponsiveFlexStyleProps & ThemeProps): CSSObject[] {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$wrap, (wrap) => {
     return {flexWrap: wrap}
@@ -51,7 +51,7 @@ export function responsiveFlexWrapStyle(props: ResponsiveFlexStyleProps & ThemeP
 export function responsiveFlexJustifyStyle(
   props: ResponsiveFlexStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$justify, (justify) => {
     return {justifyContent: justify}
@@ -61,7 +61,7 @@ export function responsiveFlexJustifyStyle(
 export function responsiveFlexDirectionStyle(
   props: ResponsiveFlexStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$direction, (direction) => {
     return {flexDirection: direction}

--- a/src/core/styles/font/responsiveFont.ts
+++ b/src/core/styles/font/responsiveFont.ts
@@ -1,4 +1,4 @@
-import {ThemeFontSize, ThemeFontKey, getTheme_v2} from '@sanity/ui/theme'
+import {ThemeFontSize, ThemeFontKey} from '@sanity/ui/theme'
 import {CSSObject} from '@sanity/ui/theme'
 import {rem, _responsive} from '../helpers'
 import {ThemeProps} from '../types'
@@ -13,7 +13,7 @@ export function responsiveFont(
   props: ResponsiveFontStyleProps & ThemeProps,
 ): CSSObject[] {
   const {$size, $weight} = props
-  const {font, media} = getTheme_v2(props.theme)
+  const {font, media} = props.theme.sanity.v2
   const {family, sizes, weights} = font[fontKey]
   const fontWeight = ($weight && weights[$weight]) || weights.regular
 

--- a/src/core/styles/font/textAlignStyle.ts
+++ b/src/core/styles/font/textAlignStyle.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {_responsive} from '../helpers'
 import {ThemeProps} from '../types'
 import {ResponsiveTextAlignStyleProps} from './types'
@@ -10,7 +10,7 @@ import {ResponsiveTextAlignStyleProps} from './types'
 export function responsiveTextAlignStyle(
   props: ResponsiveTextAlignStyleProps & ThemeProps,
 ): CSSObject[] {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$align, (textAlign) => {
     return {textAlign}

--- a/src/core/styles/grid/gridItemStyle.ts
+++ b/src/core/styles/grid/gridItemStyle.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {_responsive} from '../helpers'
 import {ThemeProps} from '../types'
 import {ResponsiveGridItemStyleProps} from './types'
@@ -27,7 +27,7 @@ const GRID_ITEM_COLUMN = {
 }
 
 function responsiveGridItemRowStyle(props: ResponsiveGridItemStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$row, (row) => {
     if (typeof row === 'number') {
@@ -39,7 +39,7 @@ function responsiveGridItemRowStyle(props: ResponsiveGridItemStyleProps & ThemeP
 }
 
 function responsiveGridItemRowStartStyle(props: ResponsiveGridItemStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$rowStart, (rowStart) => ({
     gridRowStart: rowStart,
@@ -47,13 +47,13 @@ function responsiveGridItemRowStartStyle(props: ResponsiveGridItemStyleProps & T
 }
 
 function responsiveGridItemRowEndStyle(props: ResponsiveGridItemStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$rowEnd, (rowEnd) => ({gridRowEnd: rowEnd}))
 }
 
 function responsiveGridItemColumnStyle(props: ResponsiveGridItemStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$column, (column) => {
     if (typeof column === 'number') {
@@ -65,7 +65,7 @@ function responsiveGridItemColumnStyle(props: ResponsiveGridItemStyleProps & The
 }
 
 function responsiveGridItemColumnStartStyle(props: ResponsiveGridItemStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$columnStart, (columnStart) => ({
     gridColumnStart: columnStart,
@@ -73,7 +73,7 @@ function responsiveGridItemColumnStartStyle(props: ResponsiveGridItemStyleProps 
 }
 
 function responsiveGridItemColumnEndStyle(props: ResponsiveGridItemStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$columnEnd, (columnEnd) => ({
     gridColumnEnd: columnEnd,

--- a/src/core/styles/grid/gridStyle.ts
+++ b/src/core/styles/grid/gridStyle.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {rem, _responsive} from '../helpers'
 import {ThemeProps} from '../types'
 import {ResponsiveGridStyleProps} from './types'
@@ -43,7 +43,7 @@ export function responsiveGridStyle(): Array<
 }
 
 function responsiveGridAutoFlowStyle(props: ResponsiveGridStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$autoFlow, (autoFlow) => ({
     gridAutoFlow: autoFlow,
@@ -51,7 +51,7 @@ function responsiveGridAutoFlowStyle(props: ResponsiveGridStyleProps & ThemeProp
 }
 
 function responsiveGridAutoRowsStyle(props: ResponsiveGridStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$autoRows, (autoRows) => ({
     gridAutoRows: autoRows && GRID_AUTO_ROWS[autoRows],
@@ -59,7 +59,7 @@ function responsiveGridAutoRowsStyle(props: ResponsiveGridStyleProps & ThemeProp
 }
 
 function responsiveGridAutoColsStyle(props: ResponsiveGridStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$autoCols, (autoCols) => ({
     gridAutoColumns: autoCols && GRID_AUTO_COLUMS[autoCols],
@@ -67,7 +67,7 @@ function responsiveGridAutoColsStyle(props: ResponsiveGridStyleProps & ThemeProp
 }
 
 function responsiveGridColumnsStyle(props: ResponsiveGridStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$columns, (columns) => ({
     gridTemplateColumns: columns && `repeat(${columns},minmax(0,1fr));`,
@@ -75,7 +75,7 @@ function responsiveGridColumnsStyle(props: ResponsiveGridStyleProps & ThemeProps
 }
 
 function responsiveGridRowsStyle(props: ResponsiveGridStyleProps & ThemeProps) {
-  const {media} = getTheme_v2(props.theme)
+  const {media} = props.theme.sanity.v2
 
   return _responsive(media, props.$rows, (rows) => ({
     gridTemplateRows: rows && `repeat(${rows},minmax(0,1fr));`,
@@ -83,7 +83,7 @@ function responsiveGridRowsStyle(props: ResponsiveGridStyleProps & ThemeProps) {
 }
 
 function responsiveGridGapStyle(props: ResponsiveGridStyleProps & ThemeProps) {
-  const {media, space} = getTheme_v2(props.theme)
+  const {media, space} = props.theme.sanity.v2
 
   return _responsive(media, props.$gap, (gap) => ({
     gridGap: gap ? rem(space[gap]) : undefined,
@@ -91,7 +91,7 @@ function responsiveGridGapStyle(props: ResponsiveGridStyleProps & ThemeProps) {
 }
 
 function responsiveGridGapXStyle(props: ResponsiveGridStyleProps & ThemeProps) {
-  const {media, space} = getTheme_v2(props.theme)
+  const {media, space} = props.theme.sanity.v2
 
   return _responsive(media, props.$gapX, (gapX) => ({
     columnGap: gapX ? rem(space[gapX]) : undefined,
@@ -99,7 +99,7 @@ function responsiveGridGapXStyle(props: ResponsiveGridStyleProps & ThemeProps) {
 }
 
 function responsiveGridGapYStyle(props: ResponsiveGridStyleProps & ThemeProps) {
-  const {media, space} = getTheme_v2(props.theme)
+  const {media, space} = props.theme.sanity.v2
 
   return _responsive(media, props.$gapY, (gapY) => ({
     rowGap: gapY ? rem(space[gapY]) : undefined,

--- a/src/core/styles/helpers.ts
+++ b/src/core/styles/helpers.ts
@@ -1,4 +1,4 @@
-import {Theme, getTheme_v2} from '@sanity/ui/theme'
+import {Theme} from '@sanity/ui/theme'
 import {CSSObject} from '@sanity/ui/theme'
 import {EMPTY_ARRAY} from '../constants'
 
@@ -64,7 +64,7 @@ export function _getResponsiveSpace(
     return null
   }
 
-  const {media, space} = getTheme_v2(theme)
+  const {media, space} = theme.sanity.v2
 
   return _responsive(media, spaceIndexes, (spaceIndex) =>
     _fillCSSObject(props, rem(space[spaceIndex])),

--- a/src/core/styles/input/responsiveInputPaddingStyle.ts
+++ b/src/core/styles/input/responsiveInputPaddingStyle.ts
@@ -1,4 +1,4 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {rem, _responsive} from '../helpers'
 import {ThemeProps} from '../types'
 
@@ -14,7 +14,7 @@ export function responsiveInputPaddingStyle(
   props: TextInputResponsivePaddingStyleProps & ThemeProps,
 ): CSSObject[] {
   const {$fontSize, $iconLeft, $iconRight, $padding, $space} = props
-  const {font, media, space} = getTheme_v2(props.theme)
+  const {font, media, space} = props.theme.sanity.v2
   const len = Math.max($padding.length, $space.length, $fontSize.length)
   const _padding: number[] = []
   const _space: number[] = []

--- a/src/core/styles/input/textInputStyle.ts
+++ b/src/core/styles/input/textInputStyle.ts
@@ -1,4 +1,4 @@
-import {ThemeColorSchemeKey, ThemeFontWeightKey, getTheme_v2} from '@sanity/ui/theme'
+import {ThemeColorSchemeKey, ThemeFontWeightKey} from '@sanity/ui/theme'
 import {CSSObject} from '@sanity/ui/theme'
 import {css} from 'styled-components'
 import {CardTone} from '../../types'
@@ -43,7 +43,7 @@ export function textInputBaseStyle(
   props: TextInputInputStyleProps & ThemeProps,
 ): ReturnType<typeof css> {
   const {$scheme, $tone, $weight} = props
-  const {color, font} = getTheme_v2(props.theme)
+  const {color, font} = props.theme.sanity.v2
 
   return css`
     appearance: none;
@@ -113,7 +113,7 @@ export function textInputBaseStyle(
 }
 
 export function textInputFontSizeStyle(props: TextInputInputStyleProps & ThemeProps): CSSObject[] {
-  const {font, media} = getTheme_v2(props.theme)
+  const {font, media} = props.theme.sanity.v2
 
   return _responsive(media, props.$fontSize, (sizeIndex) => {
     const size = font.text.sizes[sizeIndex] || font.text.sizes[2]
@@ -129,7 +129,7 @@ export function textInputRepresentationStyle(
   props: TextInputRepresentationStyleProps & ThemeProps,
 ): ReturnType<typeof css> {
   const {$hasPrefix, $hasSuffix, $scheme, $tone, $unstableDisableFocusRing} = props
-  const {color, input} = getTheme_v2(props.theme)
+  const {color, input} = props.theme.sanity.v2
 
   return css`
     --input-box-shadow: none;

--- a/src/core/styles/margin/marginsStyle.test.ts
+++ b/src/core/styles/margin/marginsStyle.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import {buildTheme, getScopedTheme} from '@sanity/ui/theme'
+import {buildTheme, getScopedTheme} from '../../../theme'
 import {responsiveMarginStyle} from './marginStyle'
 
 const theme = getScopedTheme(buildTheme(), 'light', 'default')

--- a/src/core/styles/padding/paddingStyle.test.ts
+++ b/src/core/styles/padding/paddingStyle.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import {buildTheme, getScopedTheme} from '@sanity/ui/theme'
+import {buildTheme, getScopedTheme} from '../../../theme'
 import {responsivePaddingStyle} from './paddingStyle'
 
 const theme = getScopedTheme(buildTheme(), 'light', 'default')

--- a/src/core/styles/radius/radiusStyle.ts
+++ b/src/core/styles/radius/radiusStyle.ts
@@ -1,10 +1,10 @@
-import {CSSObject, getTheme_v2} from '@sanity/ui/theme'
+import {CSSObject} from '@sanity/ui/theme'
 import {_responsive, rem} from '../helpers'
 import {ThemeProps} from '../types'
 import {ResponsiveRadiusStyleProps} from './types'
 
 export function responsiveRadiusStyle(props: ResponsiveRadiusStyleProps & ThemeProps): CSSObject[] {
-  const {media, radius} = getTheme_v2(props.theme)
+  const {media, radius} = props.theme.sanity.v2
 
   return _responsive(media, props.$radius, (value) => {
     let borderRadius: string | 0 = 0

--- a/src/core/styles/shadow/shadowStyle.ts
+++ b/src/core/styles/shadow/shadowStyle.ts
@@ -1,4 +1,4 @@
-import {ThemeBoxShadow, ThemeShadow, getTheme_v2} from '@sanity/ui/theme'
+import {ThemeBoxShadow, ThemeShadow} from '@sanity/ui/theme'
 import {CSSObject} from '@sanity/ui/theme'
 import {EMPTY_RECORD} from '../../constants'
 import {rem, _responsive} from '../helpers'
@@ -21,7 +21,7 @@ function shadowStyle(shadow: ThemeShadow | null, outlineWidth: number = 1): CSSO
 }
 
 export function responsiveShadowStyle(props: ResponsiveShadowStyleProps & ThemeProps): CSSObject[] {
-  const {card, media, shadow} = getTheme_v2(props.theme)
+  const {card, media, shadow} = props.theme.sanity.v2
 
   return _responsive(media, props.$shadow, (index) =>
     shadowStyle(shadow[index], card.shadow.outline),

--- a/src/core/theme/__workshop__/build/Root.tsx
+++ b/src/core/theme/__workshop__/build/Root.tsx
@@ -1,8 +1,7 @@
 import {css, styled} from 'styled-components'
-import {getTheme_v2} from '../../../../theme'
 
 export const Root = styled.div((props) => {
-  const {button, card, input} = getTheme_v2(props.theme)
+  const {button, card, input} = props.theme.sanity.v2
 
   return css`
     background: #000;

--- a/src/core/theme/theme.test.tsx
+++ b/src/core/theme/theme.test.tsx
@@ -1,8 +1,8 @@
 /** @jest-environment jsdom */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {buildTheme} from '@sanity/ui/theme'
 import {render} from '../../../test'
+import {buildTheme} from '../../theme'
 import {ThemeContext} from './themeContext'
 import {ThemeContextValue} from './types'
 import {useRootTheme} from './useRootTheme'

--- a/src/core/theme/themeProvider.tsx
+++ b/src/core/theme/themeProvider.tsx
@@ -1,12 +1,7 @@
-import {
-  RootTheme,
-  ThemeColorCardToneKey,
-  ThemeColorSchemeKey,
-  Theme,
-  getScopedTheme,
-} from '@sanity/ui/theme'
+import {RootTheme, ThemeColorCardToneKey, ThemeColorSchemeKey, Theme} from '@sanity/ui/theme'
 import {useContext, useMemo} from 'react'
 import {ThemeProvider as StyledThemeProvider} from 'styled-components'
+import {getScopedTheme} from '../../theme'
 import {ThemeContext} from './themeContext'
 import {ThemeContextValue} from './types'
 
@@ -48,9 +43,6 @@ export function ThemeProvider(props: ThemeProviderProps): React.ReactElement {
 
     return getScopedTheme(rootTheme, scheme, tone)
   }, [scheme, rootTheme, tone])
-
-  // eslint-disable-next-line no-console
-  console.log('THEME', theme)
 
   if (!theme) {
     return <pre>ThemeProvider: no "theme" property provided</pre>

--- a/src/core/theme/themeProvider.tsx
+++ b/src/core/theme/themeProvider.tsx
@@ -49,8 +49,15 @@ export function ThemeProvider(props: ThemeProviderProps): React.ReactElement {
     return getScopedTheme(rootTheme, scheme, tone)
   }, [scheme, rootTheme, tone])
 
+  // eslint-disable-next-line no-console
+  console.log('THEME', theme)
+
   if (!theme) {
     return <pre>ThemeProvider: no "theme" property provided</pre>
+  }
+
+  if (!theme.sanity.v2) {
+    return <pre>ThemeProvider: no "theme.sanity.v2" property in theme</pre>
   }
 
   return (

--- a/src/core/theme/useTheme.ts
+++ b/src/core/theme/useTheme.ts
@@ -1,5 +1,6 @@
-import {Theme, Theme_v2, getTheme_v2} from '@sanity/ui/theme'
+import type {Theme, Theme_v2} from '@sanity/ui/theme'
 import {useTheme as useStyledTheme} from 'styled-components'
+import {getTheme_v2} from '../../theme'
 
 /**
  * @public

--- a/src/theme/system/theme.ts
+++ b/src/theme/system/theme.ts
@@ -125,6 +125,6 @@ export interface Theme {
      * @deprecated Use `v2.color` instead
      */
     color: ThemeColor
-    v2?: Theme_v2
+    v2: Theme_v2
   }
 }

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -1,11 +1,12 @@
 import {Card, ThemeProvider} from '@sanity/ui'
-import {buildTheme, ThemeColorSchemeKey} from '@sanity/ui/theme'
 import {
   render as _testRender,
   RenderOptions as _TestRenderOptions,
   RenderResult,
 } from '@testing-library/react'
 import {StrictMode, Fragment, ReactElement, ReactNode} from 'react'
+import {ThemeColorSchemeKey} from '../src/theme'
+import {buildTheme} from '../src/theme'
 
 export interface TestRenderOptions extends _TestRenderOptions {
   scheme?: ThemeColorSchemeKey


### PR DESCRIPTION
Removes internal uses of getTheme_v2 as it may be causing issues when working with legacy dependencies.
Some issues were identified in which the `getTheme_v2` function is returning an incorrect theme object.

Instead, this change forces the `Theme` to have the v2 property defined, and uses it directly.
It also removes internal js references to `@sanity/ui/theme` to try to avoid this dependencies issues.
Types references were not updated.