### PR TITLE
fix(menu): override popover html attribute

### DIFF
--- a/src/core/components/menu/menuGroup.tsx
+++ b/src/core/components/menu/menuGroup.tsx
@@ -28,7 +28,7 @@ export interface MenuGroupProps {
  * @public
  */
 export function MenuGroup(
-  props: Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'tabIndex'> &
+  props: Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'popover' | 'ref' | 'tabIndex'> &
     MenuGroupProps,
 ): React.ReactElement {
   const {

--- a/src/core/components/menu/menuGroup.tsx
+++ b/src/core/components/menu/menuGroup.tsx
@@ -28,8 +28,8 @@ export interface MenuGroupProps {
  * @public
  */
 export function MenuGroup(
-  props: MenuGroupProps &
-    Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'tabIndex'>,
+  props: Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'tabIndex'> &
+    MenuGroupProps,
 ): React.ReactElement {
   const {
     as = 'button',


### PR DESCRIPTION
React canary types have added support for the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) as of this [this commit](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/0b728411cd1dfb4bd26992bb35a73cf8edaa22e7).

This is a small fix to make sure the `MenuGroup` `popover` prop type overrides that provided by the [`HTMLAttributes` interface](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/0b728411cd1dfb4bd26992bb35a73cf8edaa22e7#diff-07a6757d5c9a93bb7f7dccd78952fcf474bcaf0a00b9ee3215fe07a2b29f63c3R127).