### PR TITLE
fix(a11y): support the `prefers-reduced-motion: reduce` media query

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "semi": false,
   "printWidth": 100,
   "bracketSpacing": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "plugins": ["prettier-plugin-packagejson"]
 }

--- a/figma/package.json
+++ b/figma/package.json
@@ -2,15 +2,17 @@
   "name": "figma-plugin-sanity-ui",
   "version": "1.0.0",
   "description": "",
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
+  "sideEffects": false,
   "type": "module",
   "module": "./dist/index.js",
   "source": "./src/index.ts",
-  "author": "Sanity.io <hello@sanity.io>",
-  "license": "MIT",
   "scripts": {
     "build": "pkg build --strict && pkg --strict",
     "watch": "pkg watch --strict"
   },
+  "browserslist": "extends @sanity/browserslist-config",
   "devDependencies": {
     "@babel/plugin-transform-object-rest-spread": "^7.23.4",
     "@figma/plugin-typings": "^1.86.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,25 @@
 {
   "name": "@sanity/ui",
   "version": "2.0.2",
+  "keywords": [
+    "sanity",
+    "ui",
+    "primitives",
+    "react",
+    "components",
+    "design-system"
+  ],
+  "homepage": "https://www.sanity.io/",
+  "bugs": {
+    "url": "https://github.com/sanity-io/ui/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sanity-io/ui.git"
+  },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
   "sideEffects": false,
-  "types": "./dist/index.d.ts",
-  "source": "./exports/index.ts",
-  "module": "./dist/index.esm.js",
-  "main": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -31,6 +45,10 @@
     },
     "./package.json": "./package.json"
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.esm.js",
+  "source": "./exports/index.ts",
+  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       "theme": [
@@ -43,7 +61,6 @@
     "exports",
     "src"
   ],
-  "license": "MIT",
   "scripts": {
     "build": "run-s clean pkg:build pkg:check figma:pkg:build",
     "clean": "rimraf .workshop dist",
@@ -69,6 +86,33 @@
     "workshop:build": "workshop build",
     "workshop:dev": "workshop dev",
     "workshop:start": "http-server -a localhost -c-0 -p 1337 -s -P http://localhost:1337/index.html? dist"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
+  "lint-staged": {
+    "*": [
+      "prettier --write --cache --ignore-unknown"
+    ]
+  },
+  "browserslist": "extends @sanity/browserslist-config",
+  "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "main",
+      "next",
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
+    ],
+    "extends": "@sanity/semantic-release-preset"
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.8",
@@ -138,6 +182,7 @@
     "module-alias": "^2.2.3",
     "npm-run-all2": "^5.0.0",
     "prettier": "^3.2.5",
+    "prettier-plugin-packagejson": "^2.4.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
@@ -158,55 +203,12 @@
     "react-is": "^18",
     "styled-components": "^5.2 || ^6"
   },
