### PR TITLE
fix(theme): add resolved key to v2 theme

### DIFF
--- a/src/theme/getScopedTheme.ts
+++ b/src/theme/getScopedTheme.ts
@@ -36,6 +36,7 @@ export function getScopedTheme(
       layer: layer_v0,
       v2: {
         ...v2,
+        _resolved: true,
         color: color_v2,
         layer: layer_v2,
       },

--- a/src/theme/system/theme.ts
+++ b/src/theme/system/theme.ts
@@ -114,7 +114,7 @@ export type RootTheme = BaseTheme
 /**
  * @public
  */
-export type Theme_v2 = Omit<RootTheme_v2, 'color'> & {color: ThemeColorCard_v2}
+export type Theme_v2 = Omit<RootTheme_v2, 'color'> & {color: ThemeColorCard_v2; _resolved: boolean}
 
 /**
  * @public

--- a/src/theme/system/theme.ts
+++ b/src/theme/system/theme.ts
@@ -114,7 +114,15 @@ export type RootTheme = BaseTheme
 /**
  * @public
  */
-export type Theme_v2 = Omit<RootTheme_v2, 'color'> & {color: ThemeColorCard_v2; _resolved: boolean}
+export type Theme_v2 = Omit<RootTheme_v2, 'color'> & {
+  color: ThemeColorCard_v2
+  /**
+   * Indicates whether the theme is resolved or raw, it's necessary to avoid issues
+   * with sanity V2 components accessing a v1 <ThemeProvider>.
+   * See https://github.com/sanity-io/ui/pull/1203 for more info.
+   */
+  _resolved: boolean
+}
 
 /**
  * @public

--- a/src/theme/versioning/getTheme_v2.ts
+++ b/src/theme/versioning/getTheme_v2.ts
@@ -6,7 +6,7 @@ const cache = new WeakMap<Theme, Theme_v2>()
 
 /** @public */
 export function getTheme_v2(theme: Theme): Theme_v2 {
-  if (theme.sanity.v2) return theme.sanity.v2
+  if (theme.sanity.v2?._resolved) return theme.sanity.v2
 
   const cached_v2 = cache.get(theme)
 
@@ -14,6 +14,7 @@ export function getTheme_v2(theme: Theme): Theme_v2 {
 
   const v2: Theme_v2 = {
     _version: 2,
+    _resolved: true,
     avatar: {
       ...defaultThemeConfig.avatar,
       ...theme.sanity.avatar,


### PR DESCRIPTION
When using V1 and V2 of `sanity/ui` in the same project it can generate issues when trying to access the v2 theme.

> The following is crashing
> <img width="671" alt="Screenshot 2024-01-09 at 13 58 12" src="https://github.com/sanity-io/ui/assets/46196328/5f13eee4-9328-4b8b-9263-bd659898b81b">


This issues are caused because the check that we are doing in the `getTheme_V2` function, as it's only checking if the `sanity.v2` property exists in the theme, but it's not checking the signature of that object.


When using a studio which imports `sanity/ui v2` this studio will define a `<ThemeProvider>` which has access to the `getScopedTheme` function and it will accurately create the `theme.sanity.v2` object.
It will also add to `ThemeContext` provider the theme, which contains the **v2 raw object**, this means, the color is not resolved, so it will expose the color like this:
```
// Raw color object
 { 
  light:  {
    transparent: {...},
    primary: {...} ,
    ...
   } ,
  dark: {
    transparent: {...},
    primary: {...} ,
    ...
   } 
```
But later, if that project uses a plugin, that plugin is possibly importing `sanity/ui v1` and creating new `<ThemeProvider>` instances.
These instances, will use the [previous theme provider ](https://github.com/sanity-io/ui/blob/0fbe825a914af52ac87e7ba9d2cde430a769f728/src/theme/themeProvider.tsx#L34C29-L34C29) which just spreads the properties of the theme and also resolves the color located at `theme.sanity`, but not the one in `theme.sanity.v2` .

Then the children of this `<ThemeProvider>` could try to access the `theme.sanity.v2` property, which will be defined, because it was spreaded and added to theme, but the **color** won't be resolved, it will be in the raw state. (see example above),

To avoid this to happen, I'm adding a extra key to the `theme.sanity.v2` object, which will be added when the v2 theme is actually resolved and not anymore in raw state, if it's in raw state, the `getTheme_v2` function will resolved it. 


```

<V2_ThemeProvider>. (theme.sanity.v2.colors RESOLVED)
   <V2_UiComponent>   Access the correct object
</V2_ThemeProvider>


<V2_ThemeProvider>. (theme.sanity.v2.colors RESOLVED)
  <V1_ThemeProvider>  (get the raw theme from the themeContext, transforms theme.colors, but not theme.sanity.v2.colors which will be RAW)
     <V2_UiComponent>   Access the raw object - crashes
  </V1_ThemeProvider>
</V2_ThemeProvider>
```