### PR TITLE
fix: remove unused `focusRing` from legacy ThemeColor interface

### DIFF
--- a/src/theme/system/v0/color/color.ts
+++ b/src/theme/system/v0/color/color.ts
@@ -18,7 +18,6 @@ export interface ThemeColor extends Partial<Omit<ThemeColorGenericState, 'muted'
   button: ThemeColorButton
   card: ThemeColorCard
   dark: boolean
-  focusRing?: string
   input: ThemeColorInput
   muted: ThemeColorMuted
   selectable?: ThemeColorSelectable


### PR DESCRIPTION
Removes `focusRing` from legacy `ThemeColor` objects, as this [was not present in v1](https://github.com/sanity-io/ui/blob/0fbe825a914af52ac87e7ba9d2cde430a769f728/src/theme/lib/theme/color/types.ts#L41C8-L52) and is not being populated in the `themeColor_v2_v0` conversion function. It may have been accidentally added.