### PR TITLE
fix(menu): allow overriding `selected` property on `MenuButton`

### DIFF
--- a/src/core/components/menu/__workshop__/customSelectedState.tsx
+++ b/src/core/components/menu/__workshop__/customSelectedState.tsx
@@ -1,0 +1,38 @@
+import {ChevronDownIcon} from '@sanity/icons'
+import {useSelect} from '@sanity/ui-workshop'
+import {Box, Button} from '../../../primitives'
+import {Menu} from '../menu'
+import {MenuButton} from '../menuButton'
+import {MenuItem} from '../menuItem'
+
+const selectedOptions = {
+  undefined: 'undefined',
+  true: true,
+  false: false,
+} as const
+
+export default function CustomSelectedStateStory() {
+  const selected = useSelect('Selected', selectedOptions, false)
+
+  return (
+    <Box padding={4}>
+      <MenuButton
+        button={
+          <Button
+            icon={ChevronDownIcon}
+            mode="bleed"
+            selected={selected === 'undefined' ? undefined : selected}
+            text="Menu"
+          />
+        }
+        id="test-menu"
+        menu={
+          <Menu>
+            <MenuItem text="Item 1" />
+            <MenuItem text="Item 2" />
+          </Menu>
+        }
+      />
+    </Box>
+  )
+}

--- a/src/core/components/menu/__workshop__/index.ts
+++ b/src/core/components/menu/__workshop__/index.ts
@@ -80,5 +80,10 @@ export default defineScope({
       title: 'Avatar menu',
       component: lazy(() => import('./avatarMenu')),
     },
+    {
+      name: 'custom-selected-state',
+      title: 'Custom selected state',
+      component: lazy(() => import('./customSelectedState')),
+    },
   ],
 })

--- a/src/core/components/menu/menuButton.tsx
+++ b/src/core/components/menu/menuButton.tsx
@@ -241,7 +241,7 @@ export const MenuButton = forwardRef(function MenuButton(
         'aria-haspopup': true,
         'aria-expanded': open,
         ref: ref,
-        selected: open,
+        selected: buttonProp.props.selected ?? open,
       }),
     [buttonProp, handleButtonClick, handleButtonKeyDown, handleMouseDown, id, open],
   )


### PR DESCRIPTION
This change will allow for setting the `selected` property on buttons rendered by `MenuButton`. Example:

```tsx
<MenuButton
  button={<Button icon={ChevronDownIcon} selected />}
  // ...
/>
```