### PR TITLE
fix(theme): placeholder color in dark mode

### DIFF
--- a/src/theme/defaults/colorTokens.ts
+++ b/src/theme/defaults/colorTokens.ts
@@ -432,7 +432,7 @@ export const defaultColorTokens: ThemeColorTokens = {
         muted: {
           bg: ['50', '950'],
         },
-        placeholder: ['400', '600 50%'],
+        placeholder: ['400', '600'],
       },
       hovered: {
         border: ['300', '700'],


### PR DESCRIPTION
Before:
<img width="765" alt="image" src="https://github.com/sanity-io/ui/assets/406933/04a2b937-28dd-4fa6-ab7c-54820aa54877">

After:
<img width="767" alt="image" src="https://github.com/sanity-io/ui/assets/406933/0ab1500f-de27-49cf-b951-01ef11a0f097">
