### PR TITLE
fix: revert `useClickOutside` behaviour in dialog & menu

### DIFF
--- a/src/core/components/dialog/dialog.tsx
+++ b/src/core/components/dialog/dialog.tsx
@@ -216,18 +216,21 @@ const DialogCard = forwardRef(function DialogCard(
   )
 
   useClickOutside(
-    (event: MouseEvent) => {
-      if (!isTopLayer || !onClickOutside) return
+    useCallback(
+      (event) => {
+        if (!isTopLayer || !onClickOutside) return
 
-      const target = event.target as Node | null
+        const target = event.target as Node | null
 
-      if (target && !isTargetWithinScope(boundaryElement, portalElement, target)) {
-        // Ignore clicks outside of the scope
-        return
-      }
+        if (target && !isTargetWithinScope(boundaryElement, portalElement, target)) {
+          // Ignore clicks outside of the scope
+          return
+        }
 
-      onClickOutside()
-    },
+        onClickOutside()
+      },
+      [boundaryElement, isTopLayer, onClickOutside, portalElement],
+    ),
     [rootElement],
   )
 

--- a/src/core/components/menu/menu.tsx
+++ b/src/core/components/menu/menu.tsx
@@ -93,7 +93,13 @@ export const Menu = forwardRef(function Menu(
   }, [activeIndex, onItemSelect])
 
   // Close menu when clicking outside
-  useClickOutside((event) => isTopLayer && onClickOutside && onClickOutside(event), [rootElement])
+  useClickOutside(
+    useCallback(
+      (event) => isTopLayer && onClickOutside && onClickOutside(event),
+      [isTopLayer, onClickOutside],
+    ),
+    [rootElement],
+  )
 
   // Close menu when pressing Escape
   useGlobalKeyDown(


### PR DESCRIPTION
While restoring `useClickOutside` in #1391, I forgot to restore how `menu.tsx` and `dialog.tsx` wrapped the handler in a `useCallback` in #1390.

This is out of abundance of caution, AFAIK these changes haven't caused regression bugs in prod.