### PR TITLE
fix(useClickOutsideEvent): implement `useDebugValue` to report enabled status

### DIFF
--- a/src/core/components/dialog/__workshop__/nested.tsx
+++ b/src/core/components/dialog/__workshop__/nested.tsx
@@ -20,28 +20,38 @@ export default function NestedStory() {
   return (
     <LayerProvider>
       {open1 && (
-        <Dialog cardShadow={1} header="Dialog 1" id="dialog1">
+        <Dialog animate cardShadow={1} header="Dialog 1" id="dialog1">
           <Box padding={4}>
             <Button onClick={() => setOpen2(true)} ref={dialog2Button} text="Open Dialog 2" />
           </Box>
 
           {open2 && (
-            <Dialog cardShadow={2} header="Dialog 2" id="dialog2" onClose={() => setOpen2(false)}>
+            <Dialog
+              animate
+              cardShadow={2}
+              header="Dialog 2"
+              id="dialog2"
+              onClose={() => setOpen2(false)}
+              onClickOutside={() => setOpen2(false)}
+            >
               <Box padding={4}>
                 <Button onClick={() => setOpen3(true)} ref={dialog3Button} text="Open Dialog 3" />
               </Box>
 
               {open3 && (
                 <Dialog
+                  animate
                   cardShadow={4}
                   header="Dialog 3"
                   id="dialog3"
                   onClose={() => setOpen3(false)}
+                  onClickOutside={() => setOpen3(false)}
                 >
                   <Box padding={4}>
                     <MenuButton
                       button={<Button text="Test" />}
                       id="menu3"
+                      popover={{animate: true}}
                       menu={
                         <Menu>
                           <MenuItem text="Test" />

--- a/src/core/hooks/useClickOutsideEvent.ts
+++ b/src/core/hooks/useClickOutsideEvent.ts
@@ -1,4 +1,4 @@
-import {useEffect} from 'react'
+import {useDebugValue, useEffect} from 'react'
 import {useEffectEvent} from 'use-effect-event'
 import {EMPTY_ARRAY} from '../constants'
 
@@ -69,4 +69,6 @@ export function useClickOutsideEvent(
       document.removeEventListener('mousedown', handleEvent)
     }
   }, [hasListener, onEvent])
+
+  useDebugValue(listener ? 'MouseDown On' : 'MouseDown Off')
 }


### PR DESCRIPTION
The `useClickOutsideEvent` allows you to decide when it's active or not, by either returning a handler, or `false | undefined`.

The `<DialogCard>` component uses this to make sure that when dialogs are nested and a `onClickOutside` prop are given, only the top-most dialog implements the outside click event:
```tsx
  useClickOutsideEvent(
    isTopLayer &&
      onClickOutside &&
      ((event) => {
        const target = event.target as Node | null

        if (target && !isTargetWithinScope(boundaryElement, portalElement, target)) {
          // Ignore clicks outside of the scope
          return
        }

        onClickOutside()
      }),
    () => [ref.current],
  )
```

When inspecting `<DialogCard>` in React DevTools there isn't a way to see if the first argument were a event handler or `false`, no matter the hook arguments all you'll see is:
<img width="248" alt="image" src="https://github.com/user-attachments/assets/1969202e-a115-4f3f-b0bd-4991048f795f">
You can't inspect hook arguments like you can component props.


By implementing `useDebugValue` we can solve this though, and it becomes much easier to know if the hook is setup correctly when the handler is set based on dynamic conditions:


https://github.com/user-attachments/assets/96f86d03-b3c7-4608-a103-86147e3ecda0

