### PR TITLE
fix: forward child refs to fix regression in #1343

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/ui",
-  "version": "2.3.5",
+  "version": "2.3.6-0",
   "keywords": [
     "sanity",
     "ui",

--- a/src/core/primitives/tooltip/tooltip.tsx
+++ b/src/core/primitives/tooltip/tooltip.tsx
@@ -357,6 +357,10 @@ export const Tooltip = forwardRef(function Tooltip(
   )
 
   const childRef = useRef<HTMLElement | null>(null)
+
+  // Merge refs so that any ref we are overriding is called as well
+  useImperativeHandle((childProp as any)?.ref, () => childRef.current)
+
   const child = useMemo(() => {
     if (!childProp) return null
 


### PR DESCRIPTION
Can be tested with `pnpm i @sanity/ui@hotfix`. This is the root cause for the missing presence overlays in Sanity atm