### PR TITLE
fix(popover): default open popover has incorrect position

### DIFF
--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -98,6 +98,10 @@ export interface PopoverProps
   portal?: boolean | string
   preventOverflow?: boolean
   referenceBoundary?: HTMLElement | null
+  /**
+   * When defined, the popover will be positioned relative to this element.
+   * The children of the popover won't be rendered.
+   */
   referenceElement?: HTMLElement | null
   scheme?: ThemeColorSchemeKey
   tone?: CardTone

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -376,8 +376,9 @@ export const Popover = memo(
     }, [update, updateRef])
 
     useEffect(() => {
+      if (child) return
       refs.setReference(referenceElement || null)
-    }, [referenceElement, refs])
+    }, [referenceElement, refs, child])
 
     if (disabled) {
       return childProp || <></>

--- a/stories/primitives/Popover.stories.tsx
+++ b/stories/primitives/Popover.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import type {Meta, StoryObj} from '@storybook/react'
 import {useState} from 'react'
-import {Button, Card, Popover, Text} from '../../src/core/primitives'
+import {Box, Button, Card, Popover, Text} from '../../src/core/primitives'
 import {PLACEMENT_OPTIONS, RADII} from '../constants'
 import {getRadiusControls, getShadowControls, getSpaceControls} from '../controls'
 import {rowBuilder} from '../helpers/rowBuilder'
@@ -96,6 +96,24 @@ export const Placements: Story = {
           rows: PLACEMENT_OPTIONS,
         })}
       </Card>
+    )
+  },
+}
+
+export const DefaultOpen: Story = {
+  render: () => {
+    return (
+      <Box padding={4} style={{textAlign: 'center'}}>
+        <Popover
+          content={<Text size={[2, 2, 3, 4]}>Hello, world</Text>}
+          padding={4}
+          placement="top"
+          portal
+          open
+        >
+          <Button mode="ghost" padding={[3, 3, 4]} text="Reference" />
+        </Popover>
+      </Box>
     )
   },
 }

--- a/stories/primitives/Popover.stories.tsx
+++ b/stories/primitives/Popover.stories.tsx
@@ -117,3 +117,31 @@ export const DefaultOpen: Story = {
     )
   },
 }
+
+export const WithReferenceElement: Story = {
+  render: () => {
+    const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>(null)
+
+    return (
+      <Box padding={4} style={{textAlign: 'center'}}>
+        <Box ref={setReferenceElement}>
+          <Text>Reference element</Text>
+        </Box>
+        <Popover
+          content={<Text size={[2, 2, 3, 4]}>Hello, world</Text>}
+          padding={4}
+          placement="top"
+          referenceElement={referenceElement}
+          portal
+          open
+        >
+          <Button
+            mode="ghost"
+            padding={[3, 3, 4]}
+            text="This button won't be rendered, the popover has a reference element"
+          />
+        </Popover>
+      </Box>
+    )
+  },
+}


### PR DESCRIPTION
An issue was detected in arcade, in which the popover won't position correctly when it's rendering as open on mount.

This is caused by a `useEffect` that is removing the floating ui reference set by the child when it's mounted. 
Checking if child exists fixes the issue.

This only happens in SSR environments.

## Pre fix
<img width="900" alt="Screenshot 2024-01-18 at 10 49 30" src="https://github.com/sanity-io/ui/assets/46196328/54175e90-f451-4349-a0ee-6baf58d2ce3a">

## Post fix
<img width="900" alt="Screenshot 2024-01-18 at 10 51 22" src="https://github.com/sanity-io/ui/assets/46196328/9e6effac-561d-4bd2-9120-4bd694b312a1">