+  "packageManager": "pnpm@8.11.0",
   "engines": {
     "node": ">=14.0.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/sanity-io/ui.git"
-  },
-  "bugs": {
-    "url": "https://github.com/sanity-io/ui/issues"
-  },
-  "keywords": [
-    "sanity",
-    "ui",
-    "primitives",
-    "react",
-    "components",
-    "design-system"
-  ],
-  "author": "Sanity.io <hello@sanity.io>",
-  "homepage": "https://www.sanity.io/",
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
-  },
-  "lint-staged": {
-    "*": [
-      "prettier --write --cache --ignore-unknown"
-    ]
-  },
-  "packageManager": "pnpm@8.11.0",
   "publishConfig": {
     "access": "public",
     "provenance": true
-  },
-  "release": {
-    "extends": "@sanity/semantic-release-preset",
-    "branches": [
-      "+([0-9])?(.{+([0-9]),x}).x",
-      "main",
-      "next",
-      {
-        "name": "beta",
-        "prerelease": true
-      },
-      {
-        "name": "alpha",
-        "prerelease": true
-      }
-    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
+      prettier-plugin-packagejson:
+        specifier: ^2.4.11
+        version: 2.4.11(prettier@3.2.5)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -4026,7 +4029,7 @@ packages:
       parse-git-config: 3.0.0
       pkg-up: 3.1.0
       prettier: 3.2.5
-      prettier-plugin-packagejson: 2.4.10(prettier@3.2.5)
+      prettier-plugin-packagejson: 2.4.11(prettier@3.2.5)
       pretty-bytes: 5.6.0
       prompts: 2.4.2
       rimraf: 4.4.1
@@ -13045,8 +13048,8 @@ packages:
       fast-diff: 1.3.0
     dev: true
 
-  /prettier-plugin-packagejson@2.4.10(prettier@3.2.5):
-    resolution: {integrity: sha512-qFzOfQDHi1tzvVJRuZ2jh1j6IFV5MURh5m5WDt+qfEMOf4SSL5RpwSysiX8u0W1PJYsM0vKJGNULt43wwteKiQ==}
+  /prettier-plugin-packagejson@2.4.11(prettier@3.2.5):
+    resolution: {integrity: sha512-zmOmM96GkAjT2zUdHSQJnpyVpbisBkewDluo2NLHjI/JN7uOCZlEzWVaMhdqyZ8LVdQDfzamvbvSw4swd3Az1A==}
     peerDependencies:
       prettier: '>= 1.16.0'
     peerDependenciesMeta:

--- a/src/core/components/dialog/dialog.tsx
+++ b/src/core/components/dialog/dialog.tsx
@@ -8,7 +8,13 @@ import {
   focusLastDescendant,
   isHTMLElement,
 } from '../../helpers'
-import {useArrayProp, useClickOutside, useForwardedRef, useGlobalKeyDown} from '../../hooks'
+import {
+  useArrayProp,
+  useClickOutside,
+  useForwardedRef,
+  useGlobalKeyDown,
+  usePrefersReducedMotion,
+} from '../../hooks'
 import {Box, Button, Card, Container, Flex, Text} from '../../primitives'
 import {ResponsivePaddingProps, ResponsiveWidthProps} from '../../primitives/types'
 import {responsivePaddingStyle, ResponsivePaddingStyleProps} from '../../styles/internal'
@@ -317,9 +323,11 @@ export const Dialog = forwardRef(function Dialog(
     scheme,
     width: widthProp = 0,
     zOffset: zOffsetProp = dialog.zOffset || layer.dialog.zOffset,
-    animate = false,
+    animate: _animate = false,
     ...restProps
   } = props
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const animate = prefersReducedMotion ? false : _animate
   const portal = usePortal()
   const portalElement = portalProp ? portal.elements?.[portalProp] || null : portal.element
   const boundaryElement = useBoundaryElement().element

--- a/src/core/primitives/avatar/styles.ts
+++ b/src/core/primitives/avatar/styles.ts
@@ -33,7 +33,6 @@ function avatarArrowStyle(): CSSObject {
       left: '50%',
       transform: 'translateX(-6px)',
 
-      // @ts-expect-error -- TODO wait for CSSObject types to be fixed in `styled-components` itself
       '&:not([hidden])': {
         display: 'block',
       },
@@ -75,7 +74,6 @@ export function avatarRootStyle(props: AvatarRootStyleProps & ThemeProps): CSSOb
     },
 
     '&>svg': {
-      // @ts-expect-error -- TODO wait for CSSObject types to be fixed in `styled-components` itself
       '&:not([hidden])': {
         display: 'block',
       },
@@ -92,7 +90,6 @@ export function avatarRootStyle(props: AvatarRootStyleProps & ThemeProps): CSSOb
       color: 'inherit',
       outline: 'none',
 
-      // @ts-expect-error -- TODO wait for CSSObject types to be fixed in `styled-components` itself
       '&:focus': {
         boxShadow: focusRingStyle({focusRing: avatar.focusRing}),
       },

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -22,7 +22,13 @@ import {
   useMemo,
   useRef,
 } from 'react'
-import {useForwardedRef, useArrayProp, useElementSize, useMediaIndex} from '../../hooks'
+import {
+  useForwardedRef,
+  useArrayProp,
+  useElementSize,
+  useMediaIndex,
+  usePrefersReducedMotion,
+} from '../../hooks'
 import {origin} from '../../middleware/origin'
 import {useTheme_v2} from '../../theme'
 import {BoxOverflow, CardTone, Placement, PopoverMargins} from '../../types'
@@ -128,7 +134,7 @@ export const Popover = memo(
 
     const {
       __unstable_margins: margins = DEFAULT_POPOVER_MARGINS,
-      animate = false,
+      animate: _animate = false,
       arrow: arrowProp = false,
       boundaryElement = boundaryElementContext.element,
       children: childProp,
@@ -158,6 +164,8 @@ export const Popover = memo(
       updateRef,
       ...restProps
     } = props
+    const prefersReducedMotion = usePrefersReducedMotion()
+    const animate = prefersReducedMotion ? false : _animate
     const boundarySize = useElementSize(boundaryElement)?.border
     const padding = useArrayProp(paddingProp)
     const radius = useArrayProp(radiusProp)

--- a/src/core/primitives/tooltip/tooltip.tsx
+++ b/src/core/primitives/tooltip/tooltip.tsx
@@ -23,7 +23,7 @@ import {
   useId,
 } from 'react'
 import styled from 'styled-components'
-import {useArrayProp, useForwardedRef} from '../../hooks'
+import {useArrayProp, useForwardedRef, usePrefersReducedMotion} from '../../hooks'
 import {useDelayedState} from '../../hooks/useDelayedState'
 import {origin} from '../../middleware/origin'
 import {useTheme_v2} from '../../theme'
@@ -101,7 +101,7 @@ export const Tooltip = forwardRef(function Tooltip(
   const boundaryElementContext = useBoundaryElement()
   const {layer} = useTheme_v2()
   const {
-    animate = false,
+    animate: _animate = false,
     arrow: arrowProp = false,
     boundaryElement = boundaryElementContext?.element,
     children: childProp,
@@ -119,6 +119,8 @@ export const Tooltip = forwardRef(function Tooltip(
     delay,
     ...restProps
   } = props
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const animate = prefersReducedMotion ? false : _animate
   const fallbackPlacements = useArrayProp(fallbackPlacementsProp)
   const forwardedRef = useForwardedRef(ref)
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)

--- a/stories/tests/Tones.mdx
+++ b/stories/tests/Tones.mdx
@@ -5,6 +5,6 @@ import {Tones} from './Tones'
 
 A page containing cards with all components that are modified when the card tone changes.
 
-<Unstyled >
+<Unstyled>
   <Tones scheme="light" />
 </Unstyled>


### PR DESCRIPTION
Ensures that Popovers, Tooltips, Toasts and Dialogs aren't animated if the browser reports that the user wants reduced motion.