### PR TITLE
fix(MenuGroup): reduce rerenders when opening groups

### DIFF
--- a/src/core/components/menu/useMenuController.ts
+++ b/src/core/components/menu/useMenuController.ts
@@ -184,7 +184,7 @@ export function useMenuController(props: {
   useEffect(() => {
     if (!mounted) return
 
-    const rafId = window.requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       if (activeIndex === -1) {
         if (shouldFocus === 'first') {
           const focusableElements = _getFocusableElements(elementsRef.current)
@@ -194,7 +194,6 @@ export function useMenuController(props: {
             const currentIndex = elementsRef.current.indexOf(el)
 
             setActiveIndex(currentIndex)
-            activeIndexRef.current = currentIndex
           }
         }
 
@@ -206,7 +205,6 @@ export function useMenuController(props: {
             const currentIndex = elementsRef.current.indexOf(el)
 
             setActiveIndex(currentIndex)
-            activeIndexRef.current = currentIndex
           }
         }
 
@@ -218,9 +216,7 @@ export function useMenuController(props: {
       element?.focus()
     })
 
-    return () => {
-      window.cancelAnimationFrame(rafId)
-    }
+    return () => cancelAnimationFrame(rafId)
   }, [activeIndex, mounted, setActiveIndex, shouldFocus])
 
   return {

--- a/src/core/components/toast/styles.ts
+++ b/src/core/components/toast/styles.ts
@@ -14,7 +14,7 @@ const loadingAnimation = keyframes`
   }
   100% {
     width: 100%;
-  } 
+  }
 `
 
 const LOADING_BAR_HEIGHT = 2

--- a/src/core/hooks/useClickOutsideEvent.ts
+++ b/src/core/hooks/useClickOutsideEvent.ts
@@ -35,15 +35,13 @@ export function useClickOutsideEvent(
       return
     }
 
-    const resolvedBoundaryElement =
-      typeof boundaryElement === 'function' ? boundaryElement() : boundaryElement
+    const resolvedBoundaryElement = boundaryElement?.()
 
     if (resolvedBoundaryElement && !resolvedBoundaryElement.contains(target)) {
       return
     }
 
-    const resolvedElements = Array.isArray(elementsArg) ? elementsArg : elementsArg()
-    const elements = resolvedElements.flat()
+    const elements = elementsArg().flat()
 
     for (const el of elements) {
       if (!el) continue


### PR DESCRIPTION
Also removes leftover logic from `useClickOutsideEvent` from after the split from `useClickOutside`.