### PR TITLE
fix(primitives): disabled button contrast 

### DIFF
--- a/src/core/primitives/button/__workshop__/disabled.tsx
+++ b/src/core/primitives/button/__workshop__/disabled.tsx
@@ -1,0 +1,73 @@
+import {SquareIcon} from '@sanity/icons'
+import {Card} from '../../card/card'
+import {Container} from '../../container/container'
+import {Grid} from '../../grid/grid'
+import {Stack} from '../../stack/stack'
+import {Text} from '../../text/text'
+import {Button, ButtonProps} from '../button'
+
+const GAP = 4
+const COLUMNS = 3
+
+const DEFAULT_PROPS: ButtonProps = {
+  icon: SquareIcon,
+  iconRight: SquareIcon,
+}
+
+function Layout() {
+  return (
+    <Container width={2}>
+      <Stack space={4}>
+        <Grid columns={COLUMNS} gap={GAP}>
+          <Text size={1} weight="semibold">
+            Default
+          </Text>
+          <Text size={1} weight="semibold">
+            Ghost
+          </Text>
+          <Text size={1} weight="semibold">
+            Bleed
+          </Text>
+        </Grid>
+
+        <Stack space={2}>
+          <Grid columns={COLUMNS} gap={GAP}>
+            <Stack space={2}>
+              <Button {...DEFAULT_PROPS} mode="default" text="Enabled" />
+              <Button {...DEFAULT_PROPS} disabled mode="default" text="Disabled" />
+              <Button {...DEFAULT_PROPS} disabled mode="default" muted text="Disabled (muted)" />
+            </Stack>
+
+            <Stack space={2}>
+              <Button {...DEFAULT_PROPS} mode="ghost" text="Enabled" />
+              <Button {...DEFAULT_PROPS} disabled mode="ghost" text="Disabled" />
+              <Button {...DEFAULT_PROPS} disabled mode="ghost" muted text="Disabled (muted)" />
+            </Stack>
+
+            <Stack space={2}>
+              <Button {...DEFAULT_PROPS} mode="bleed" text="Enabled" />
+              <Button {...DEFAULT_PROPS} mode="bleed" disabled text="Disabled" />
+              <Button {...DEFAULT_PROPS} disabled mode="bleed" muted text="Disabled (muted)" />
+            </Stack>
+          </Grid>
+        </Stack>
+      </Stack>
+    </Container>
+  )
+}
+
+export default function DisabledButtonStory() {
+  return (
+    <Stack>
+      <Stack space={4}>
+        <Card padding={5} scheme="light">
+          <Layout />
+        </Card>
+
+        <Card padding={5} scheme="dark">
+          <Layout />
+        </Card>
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/core/primitives/button/__workshop__/index.ts
+++ b/src/core/primitives/button/__workshop__/index.ts
@@ -50,5 +50,10 @@ export default defineScope({
       title: 'Custom icons',
       component: lazy(() => import('./customIcons')),
     },
+    {
+      name: 'disabled',
+      title: 'Disabled',
+      component: lazy(() => import('./disabled')),
+    },
   ],
 })

--- a/src/theme/defaults/colorTokens.ts
+++ b/src/theme/defaults/colorTokens.ts
@@ -155,7 +155,12 @@ export const defaultColorTokens: ThemeColorTokens = {
               icon: ['white', 'black'],
             },
           },
-          bg: ['200', '800'],
+          bg: ['300', '600'],
+          fg: ['300', '600'],
+          muted: {
+            bg: ['300', '600'],
+            fg: ['300', '600'],
+          },
           kbd: {
             bg: ['black', 'white'],
             fg: ['white', 'black'],
@@ -256,17 +261,17 @@ export const defaultColorTokens: ThemeColorTokens = {
             bg: ['50', '950'],
             fg: ['200', '800'],
           },
-          fg: ['200', '800'],
-          icon: ['200', '800'],
+          fg: ['400', '600'],
+          icon: ['300', '700'],
+          muted: {
+            fg: ['400', '600'],
+          },
           kbd: {
             bg: ['white', 'black'],
             fg: ['200', '800'],
             border: ['100', '900'],
           },
           link: {
-            fg: ['200', '800'],
-          },
-          muted: {
             fg: ['200', '800'],
           },
         },
@@ -354,17 +359,17 @@ export const defaultColorTokens: ThemeColorTokens = {
             bg: ['50', '950'],
             fg: ['200', '800'],
           },
-          fg: ['200', '800'],
-          icon: ['200', '800'],
+          fg: ['400', '600'],
+          icon: ['300', '700'],
+          muted: {
+            fg: ['400', '600'],
+          },
           kbd: {
             bg: ['white', 'black'],
             fg: ['200', '800'],
             border: ['100', '900'],
           },
           link: {
-            fg: ['200', '800'],
-          },
-          muted: {
             fg: ['200', '800'],
           },
         },


### PR DESCRIPTION
This pull request improves the contrast of disabled buttons. Note that this pull request aims to _improve_ the contrast ratio; however, the contrast ratios might not comply with a11y standards. Another pass needs to be done in the future to ensure the buttons have the correct ratio in regard to a11y standards.

<img width="875" alt="Screenshot 2024-04-04 at 12 13 23" src="https://github.com/sanity-io/ui/assets/15094168/854c6152-3da8-42f4-9e56-ac80f7b48c6a">
