### PR TITLE
feat(autocomplete): `openOnFocus` property

### DIFF
--- a/src/core/components/autocomplete/autocomplete.tsx
+++ b/src/core/components/autocomplete/autocomplete.tsx
@@ -61,6 +61,8 @@ export interface AutocompleteProps<Option extends BaseAutocompleteOption = BaseA
   onSelect?: (value: string) => void
   /** @beta */
   openButton?: boolean | AutocompleteOpenButtonProps
+  /** @beta */
+  openOnFocus?: boolean
   /** The options to render. */
   options?: Option[]
   padding?: number | number[]
@@ -138,6 +140,7 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
     onQueryChange,
     onSelect,
     openButton,
+    openOnFocus,
     options: optionsProp,
     padding: paddingProp = 3,
     popover = EMPTY_RECORD,
@@ -354,15 +357,23 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
     [onQueryChange],
   )
 
+  const handleDispatchOpen = useCallback(() => {
+    dispatch({
+      type: 'root/open',
+      query: value ? renderValue(value, currentOption) : '',
+    })
+  }, [currentOption, renderValue, value])
+
   const handleInputFocus = useCallback(
     (event: FocusEvent<HTMLInputElement>) => {
       if (!focused) {
         dispatch({type: 'input/focus'})
 
         if (onFocus) onFocus(event)
+        if (openOnFocus) handleDispatchOpen()
       }
     },
-    [focused, onFocus],
+    [focused, onFocus, openOnFocus, handleDispatchOpen],
   )
 
   const handlePopoverMouseEnter = useCallback(() => {
@@ -467,16 +478,13 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
 
   const handleOpenClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
-      dispatch({
-        type: 'root/open',
-        query: value ? renderValue(value, currentOption) : '',
-      })
+      handleDispatchOpen()
 
       if (openButtonProps.onClick) openButtonProps.onClick(event)
 
       _raf(() => inputElementRef.current?.focus())
     },
-    [currentOption, openButtonProps, renderValue, value],
+    [openButtonProps, handleDispatchOpen],
   )
 
   const openButtonNode = useMemo(

--- a/src/core/components/autocomplete/autocomplete.tsx
+++ b/src/core/components/autocomplete/autocomplete.tsx
@@ -357,7 +357,7 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
     [onQueryChange],
   )
 
-  const handleDispatchOpen = useCallback(() => {
+  const dispatchOpen = useCallback(() => {
     dispatch({
       type: 'root/open',
       query: value ? renderValue(value, currentOption) : '',
@@ -370,10 +370,10 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
         dispatch({type: 'input/focus'})
 
         if (onFocus) onFocus(event)
-        if (openOnFocus) handleDispatchOpen()
+        if (openOnFocus) dispatchOpen()
       }
     },
-    [focused, onFocus, openOnFocus, handleDispatchOpen],
+    [focused, onFocus, openOnFocus, dispatchOpen],
   )
 
   const handlePopoverMouseEnter = useCallback(() => {
@@ -478,13 +478,13 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
 
   const handleOpenClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
-      handleDispatchOpen()
+      dispatchOpen()
 
       if (openButtonProps.onClick) openButtonProps.onClick(event)
 
       _raf(() => inputElementRef.current?.focus())
     },
-    [openButtonProps, handleDispatchOpen],
+    [openButtonProps, dispatchOpen],
   )
 
   const openButtonNode = useMemo(


### PR DESCRIPTION
This PR introduces a new prop to the Autocomplete component, `openOnFocus`. This let's you open the popover immediately by clicking on the input field. 