### PR TITLE
feat(card): add `muted` property

### DIFF
--- a/src/core/primitives/card/__workshop__/props.tsx
+++ b/src/core/primitives/card/__workshop__/props.tsx
@@ -12,6 +12,7 @@ export default function PropsStory() {
   const as = useSelect('As', WORKSHOP_CARD_AS_OPTIONS, 'div', 'Props')
   const border = useBoolean('Border', false, 'Props')
   const checkered = useBoolean('Checkered', false, 'Props')
+  const muted = useBoolean('Muted', false, 'Props')
   const padding = useSelect('Padding', WORKSHOP_SPACE_OPTIONS, 0, 'Props')
   const radius = useSelect('Radius', WORKSHOP_RADIUS_OPTIONS, 0, 'Props')
   const selected = useBoolean('Selected', false, 'Props')
@@ -24,6 +25,7 @@ export default function PropsStory() {
         __unstable_checkered={checkered}
         as={as}
         border={border}
+        muted={muted}
         onClick={useAction('onClick')}
         padding={padding}
         radius={radius}

--- a/src/core/primitives/card/card.tsx
+++ b/src/core/primitives/card/card.tsx
@@ -36,6 +36,7 @@ export interface CardProps
    * @beta
    */
   __unstable_focusRing?: boolean
+  muted?: boolean
   pressed?: boolean
   scheme?: ThemeColorSchemeKey
   tone?: CardTone
@@ -67,6 +68,7 @@ export const Card = forwardRef(function Card(
     borderRight,
     borderBottom,
     borderLeft,
+    muted,
     pressed,
     radius = 0,
     scheme,
@@ -96,6 +98,7 @@ export const Card = forwardRef(function Card(
         $borderLeft={useArrayProp(borderLeft)}
         $checkered={checkered}
         $focusRing={focusRing}
+        $muted={muted}
         $radius={useArrayProp(radius)}
         $shadow={useArrayProp(shadow)}
         $tone={tone}

--- a/src/core/primitives/card/styles.ts
+++ b/src/core/primitives/card/styles.ts
@@ -49,7 +49,7 @@ export function cardBaseStyle(props: CardStyleProps & ThemeProps): ReturnType<ty
 }
 
 export function cardColorStyle(props: CardStyleProps & ThemeProps): ReturnType<typeof css> {
-  const {$checkered, $focusRing} = props
+  const {$checkered, $focusRing, $muted} = props
   const {card, color, style} = getTheme_v2(props.theme)
   const border = {width: card.border.width, color: 'var(--card-border-color)'}
 
@@ -58,7 +58,7 @@ export function cardColorStyle(props: CardStyleProps & ThemeProps): ReturnType<t
 
     ${_cardColorStyle(color, color, $checkered)}
 
-    background-color: var(--card-bg-color);
+    background-color: ${$muted ? 'var(--card-muted-bg-color)' : 'var(--card-bg-color)'};
     color: var(--card-fg-color);
 
     /* &:is(button) */

--- a/src/core/primitives/card/types.ts
+++ b/src/core/primitives/card/types.ts
@@ -6,5 +6,6 @@ import {ThemeColorToneKey} from '@sanity/ui/theme'
 export interface CardStyleProps {
   $checkered: boolean
   $focusRing: boolean
+  $muted: boolean
   $tone: ThemeColorToneKey
 }


### PR DESCRIPTION
With this change we introduce a new `muted` property on the `<Card>` component.

`<Card muted tone="inherit">` will render a card with a slightly darker background (and slightly lighter in dark) than its surroundings.

The benefit of this in comparison to `<Card tone="transparent">` is that you can combine `muted` and `tone` like `<Card muted tone="critical">` – and it also works within button, card, and menu item states.

Try it here:
https://sanity-ui-workshop-git-feat-muted-card.sanity.build/primitives/card/props