### PR TITLE
fix(tooltip): regression where hover to open stops working

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 5.0.0(semantic-release@24.0.0(typescript@5.5.3))
       '@sanity/ui-workshop':
         specifier: ^2.0.15
-        version: 2.0.15(@sanity/icons@3.3.0(react@18.3.1))(@sanity/ui@2.6.3(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@20.12.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.30.3)
+        version: 2.0.15(@sanity/icons@3.3.0(react@18.3.1))(@sanity/ui@2.6.5(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@20.12.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.30.3)
       '@storybook/addon-a11y':
         specifier: ^8.2.1
         version: 8.2.1(storybook@8.2.1(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
@@ -1861,8 +1861,8 @@ packages:
       react-dom: ^18
       styled-components: ^5.2 || ^6
 
-  '@sanity/ui@2.6.3':
-    resolution: {integrity: sha512-qyNaIlfRvLQ21Z4+PP61qZ/Rjbk2UqqC/YTS9AmeRvetL9WEuUYFbMrprdKzAAUcWOqabBZVLjrU9F01nDEtmw==}
+  '@sanity/ui@2.6.5':
+    resolution: {integrity: sha512-9IDql5kxx3Rloed8apTHu4soQfgQg7j72vd97IA9g05hjHfpuDWVpwK0P1Yvgb2wQvNYC1IMsyCNpLZTL9fWrw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^18
@@ -6497,7 +6497,7 @@ packages:
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
-      react: ^18.3.1
+      react: '*'
 
   react-element-to-jsx-string@15.0.0:
     resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
@@ -9676,10 +9676,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sanity/ui-workshop@2.0.15(@sanity/icons@3.3.0(react@18.3.1))(@sanity/ui@2.6.3(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@20.12.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.30.3)':
+  '@sanity/ui-workshop@2.0.15(@sanity/icons@3.3.0(react@18.3.1))(@sanity/ui@2.6.5(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@20.12.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.30.3)':
     dependencies:
       '@sanity/icons': 3.3.0(react@18.3.1)
-      '@sanity/ui': 2.6.3(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/ui': 2.6.5(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@vitejs/plugin-react': 4.3.0(vite@5.3.3(@types/node@20.12.7)(terser@5.30.3))
       axe-core: 4.9.1
       cac: 6.7.14
@@ -9709,7 +9709,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@sanity/ui@2.6.3(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@sanity/ui@2.6.5(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sanity/color': 3.0.6
@@ -9721,6 +9721,7 @@ snapshots:
       react-is: 18.3.1
       react-refractor: 2.2.0(react@18.3.1)
       styled-components: 6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      use-effect-event: 1.0.2(react@18.3.1)
 
   '@sec-ant/readable-stream@0.4.1': {}
 

--- a/src/core/primitives/tooltip/tooltip.tsx
+++ b/src/core/primitives/tooltip/tooltip.tsx
@@ -268,6 +268,9 @@ export const Tooltip = forwardRef(function Tooltip(
     [childProp?.props, handleIsOpenChange],
   )
 
+  // Handle closing the tooltip when the mouse leaves the referenceElement
+  useCloseOnMouseLeave({handleIsOpenChange, referenceElement, showTooltip})
+
   // Close when `disabled` changes to `true`
   useEffect(() => {
     if (disabled && showTooltip) handleIsOpenChange(false)
@@ -297,9 +300,6 @@ export const Tooltip = forwardRef(function Tooltip(
       window.removeEventListener('keydown', handleWindowKeyDown)
     }
   }, [handleIsOpenChange, showTooltip])
-
-  // Handle closing the tooltip when the mouse leaves the referenceElement
-  useCloseOnMouseLeave({handleIsOpenChange, referenceElement, showTooltip})
 
   // // Set the max width of the tooltip based on boundaries and portals
   useLayoutEffect(() => {
@@ -446,7 +446,7 @@ function useCloseOnMouseLeave({
   // Since we don't want the `mouseevent` events to be attached and removed if the `referenceElement` is changed
   // we use a "effect event" (https://19.react.dev/learn/separating-events-from-effects#reading-latest-props-and-state-with-effect-events)
   // in order to always see the latest `referenceElement` value inside the event handler itself.
-  const onMouseMove = useEffectEvent((target: EventTarget | null) => {
+  const onMouseMove = useEffectEvent((target: EventTarget | null, teardown: () => void) => {
     if (!referenceElement) return
 
     const isHoveringReference =
@@ -454,6 +454,8 @@ function useCloseOnMouseLeave({
 
     if (!isHoveringReference) {
       handleIsOpenChange(false)
+      // Allow removing the event listener eagerly, to avoid race conditions
+      teardown()
     }
   })
 
@@ -464,7 +466,7 @@ function useCloseOnMouseLeave({
     if (!showTooltip) return
 
     const handleMouseMove = (event: MouseEvent) => {
-      onMouseMove(event.target)
+      onMouseMove(event.target, () => window.removeEventListener('mousemove', handleMouseMove))
     }
 
     window.addEventListener('mousemove', handleMouseMove)


### PR DESCRIPTION
Properly fixes the hover regressions introduced in #1369, causing studio [tests to fail](https://github.com/sanity-io/sanity/actions/runs/9892053091/job/27325213848?pr=7136), which #1370 attempted to resolve but didn't.

Here's a video demonstrating that moving between tooltips [last worked](https://sanity-ui-workshop-eiaiwcfyu.sanity.build/primitives/tooltip/props?scheme=light) before #1369 merged, how it [stopped working](https://sanity-ui-workshop-git-fix-tooltip-layout-trashing.sanity.build/primitives/tooltip/props?scheme=light), and finally [that it's working again in this PR](https://sanity-ui-workshop-git-fix-tooltip-mousemove-regression.sanity.build/primitives/tooltip/props?scheme=light):

https://github.com/sanity-io/ui/assets/81981/5970be76-9ce0-4dfa-8337-556fcc4f9538

The root cause is that I didn't understand the significance of [eagerly removing the `mousemove` event listener (line 303)](https://github.com/sanity-io/ui/blob/3351fa234dae215816b0409a02d23f9c80c91fda/src/core/primitives/tooltip/tooltip.tsx#L303) in the original code: 
https://github.com/sanity-io/ui/blob/3351fa234dae215816b0409a02d23f9c80c91fda/src/core/primitives/tooltip/tooltip.tsx#L288-L312
and assumed it was there by mistake.
[It's clearly very intentional and I've added a comment so that others don't make the same assumption in the future.](https://github.com/sanity-io/ui/blob/34d2c4ec4e6f9b3ef9936c895c28464ef0a0d74a/src/core/primitives/tooltip/tooltip.tsx#L457)