### PR TITLE
feat(useClickOutside): support react refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/ui",
-  "version": "2.7.0",
+  "version": "2.7.1-canary.2",
   "keywords": [
     "sanity",
     "ui",

--- a/src/core/components/dialog/dialog.tsx
+++ b/src/core/components/dialog/dialog.tsx
@@ -216,21 +216,18 @@ const DialogCard = forwardRef(function DialogCard(
   )
 
   useClickOutside(
-    useCallback(
-      (event: MouseEvent) => {
-        if (!isTopLayer || !onClickOutside) return
+    (event: MouseEvent) => {
+      if (!isTopLayer || !onClickOutside) return
 
-        const target = event.target as Node | null
+      const target = event.target as Node | null
 
-        if (target && !isTargetWithinScope(boundaryElement, portalElement, target)) {
-          // Ignore clicks outside of the scope
-          return
-        }
+      if (target && !isTargetWithinScope(boundaryElement, portalElement, target)) {
+        // Ignore clicks outside of the scope
+        return
+      }
 
-        onClickOutside()
-      },
-      [boundaryElement, isTopLayer, onClickOutside, portalElement],
-    ),
+      onClickOutside()
+    },
     [rootElement],
   )
 

--- a/src/core/components/menu/menu.tsx
+++ b/src/core/components/menu/menu.tsx
@@ -93,13 +93,7 @@ export const Menu = forwardRef(function Menu(
   }, [activeIndex, onItemSelect])
 
   // Close menu when clicking outside
-  useClickOutside(
-    useCallback(
-      (event) => isTopLayer && onClickOutside && onClickOutside(event),
-      [isTopLayer, onClickOutside],
-    ),
-    [rootElement],
-  )
+  useClickOutside((event) => isTopLayer && onClickOutside && onClickOutside(event), [rootElement])
 
   // Close menu when pressing Escape
   useGlobalKeyDown(

--- a/src/core/primitives/popover/__workshop__/AlignedStory.tsx
+++ b/src/core/primitives/popover/__workshop__/AlignedStory.tsx
@@ -1,7 +1,7 @@
 import {EllipsisVerticalIcon} from '@sanity/icons'
 import {Button, Card, Flex, Popover, Text, useClickOutside} from '@sanity/ui'
 import {useBoolean, useSelect} from '@sanity/ui-workshop'
-import {useCallback, useState} from 'react'
+import {useCallback, useRef, useState} from 'react'
 import {
   WORKSHOP_FLEX_ALIGN_OPTIONS,
   WORKSHOP_FLEX_JUSTIFY_OPTIONS,
@@ -20,8 +20,8 @@ export default function AlignedStory() {
 
   const [open, setOpen] = useState(false)
   const [boundaryElement, setBoundaryElement] = useState<HTMLDivElement | null>(null)
-  const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
-  const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
+  const buttonElementRef = useRef<HTMLButtonElement | null>(null)
+  const popoverElementRef = useRef<HTMLDivElement | null>(null)
 
   const content = (
     <Text>
@@ -39,9 +39,11 @@ export default function AlignedStory() {
   )
 
   const handleToggleOpen = useCallback(() => setOpen((v) => !v), [])
-  const handleClose = useCallback(() => setOpen(false), [])
 
-  useClickOutside(handleClose, [buttonElement, popoverElement])
+  useClickOutside(
+    () => setOpen(false),
+    () => [buttonElementRef.current, popoverElementRef.current],
+  )
 
   return (
     <Card height="fill" padding={[4, 5, 6]} sizing="border" tone="transparent">
@@ -56,14 +58,14 @@ export default function AlignedStory() {
             padding={3}
             portal={portal}
             placement={placement}
-            ref={setPopoverElement}
+            ref={popoverElementRef}
             width={width}
           >
             <Button
               icon={EllipsisVerticalIcon}
               mode="bleed"
               onClick={handleToggleOpen}
-              ref={setButtonElement}
+              ref={buttonElementRef}
               selected={open}
             />
           </Popover>


### PR DESCRIPTION
The `useClickOutside` hook is rewritten [internally to use `useEffectEvent`](https://www.npmjs.com/package/use-effect-event), which means it's no longer necessary to wrap the handler in a `useCallback`:

```diff
 useClickOutside(
-    useCallback(
-     (event) => onClickOutside && onClickOutside(event),
-     [isTopLayer, onClickOutside],
-   ),
+   (event) => onClickOutside && onClickOutside(event)
    [rootElement],
 )
```

It also allows a new API where the `elements` and `boundaryElement` can use functions which allows safely using `React.useRef` instead of requiring ref callbacks to use `useState`:
```diff
-const [buttonElement, setButtonElement] = useState(null)
+const buttonRef = useRef(null)

useClickOutside(
  event => setOpen(false),
- [buttonElement]
+ () => [buttonRef.current]
)

return <button 
- ref={setButton}
+ ref={buttonRef}
/>
```

There are 3 components in `@sanity/ui` that uses `useClickOutside` internally:
- `<Breadcrumbs />`
- `<Menu />`
- `<Dialog />`


They will be migrated to the new API in separate PRs.

There are 2 custom hooks in `sanity` that will be replaced with the new API:
- https://github.com/sanity-io/sanity/blob/8805315cbcb8c9068540c90afb039052fb411c59/packages/sanity/src/core/form/hooks/useOnClickOutside.ts#L7
- https://github.com/sanity-io/sanity/blob/8805315cbcb8c9068540c90afb039052fb411c59/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/utils/useOnClickOutside.ts#L4