### PR TITLE
fix(theme): restore selectable in v0 theme

### DIFF
--- a/src/theme/versioning/v2_v0.ts
+++ b/src/theme/versioning/v2_v0.ts
@@ -91,6 +91,7 @@ function themeColor_v2_v0(color_v2: ThemeColorCard_v2): ThemeColor {
       ...color_v2.button.default,
       transparent: color_v2.button.default.default,
     },
+    selectable: color_v2.selectable,
     spot: {
       gray: color_v2.avatar.gray.bg,
       blue: color_v2.avatar.blue.bg,


### PR DESCRIPTION
fixes: https://github.com/sanity-io/sanity-plugin-markdown/issues/90

Restores Legacy `sanity.color.selectable `values  in the v1 theme object when using the conversion function `v2_v0` which takes the `V2 theme` and creates the `V0 theme`.

