### PR TITLE
fix: remove ssr warning "Detected multiple renderers"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,5 +72,6 @@ jobs:
       # Branches that will release new versions are defined in .releaserc.json
       - run: pnpm exec semantic-release
         env:
+          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/figma/package.config.ts
+++ b/figma/package.config.ts
@@ -7,4 +7,9 @@ export default defineConfig({
   dist: './dist',
   src: './src',
   tsconfig: './tsconfig.dist.json',
+  strictOptions: {
+    alwaysPackageJsonMain: 'off',
+    alwaysPackageJsonFiles: 'off',
+    noImplicitBrowsersList: 'off',
+  },
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/ui",
-  "version": "2.1.2",
+  "version": "2.1.3-canary.0",
   "keywords": [
     "sanity",
     "ui",
@@ -119,7 +119,7 @@
     "@commitlint/cli": "^19.2.1",
     "@commitlint/config-conventional": "^19.1.0",
     "@juggle/resize-observer": "^3.4.0",
-    "@sanity/pkg-utils": "^6.4.1",
+    "@sanity/pkg-utils": "^6.6.1",
     "@sanity/semantic-release-preset": "^4.1.7",
     "@sanity/ui-workshop": "^2.0.12",
     "@storybook/addon-a11y": "^8.0.7",
@@ -197,8 +197,7 @@
     "node": ">=14.0.0"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "esm.sh": {
     "bundle": false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,14 +49,14 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       '@sanity/pkg-utils':
-        specifier: ^6.4.1
-        version: 6.4.1(@types/node@20.12.4)(typescript@5.4.5)
+        specifier: ^6.6.1
+        version: 6.6.1(@types/node@20.12.4)(typescript@5.4.5)
       '@sanity/semantic-release-preset':
         specifier: ^4.1.7
         version: 4.1.7(semantic-release@23.0.8)
       '@sanity/ui-workshop':
         specifier: ^2.0.12
-        version: 2.0.12(@sanity/icons@2.11.8)(@sanity/ui@)(@types/node@20.12.4)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.8)
+        version: 2.0.12(@sanity/icons@2.11.8)(@sanity/ui@2.1.2)(@types/node@20.12.4)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.8)
       '@storybook/addon-a11y':
         specifier: ^8.0.7
         version: 8.0.7
@@ -1872,7 +1872,6 @@ packages:
     requiresBuild: true
     dependencies:
       '@emotion/memoize': 0.7.4
-    dev: false
     optional: true
 
   /@emotion/is-prop-valid@1.2.1:
@@ -1884,7 +1883,6 @@ packages:
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /@emotion/memoize@0.8.1:
@@ -2159,14 +2157,12 @@ packages:
     resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
     dependencies:
       '@floating-ui/utils': 0.2.1
-    dev: false
 
   /@floating-ui/dom@1.6.3:
     resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
     dependencies:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
-    dev: false
 
   /@floating-ui/react-dom@2.0.8(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
@@ -2177,11 +2173,9 @@ packages:
       '@floating-ui/dom': 1.6.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@floating-ui/utils@0.2.1:
     resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
-    dev: false
 
   /@hapi/hoek@9.3.0:
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -3125,8 +3119,8 @@ packages:
     dependencies:
       react: 18.2.0
 
-  /@sanity/pkg-utils@6.4.1(@types/node@20.12.4)(typescript@5.4.5):
-    resolution: {integrity: sha512-X66IgwDLcv7gVwmxqx0ZMD9BXQeskVivRvhBqAnsbU0zVjSgvLplg5AGdzNdHX9kbeY4DYQEgjZhUyYSJASTFA==}
+  /@sanity/pkg-utils@6.6.1(@types/node@20.12.4)(typescript@5.4.5):
+    resolution: {integrity: sha512-23IPa4dr5IiVr/6SuQz3/OH4XhVUyPQHat5c3ZXpFYaPmWGNSGcQ8iOIJKDSDqxq9oM+kv/3oZg18uyYu2y8kg==}
     engines: {node: '>=18.17.0'}
     hasBin: true
     peerDependencies:
@@ -3172,6 +3166,7 @@ packages:
       typescript: 5.4.5
       uuid: 9.0.1
       zod: 3.22.4
+      zod-validation-error: 3.1.0(zod@3.22.4)
     transitivePeerDependencies:
       - '@types/babel__core'
       - '@types/node'
@@ -3194,7 +3189,7 @@ packages:
       - supports-color
     dev: true
 
-  /@sanity/ui-workshop@2.0.12(@sanity/icons@2.11.8)(@sanity/ui@)(@types/node@20.12.4)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.8):
+  /@sanity/ui-workshop@2.0.12(@sanity/icons@2.11.8)(@sanity/ui@2.1.2)(@types/node@20.12.4)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.8):
     resolution: {integrity: sha512-adMmfkY3zyVq6ni+vyq1f0M16S+sor5Kgsg+oLxewRZ2u5Wu0tLZ50blqnmqisNPnI2WRlxsFbPxHsmRXvEphg==}
     hasBin: true
     peerDependencies:
@@ -3205,7 +3200,7 @@ packages:
       styled-components: ^5.2 || ^6
     dependencies:
       '@sanity/icons': 2.11.8(react@18.2.0)
-      '@sanity/ui': 'link:'
+      '@sanity/ui': 2.1.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8)
       '@vitejs/plugin-react': 4.2.1(vite@5.2.8)
       axe-core: 4.9.0
       cac: 6.7.14
