### PR TITLE
refactor: ensure global scoped context has stable symbol prefixes

### DIFF
--- a/src/core/components/dialog/dialogContext.ts
+++ b/src/core/components/dialog/dialogContext.ts
@@ -11,11 +11,10 @@ export interface DialogContextValue {
   zOffset?: number | number[]
 }
 
-const key = Symbol.for('@sanity/ui/context/dialog')
-
 /**
  * @internal
  */
-export const DialogContext = createGlobalScopedContext<DialogContextValue>(key, {
-  version: 0.0,
-})
+export const DialogContext = createGlobalScopedContext<DialogContextValue>(
+  '@sanity/ui/context/dialog',
+  {version: 0.0},
+)

--- a/src/core/components/menu/menuContext.ts
+++ b/src/core/components/menu/menuContext.ts
@@ -23,6 +23,7 @@ export interface MenuContextValue {
   onMouseLeave: (event: React.MouseEvent<HTMLElement>) => void
 }
 
-const key = Symbol.for('@sanity/ui/context/menu')
-
-export const MenuContext = createGlobalScopedContext<MenuContextValue | null>(key, null)
+export const MenuContext = createGlobalScopedContext<MenuContextValue | null>(
+  '@sanity/ui/context/menu',
+  null,
+)

--- a/src/core/components/toast/toastContext.ts
+++ b/src/core/components/toast/toastContext.ts
@@ -1,6 +1,7 @@
 import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {ToastContextValue} from './types'
 
-const key = Symbol.for('@sanity/ui/context/toast')
-
-export const ToastContext = createGlobalScopedContext<ToastContextValue | null>(key, null)
+export const ToastContext = createGlobalScopedContext<ToastContextValue | null>(
+  '@sanity/ui/context/toast',
+  null,
+)

--- a/src/core/components/tree/treeContext.ts
+++ b/src/core/components/tree/treeContext.ts
@@ -1,9 +1,10 @@
 import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {TreeContextValue} from './types'
 
-const key = Symbol.for('@sanity/ui/context/tree')
-
 /**
  * @internal
  */
-export const TreeContext = createGlobalScopedContext<TreeContextValue | null>(key, null)
+export const TreeContext = createGlobalScopedContext<TreeContextValue | null>(
+  '@sanity/ui/context/tree',
+  null,
+)

--- a/src/core/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupContext.tsx
+++ b/src/core/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupContext.tsx
@@ -1,10 +1,11 @@
 import {createGlobalScopedContext} from '../../../lib/createGlobalScopedContext'
 import {TooltipDelayGroupContextValue} from './types'
 
-const key = Symbol.for('@sanity/ui/context/tooltipDelayGroup')
-
 /**
  * @beta
  */
 export const TooltipDelayGroupContext =
-  createGlobalScopedContext<TooltipDelayGroupContextValue | null>(key, null)
+  createGlobalScopedContext<TooltipDelayGroupContextValue | null>(
+    '@sanity/ui/context/tooltipDelayGroup',
+    null,
+  )

--- a/src/core/theme/themeContext.ts
+++ b/src/core/theme/themeContext.ts
@@ -1,9 +1,10 @@
 import {createGlobalScopedContext} from '../lib/createGlobalScopedContext'
 import {ThemeContextValue} from './types'
 
-const key = Symbol.for('@sanity/ui/context/theme')
-
 /**
  * @internal
  */
-export const ThemeContext = createGlobalScopedContext<ThemeContextValue | null>(key, null)
+export const ThemeContext = createGlobalScopedContext<ThemeContextValue | null>(
+  '@sanity/ui/context/theme',
+  null,
+)

--- a/src/core/utils/boundaryElement/boundaryElementContext.ts
+++ b/src/core/utils/boundaryElement/boundaryElementContext.ts
@@ -1,9 +1,7 @@
 import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {BoundaryElementContextValue} from './types'
 
-const key = Symbol.for('@sanity/ui/context/boundaryElement')
-
 export const BoundaryElementContext = createGlobalScopedContext<BoundaryElementContextValue | null>(
-  key,
+  '@sanity/ui/context/boundaryElement',
   null,
 )

--- a/src/core/utils/layer/layerContext.ts
+++ b/src/core/utils/layer/layerContext.ts
@@ -1,6 +1,7 @@
 import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {LayerContextValue} from './types'
 
-const key = Symbol.for('@sanity/ui/context/layer')
-
-export const LayerContext = createGlobalScopedContext<LayerContextValue | null>(key, null)
+export const LayerContext = createGlobalScopedContext<LayerContextValue | null>(
+  '@sanity/ui/context/layer',
+  null,
+)

--- a/src/core/utils/portal/portalContext.ts
+++ b/src/core/utils/portal/portalContext.ts
@@ -2,8 +2,8 @@ import {createGlobalScopedContext} from '../../lib/createGlobalScopedContext'
 import {globalScope} from '../../lib/globalScope'
 import {PortalContextValue} from './types'
 
-const key = Symbol.for('@sanity/ui/context/portal')
-const elementKey = Symbol.for('@sanity/ui/context/portal/element')
+const key = '@sanity/ui/context/portal'
+const elementKey = Symbol.for(`${key}/element`)
 
 globalScope[elementKey] = null
 


### PR DESCRIPTION
Split from #1368. Refactors contexts that are globally scoped to ensure that a specific string prefix are used for the symbols.
[Also adds more context to why global scoped contexts are used.](https://github.com/sanity-io/ui/blob/05b12f43d32fd25299eeb295837ef720a5f34e62/src/core/lib/createGlobalScopedContext.ts#L1-L9)