### PR TITLE
refactor(CI): enable strict branch rules for code review

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,9 +5,11 @@
     "github>sanity-io/renovate-config:studio-v3",
     ":reviewer(team:ecosystem)"
   ],
+  "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "packageRules": [
     {
       "matchDepTypes": ["dependencies"],
+      "semanticCommitType": "fix",
       "rangeStrategy": "bump"
     }
   ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,19 +51,25 @@ jobs:
 
   release:
     permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
     name: 'Semantic release'
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           # Need to fetch entire commit history to
           # analyze every commit since last release
           fetch-depth: 0
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
@@ -73,5 +79,5 @@ jobs:
       - run: pnpm exec semantic-release
         env:
           NPM_CONFIG_PROVENANCE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
Also changes renovate to split up deps PRs so it's easier to handle cases where one of the deps are causing the build to fail, as seen in #1267