@@ -3234,6 +3229,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /@sanity/ui@2.1.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8):
+    resolution: {integrity: sha512-mrg0zyTdOVnaGsGIa9aOEvCcSNN3J97wH57aID1T4OhG29diO7lTyehRG5R+YfXBPjoCyfV3dU+aFLKXCsiBUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^18
+      react-dom: ^18
+      react-is: ^18
+      styled-components: ^5.2 || ^6
+    dependencies:
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0)(react@18.2.0)
+      '@sanity/color': 3.0.6
+      '@sanity/icons': 2.11.8(react@18.2.0)
+      csstype: 3.1.3
+      framer-motion: 11.0.8(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 18.2.0
+      react-refractor: 2.1.7(react@18.2.0)
+      styled-components: 6.1.8(react-dom@18.2.0)(react@18.2.0)
     dev: true
 
   /@semantic-release/changelog@6.0.3(semantic-release@23.0.8):
@@ -5962,7 +5978,6 @@ packages:
 
   /character-entities-legacy@1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
-    dev: false
 
   /character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
@@ -5970,7 +5985,6 @@ packages:
 
   /character-entities@1.2.4:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
-    dev: false
 
   /character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
@@ -5978,7 +5992,6 @@ packages:
 
   /character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
-    dev: false
 
   /character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
@@ -6222,7 +6235,6 @@ packages:
 
   /comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
-    dev: false
 
   /comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -8319,7 +8331,6 @@ packages:
       tslib: 2.6.2
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
-    dev: false
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -8934,7 +8945,6 @@ packages:
 
   /hast-util-parse-selector@2.2.5:
     resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
-    dev: false
 
   /hast-util-parse-selector@3.1.1:
     resolution: {integrity: sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==}
@@ -8956,7 +8966,6 @@ packages:
       hast-util-parse-selector: 2.2.5
       property-information: 5.6.0
       space-separated-tokens: 1.1.5
-    dev: false
 
   /hastscript@7.2.0:
     resolution: {integrity: sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==}
@@ -9310,7 +9319,6 @@ packages:
 
   /is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
-    dev: false
 
   /is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -9321,7 +9329,6 @@ packages:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
-    dev: false
 
   /is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
@@ -9437,7 +9444,6 @@ packages:
 
   /is-decimal@1.0.4:
     resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
-    dev: false
 
   /is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -9552,7 +9558,6 @@ packages:
 
   /is-hexadecimal@1.0.4:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
-    dev: false
 
   /is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -11911,7 +11916,6 @@ packages:
       is-alphanumerical: 1.0.4
       is-decimal: 1.0.4
       is-hexadecimal: 1.0.4
-    dev: false
 
   /parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
@@ -12312,7 +12316,6 @@ packages:
   /prismjs@1.27.0:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
     engines: {node: '>=6'}
-    dev: false
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -12349,7 +12352,6 @@ packages:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
     dependencies:
       xtend: 4.0.2
-    dev: false
 
   /property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
@@ -12578,7 +12580,6 @@ packages:
       refractor: 3.6.0
       unist-util-filter: 2.0.3
       unist-util-visit-parents: 3.1.1
-    dev: false
 
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
@@ -12717,7 +12718,6 @@ packages:
       hastscript: 6.0.0
       parse-entities: 2.0.0
       prismjs: 1.27.0
-    dev: false
 
   /refractor@4.8.1:
     resolution: {integrity: sha512-/fk5sI0iTgFYlmVGYVew90AoYnNMP6pooClx/XKqyeeCQXrL0Kvgn8V0VEht5ccdljbzzF1i3Q213gcntkRExg==}
@@ -13476,7 +13476,6 @@ packages:
 
   /space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
-    dev: false
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -14401,11 +14400,9 @@ packages:
     resolution: {integrity: sha512-8k6Jl/KLFqIRTHydJlHh6+uFgqYHq66pV75pZgr1JwfyFSjbWb12yfb0yitW/0TbHXjr9U4G9BQpOvMANB+ExA==}
     dependencies:
       unist-util-is: 4.1.0
-    dev: false
 
   /unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
-    dev: false
 
   /unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
@@ -14418,7 +14415,6 @@ packages:
     dependencies:
       '@types/unist': 2.0.10
       unist-util-is: 4.1.0
-    dev: false
 
   /unist-util-visit-parents@6.0.1:
     resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
@@ -14962,6 +14958,15 @@ packages:
       validator: 13.11.0
     optionalDependencies:
       commander: 9.5.0
+    dev: true
+
+  /zod-validation-error@3.1.0(zod@3.22.4):
+    resolution: {integrity: sha512-zujS6HqJjMZCsvjfbnRs7WI3PXN39ovTcY1n8a+KTm4kOH0ZXYsNiJkH1odZf4xZKMkBDL7M2rmQ913FCS1p9w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.18.0
+    dependencies:
+      zod: 3.22.4
     dev: true
 
   /zod@3.22.4:

--- a/src/core/components/dialog/dialogContext.ts
+++ b/src/core/components/dialog/dialogContext.ts
@@ -1,5 +1,4 @@
-import {createContext} from 'react'
-import {globalScope} from '../../lib/globalScope'
+import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {DialogPosition} from '../../types'
 
 /**
@@ -14,9 +13,9 @@ export interface DialogContextValue {
 
 const key = Symbol.for('@sanity/ui/context/dialog')
 
-globalScope[key] = globalScope[key] || createContext<DialogContextValue>({version: 0.0})
-
 /**
  * @internal
  */
-export const DialogContext: React.Context<DialogContextValue> = globalScope[key]
+export const DialogContext = createGlobalScopedContext<DialogContextValue>(key, {
+  version: 0.0,
+})

--- a/src/core/components/menu/menuContext.ts
+++ b/src/core/components/menu/menuContext.ts
@@ -1,5 +1,4 @@
-import {createContext} from 'react'
-import {globalScope} from '../../lib/globalScope'
+import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 
 export interface MenuContextValue {
   version: 0.0
@@ -26,6 +25,4 @@ export interface MenuContextValue {
 
 const key = Symbol.for('@sanity/ui/context/menu')
 
-globalScope[key] = globalScope[key] || createContext<MenuContextValue | null>(null)
-
-export const MenuContext: React.Context<MenuContextValue | null> = globalScope[key]
+export const MenuContext = createGlobalScopedContext<MenuContextValue | null>(key, null)

--- a/src/core/components/toast/toastContext.ts
+++ b/src/core/components/toast/toastContext.ts
@@ -1,9 +1,6 @@
-import {createContext} from 'react'
-import {globalScope} from '../../lib/globalScope'
+import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {ToastContextValue} from './types'
 
 const key = Symbol.for('@sanity/ui/context/toast')
 
-globalScope[key] = globalScope[key] || createContext<ToastContextValue | null>(null)
-
-export const ToastContext: React.Context<ToastContextValue | null> = globalScope[key]
+export const ToastContext = createGlobalScopedContext<ToastContextValue | null>(key, null)

--- a/src/core/components/tree/treeContext.ts
+++ b/src/core/components/tree/treeContext.ts
@@ -1,12 +1,9 @@
-import {createContext} from 'react'
-import {globalScope} from '../../lib/globalScope'
+import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {TreeContextValue} from './types'
 
 const key = Symbol.for('@sanity/ui/context/tree')
 
-globalScope[key] = globalScope[key] || createContext<TreeContextValue | null>(null)
-
 /**
  * @internal
  */
-export const TreeContext: React.Context<TreeContextValue | null> = globalScope[key]
+export const TreeContext = createGlobalScopedContext<TreeContextValue | null>(key, null)

--- a/src/core/lib/createGlobalScopedContext.ts
+++ b/src/core/lib/createGlobalScopedContext.ts
@@ -1,0 +1,24 @@
+/**
+ * To improve performance and DevEx for things such as Hot Module Replacement,
+ * we want to preserve created contexts between reloads.
+ * It also helps with module duplication and other issues.
+ */
+
+import {createContext, type Context} from 'react'
+import {globalScope} from './globalScope'
+
+export function createGlobalScopedContext<ContextType, const T extends ContextType = ContextType>(
+  key: symbol,
+  defaultValue: T,
+): Context<ContextType> {
+  /**
+   * Prevent errors about re-renders on React SSR on Next.js App Router
+   */
+  if (typeof document === 'undefined') {
+    return createContext<ContextType>(defaultValue)
+  }
+
+  globalScope[key] = globalScope[key] || createContext<T>(defaultValue)
+
+  return globalScope[key]
+}

--- a/src/core/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupContext.tsx
+++ b/src/core/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupContext.tsx
@@ -1,13 +1,10 @@
-import {createContext} from 'react'
-import {globalScope} from '../../../lib/globalScope'
+import {createGlobalScopedContext} from '../../../lib/createGlobalScopedContext'
 import {TooltipDelayGroupContextValue} from './types'
 
 const key = Symbol.for('@sanity/ui/context/tooltipDelayGroup')
 
-globalScope[key] = globalScope[key] || createContext<TooltipDelayGroupContextValue | null>(null)
-
 /**
  * @beta
  */
-export const TooltipDelayGroupContext: React.Context<TooltipDelayGroupContextValue | null> =
-  globalScope[key]
+export const TooltipDelayGroupContext =
+  createGlobalScopedContext<TooltipDelayGroupContextValue | null>(key, null)

--- a/src/core/theme/themeContext.ts
+++ b/src/core/theme/themeContext.ts
@@ -1,12 +1,9 @@
-import {Context, createContext} from 'react'
-import {globalScope} from '../lib/globalScope'
+import {createGlobalScopedContext} from '../lib/createGlobalScopedContext'
 import {ThemeContextValue} from './types'
 
 const key = Symbol.for('@sanity/ui/context/theme')
 
-globalScope[key] = globalScope[key] || createContext<ThemeContextValue | null>(null)
-
 /**
  * @internal
  */
-export const ThemeContext: Context<ThemeContextValue | null> = globalScope[key]
+export const ThemeContext = createGlobalScopedContext<ThemeContextValue | null>(key, null)

--- a/src/core/theme/themeProvider.tsx
+++ b/src/core/theme/themeProvider.tsx
@@ -1,8 +1,8 @@
 import {
-  RootTheme,
-  ThemeColorCardToneKey,
-  ThemeColorSchemeKey,
-  Theme,
+  type RootTheme,
+  type ThemeColorCardToneKey,
+  type ThemeColorSchemeKey,
+  type Theme,
   getScopedTheme,
 } from '@sanity/ui/theme'
 import {useContext, useMemo} from 'react'

--- a/src/core/utils/boundaryElement/boundaryElementContext.ts
+++ b/src/core/utils/boundaryElement/boundaryElementContext.ts
@@ -1,10 +1,9 @@
-import {createContext} from 'react'
-import {globalScope} from '../../lib/globalScope'
+import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {BoundaryElementContextValue} from './types'
 
 const key = Symbol.for('@sanity/ui/context/boundaryElement')
 
-globalScope[key] = globalScope[key] || createContext<BoundaryElementContextValue | null>(null)
-
-export const BoundaryElementContext: React.Context<BoundaryElementContextValue | null> =
-  globalScope[key]
+export const BoundaryElementContext = createGlobalScopedContext<BoundaryElementContextValue | null>(
+  key,
+  null,
+)

--- a/src/core/utils/layer/layerContext.ts
+++ b/src/core/utils/layer/layerContext.ts
@@ -1,9 +1,6 @@
-import {Context, createContext} from 'react'
-import {globalScope} from '../../lib/globalScope'
+import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {LayerContextValue} from './types'
 
 const key = Symbol.for('@sanity/ui/context/layer')
 
-globalScope[key] = globalScope[key] || createContext<LayerContextValue | null>(null)
-
-export const LayerContext: Context<LayerContextValue | null> = globalScope[key]
+export const LayerContext = createGlobalScopedContext<LayerContextValue | null>(key, null)

--- a/src/core/utils/portal/portalContext.ts
+++ b/src/core/utils/portal/portalContext.ts
@@ -1,4 +1,4 @@
-import {createContext} from 'react'
+import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {globalScope} from '../../lib/globalScope'
 import {PortalContextValue} from './types'
 
@@ -28,6 +28,4 @@ export const defaultContextValue: PortalContextValue = {
   },
 }
 
-globalScope[key] = globalScope[key] || createContext<PortalContextValue>(defaultContextValue)
-
-export const PortalContext: React.Context<PortalContextValue> = globalScope[key]
+export const PortalContext = createGlobalScopedContext<PortalContextValue>(key, defaultContextValue)

--- a/src/core/utils/portal/portalProvider.tsx
+++ b/src/core/utils/portal/portalProvider.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react'
+import {useMemo, useSyncExternalStore} from 'react'
 import {useUnique} from '../../hooks/_internal'
 import {PortalContext} from './portalContext'
 import {PortalContextValue} from './types'
@@ -19,23 +19,28 @@ export interface PortalProviderProps {
   __unstable_elements?: Record<string, HTMLElement | null | undefined>
 }
 
-const __BROWSER__ = typeof document !== 'undefined'
-
 /**
  * @public
  */
 export function PortalProvider(props: PortalProviderProps): React.ReactElement {
   const {boundaryElement, children, element, __unstable_elements: elementsProp} = props
   const elements = useUnique(elementsProp)
+  const fallbackElement = useSyncExternalStore(
+    emptySubscribe,
+    () => document.body,
+    () => null,
+  )
 
   const value: PortalContextValue = useMemo(() => {
     return {
       version: 0.0,
       boundaryElement: boundaryElement || null,
-      element: element || (__BROWSER__ && document.body) || null,
+      element: element || fallbackElement,
       elements,
     }
-  }, [boundaryElement, element, elements])
+  }, [boundaryElement, element, elements, fallbackElement])
 
   return <PortalContext.Provider value={value}>{children}</PortalContext.Provider>
 }
+
+const emptySubscribe = () => () => {}


### PR DESCRIPTION
In App Router there's frequently very long (truncated below) warnings:
```
Warning: Detected multiple renderers concurrently rendering the same context provider. This is currently unsupported.
    at ThemeProvider (webpack-internal:///(ssr)/./node_modules/@sanity/ui/dist/index.mjs:662:72)
    at ThemeProvider (webpack-internal:///(ssr)/./app/[lang]/ThemeProvider.tsx:14:26)
    at Lazy
    at Le (webpack-internal:///(ssr)/./node_modules/styled-components/dist/styled-components.esm.js:32:16022)
    at StyledComponentsRegistry (webpack-internal:///(ssr)/./app/[lang]/registry.tsx:17:37)
    at Lazy
    at body
    at html
```
It was first reported at [next-sanity](https://github.com/sanity-io/next-sanity/issues/1008).

[Expo had to solve for the same warning, as it relates to how React deals with contexts during SRR.](https://github.com/expo/router/pull/589/files)

This PR solves it by wrapping the usage of `globalScope[key] = globalScope[key] || React.createContext` in a helper that detects if we're in SSR where it falls back to always calling `React.createContext` and thus the warning stops showing up.