### PR TITLE
fix: add `displayName` to all components to improve debugging

### DIFF
--- a/src/core/components/autocomplete/autocomplete.tsx
+++ b/src/core/components/autocomplete/autocomplete.tsx
@@ -691,6 +691,8 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
   )
 })
 
+InnerAutocomplete.displayName = 'ForwardRef(Autocomplete)'
+
 /**
  * The Autocomplete component is typically used for search components.
  * It consists of a text input for writing a query, and properties for rendering suggestions.

--- a/src/core/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/core/components/breadcrumbs/breadcrumbs.tsx
@@ -95,3 +95,4 @@ export const Breadcrumbs = forwardRef(function Breadcrumbs(
     </Root>
   )
 })
+Breadcrumbs.displayName = 'ForwardRef(Breadcrumbs)'

--- a/src/core/components/dialog/dialog.tsx
+++ b/src/core/components/dialog/dialog.tsx
@@ -276,6 +276,8 @@ const DialogCard = forwardRef(function DialogCard(
   )
 })
 
+DialogCard.displayName = 'ForwardRef(DialogCard)'
+
 /**
  * The Dialog component.
  *
@@ -424,3 +426,4 @@ export const Dialog = forwardRef(function Dialog(
     </Portal>
   )
 })
+Dialog.displayName = 'ForwardRef(Dialog)'

--- a/src/core/components/dialog/dialogProvider.tsx
+++ b/src/core/components/dialog/dialogProvider.tsx
@@ -30,3 +30,5 @@ export function DialogProvider(props: DialogProviderProps): React.ReactElement {
 
   return <DialogContext.Provider value={contextValue}>{children}</DialogContext.Provider>
 }
+
+DialogProvider.displayName = 'DialogProvider'

--- a/src/core/components/hotkeys/hotkeys.tsx
+++ b/src/core/components/hotkeys/hotkeys.tsx
@@ -58,3 +58,4 @@ export const Hotkeys = forwardRef(function Hotkeys(
     </Root>
   )
 })
+Hotkeys.displayName = 'ForwardRef(Hotkeys)'

--- a/src/core/components/menu/menu.tsx
+++ b/src/core/components/menu/menu.tsx
@@ -169,3 +169,4 @@ export const Menu = forwardRef(function Menu(
     </MenuContext.Provider>
   )
 })
+Menu.displayName = 'ForwardRef(Menu)'

--- a/src/core/components/menu/menuButton.tsx
+++ b/src/core/components/menu/menuButton.tsx
@@ -286,3 +286,4 @@ export const MenuButton = forwardRef(function MenuButton(
     </Popover>
   )
 })
+MenuButton.displayName = 'ForwardRef(MenuButton)'

--- a/src/core/components/menu/menuDivider.ts
+++ b/src/core/components/menu/menuDivider.ts
@@ -9,3 +9,4 @@ export const MenuDivider = styled.hr`
   background: var(--card-hairline-soft-color);
   margin: 0;
 `
+MenuDivider.displayName = 'MenuDivider'

--- a/src/core/components/menu/menuGroup.tsx
+++ b/src/core/components/menu/menuGroup.tsx
@@ -198,3 +198,5 @@ export function MenuGroup(
     </Popover>
   )
 }
+
+MenuGroup.displayName = 'MenuGroup'

--- a/src/core/components/menu/menuItem.tsx
+++ b/src/core/components/menu/menuItem.tsx
@@ -175,3 +175,4 @@ export const MenuItem = forwardRef(function MenuItem(
     </Selectable>
   )
 })
+MenuItem.displayName = 'ForwardRef(MenuItem)'

--- a/src/core/components/skeleton/skeleton.tsx
+++ b/src/core/components/skeleton/skeleton.tsx
@@ -55,3 +55,4 @@ export const Skeleton = forwardRef(function Skeleton(
     />
   )
 })
+Skeleton.displayName = 'ForwardRef(Skeleton)'

--- a/src/core/components/skeleton/textSkeleton.tsx
+++ b/src/core/components/skeleton/textSkeleton.tsx
@@ -71,6 +71,7 @@ export const TextSkeleton = forwardRef(function TextSkeleton(
 
   return <Root {...restProps} $size={$size} ref={ref} $style="text" />
 })
+TextSkeleton.displayName = 'ForwardRef(TextSkeleton)'
 
 /**
  * This API might change. DO NOT USE IN PRODUCTION.
@@ -86,6 +87,7 @@ export const LabelSkeleton = forwardRef(function TextSkeleton(
 
   return <Root {...restProps} $size={$size} ref={ref} $style="label" />
 })
+LabelSkeleton.displayName = 'ForwardRef(LabelSkeleton)'
 
 /**
  * This API might change. DO NOT USE IN PRODUCTION.
@@ -101,6 +103,7 @@ export const HeadingSkeleton = forwardRef(function TextSkeleton(
 
   return <Root {...restProps} $size={$size} ref={ref} $style="heading" />
 })
+HeadingSkeleton.displayName = 'ForwardRef(HeadingSkeleton)'
 
 /**
  * This API might change. DO NOT USE IN PRODUCTION.
@@ -116,3 +119,4 @@ export const CodeSkeleton = forwardRef(function TextSkeleton(
 
   return <Root {...restProps} $size={$size} ref={ref} $style="code" />
 })
+CodeSkeleton.displayName = 'ForwardRef(CodeSkeleton)'

--- a/src/core/components/tab/tab.tsx
+++ b/src/core/components/tab/tab.tsx
@@ -97,3 +97,4 @@ export const Tab = forwardRef(function Tab(
     />
   )
 })
+Tab.displayName = 'ForwardRef(Tab)'

--- a/src/core/components/tab/tabList.tsx
+++ b/src/core/components/tab/tabList.tsx
@@ -74,3 +74,4 @@ export const TabList = forwardRef(function TabList(
     </CustomInline>
   )
 })
+TabList.displayName = 'ForwardRef(TabList)'

--- a/src/core/components/tab/tabPanel.tsx
+++ b/src/core/components/tab/tabPanel.tsx
@@ -35,3 +35,4 @@ export const TabPanel = forwardRef(function TabPanel(
     </Box>
   )
 })
+TabPanel.displayName = 'ForwardRef(TabPanel)'

--- a/src/core/components/toast/toast.tsx
+++ b/src/core/components/toast/toast.tsx
@@ -103,3 +103,5 @@ export function Toast(
     </Root>
   )
 }
+
+Toast.displayName = 'Toast'

--- a/src/core/components/toast/toastProvider.tsx
+++ b/src/core/components/toast/toastProvider.tsx
@@ -189,3 +189,5 @@ export function ToastProvider(props: ToastProviderProps): React.ReactElement {
     </ToastContext.Provider>
   )
 }
+
+ToastProvider.displayName = 'ToastProvider'

--- a/src/core/components/tree/tree.tsx
+++ b/src/core/components/tree/tree.tsx
@@ -233,5 +233,4 @@ export const Tree = memo(
     )
   }),
 )
-
-Tree.displayName = 'Tree'
+Tree.displayName = 'Memo(ForwardRef(Tree))'

--- a/src/core/components/tree/treeItem.tsx
+++ b/src/core/components/tree/treeItem.tsx
@@ -201,3 +201,4 @@ export const TreeItem = memo(function TreeItem(
     </Root>
   )
 })
+TreeItem.displayName = 'Memo(TreeItem)'

--- a/src/core/primitives/_selectable/selectable.tsx
+++ b/src/core/primitives/_selectable/selectable.tsx
@@ -11,3 +11,4 @@ export const Selectable = styled(Box)<SelectableStyleProps & ResponsiveRadiusSty
   selectableBaseStyle,
   selectableColorStyle,
 )
+Selectable.displayName = 'Selectable'

--- a/src/core/primitives/avatar/avatar.tsx
+++ b/src/core/primitives/avatar/avatar.tsx
@@ -194,3 +194,4 @@ export const Avatar = forwardRef(function Avatar(
     </Root>
   )
 })
+Avatar.displayName = 'ForwardRef(Avatar)'

--- a/src/core/primitives/avatar/avatarCounter.tsx
+++ b/src/core/primitives/avatar/avatarCounter.tsx
@@ -90,3 +90,4 @@ export const AvatarCounter = forwardRef(function AvatarCounter(
     </Root>
   )
 })
+AvatarCounter.displayName = 'ForwardRef(AvatarCounter)'

--- a/src/core/primitives/avatar/avatarStack.tsx
+++ b/src/core/primitives/avatar/avatarStack.tsx
@@ -97,3 +97,4 @@ export const AvatarStack = forwardRef(function AvatarStack(
     </Root>
   )
 })
+AvatarStack.displayName = 'ForwardRef(AvatarStack)'

--- a/src/core/primitives/badge/badge.tsx
+++ b/src/core/primitives/badge/badge.tsx
@@ -58,3 +58,4 @@ export const Badge = forwardRef(function Badge(
     </Root>
   )
 })
+Badge.displayName = 'ForwardRef(Badge)'

--- a/src/core/primitives/box/box.tsx
+++ b/src/core/primitives/box/box.tsx
@@ -127,3 +127,4 @@ export const Box = forwardRef(function Box(
     </Root>
   )
 })
+Box.displayName = 'ForwardRef(Box)'

--- a/src/core/primitives/button/button.tsx
+++ b/src/core/primitives/button/button.tsx
@@ -178,3 +178,4 @@ export const Button = forwardRef(function Button(
     </Root>
   )
 })
+Button.displayName = 'ForwardRef(Button)'

--- a/src/core/primitives/card/card.tsx
+++ b/src/core/primitives/card/card.tsx
@@ -112,3 +112,4 @@ export const Card = forwardRef(function Card(
     </ThemeColorProvider>
   )
 })
+Card.displayName = 'ForwardRef(Card)'

--- a/src/core/primitives/checkbox/checkbox.tsx
+++ b/src/core/primitives/checkbox/checkbox.tsx
@@ -69,3 +69,4 @@ export const Checkbox = forwardRef(function Checkbox(
     </Root>
   )
 })
+Checkbox.displayName = 'ForwardRef(Checkbox)'

--- a/src/core/primitives/code/code.tsx
+++ b/src/core/primitives/code/code.tsx
@@ -37,3 +37,4 @@ export const Code = forwardRef(function Code(
     </Root>
   )
 })
+Code.displayName = 'ForwardRef(Code)'

--- a/src/core/primitives/container/container.tsx
+++ b/src/core/primitives/container/container.tsx
@@ -37,3 +37,4 @@ export const Container = forwardRef(function Container(
     />
   )
 })
+Container.displayName = 'ForwardRef(Container)'

--- a/src/core/primitives/flex/flex.tsx
+++ b/src/core/primitives/flex/flex.tsx
@@ -50,3 +50,4 @@ export const Flex = forwardRef(function Flex(
     />
   )
 })
+Flex.displayName = 'ForwardRef(Flex)'

--- a/src/core/primitives/grid/grid.tsx
+++ b/src/core/primitives/grid/grid.tsx
@@ -44,3 +44,4 @@ export const Grid = forwardRef(function Grid(
     </Root>
   )
 })
+Grid.displayName = 'ForwardRef(Grid)'

--- a/src/core/primitives/heading/heading.tsx
+++ b/src/core/primitives/heading/heading.tsx
@@ -83,3 +83,4 @@ export const Heading = forwardRef(function Heading(
     </Root>
   )
 })
+Heading.displayName = 'ForwardRef(Heading)'

--- a/src/core/primitives/inline/inline.tsx
+++ b/src/core/primitives/inline/inline.tsx
@@ -44,3 +44,4 @@ export const Inline = forwardRef(function Inline(
     </Root>
   )
 })
+Inline.displayName = 'ForwardRef(Inline)'

--- a/src/core/primitives/kbd/kbd.tsx
+++ b/src/core/primitives/kbd/kbd.tsx
@@ -57,3 +57,4 @@ export const KBD = forwardRef(function KBD(
     </Root>
   )
 })
+KBD.displayName = 'ForwardRef(KBD)'

--- a/src/core/primitives/label/label.tsx
+++ b/src/core/primitives/label/label.tsx
@@ -82,3 +82,4 @@ export const Label = forwardRef(function Label(
     </Root>
   )
 })
+Label.displayName = 'ForwardRef(Label)'

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -454,5 +454,4 @@ export const Popover = memo(
     )
   }),
 )
-
-Popover.displayName = 'Popover'
+Popover.displayName = 'Memo(ForwardRef(Popover))'

--- a/src/core/primitives/popover/popoverCard.tsx
+++ b/src/core/primitives/popover/popoverCard.tsx
@@ -152,5 +152,4 @@ export const PopoverCard = memo(
     )
   }),
 )
-
-PopoverCard.displayName = 'PopoverCard'
+PopoverCard.displayName = 'Memo(ForwardRef(PopoverCard))'

--- a/src/core/primitives/radio/radio.tsx
+++ b/src/core/primitives/radio/radio.tsx
@@ -47,3 +47,4 @@ export const Radio = forwardRef(function Radio(
     </Root>
   )
 })
+Radio.displayName = 'ForwardRef(Radio)'

--- a/src/core/primitives/select/select.tsx
+++ b/src/core/primitives/select/select.tsx
@@ -83,3 +83,4 @@ export const Select = forwardRef(function Select(
     </Root>
   )
 })
+Select.displayName = 'ForwardRef(Select)'

--- a/src/core/primitives/spinner/spinner.tsx
+++ b/src/core/primitives/spinner/spinner.tsx
@@ -42,3 +42,4 @@ export const Spinner = forwardRef(function Spinner(
     </Root>
   )
 })
+Spinner.displayName = 'ForwardRef(Spinner)'

--- a/src/core/primitives/stack/stack.tsx
+++ b/src/core/primitives/stack/stack.tsx
@@ -36,3 +36,4 @@ export const Stack = forwardRef(function Stack(
     />
   )
 })
+Stack.displayName = 'ForwardRef(Stack)'

--- a/src/core/primitives/switch/switch.tsx
+++ b/src/core/primitives/switch/switch.tsx
@@ -64,3 +64,4 @@ export const Switch = forwardRef(function Switch(
     </Root>
   )
 })
+Switch.displayName = 'ForwardRef(Switch)'

--- a/src/core/primitives/text/text.tsx
+++ b/src/core/primitives/text/text.tsx
@@ -84,3 +84,4 @@ export const Text = forwardRef(function Text(
     </Root>
   )
 })
+Text.displayName = 'ForwardRef(Text)'

--- a/src/core/primitives/textArea/textArea.tsx
+++ b/src/core/primitives/textArea/textArea.tsx
@@ -115,3 +115,4 @@ export const TextArea = forwardRef(function TextArea(
     </Root>
   )
 })
+TextArea.displayName = 'ForwardRef(TextArea)'

--- a/src/core/primitives/textInput/textInput.tsx
+++ b/src/core/primitives/textInput/textInput.tsx
@@ -384,3 +384,4 @@ export const TextInput = forwardRef(function TextInput(
     </Root>
   )
 })
+TextInput.displayName = 'ForwardRef(TextInput)'

--- a/src/core/primitives/tooltip/tooltip.tsx
+++ b/src/core/primitives/tooltip/tooltip.tsx
@@ -429,6 +429,7 @@ export const Tooltip = forwardRef(function Tooltip(
     </>
   )
 })
+Tooltip.displayName = 'ForwardRef(Tooltip)'
 
 /**
  * As `useEffectEvent` should never be passed to other components or hooks, this custom hook groups together the `useEffectEvent` and the `useEffect` hook using it.

--- a/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/src/core/primitives/tooltip/tooltipCard.tsx
@@ -106,5 +106,4 @@ export const TooltipCard = memo(
     )
   }),
 )
-
-TooltipCard.displayName = 'TooltipCard'
+TooltipCard.displayName = 'Memo(ForwardRef(TooltipCard))'

--- a/src/core/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupProvider.tsx
+++ b/src/core/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupProvider.tsx
@@ -53,3 +53,5 @@ export function TooltipDelayGroupProvider(
     <TooltipDelayGroupContext.Provider value={value}>{children}</TooltipDelayGroupContext.Provider>
   )
 }
+
+TooltipDelayGroupProvider.displayName = 'TooltipDelayGroupProvider'

--- a/src/core/theme/themeColorProvider.tsx
+++ b/src/core/theme/themeColorProvider.tsx
@@ -24,3 +24,5 @@ export function ThemeColorProvider(props: ThemeColorProviderProps): React.ReactE
     </ThemeProvider>
   )
 }
+
+ThemeColorProvider.displayName = 'ThemeColorProvider'

--- a/src/core/theme/themeProvider.tsx
+++ b/src/core/theme/themeProvider.tsx
@@ -59,3 +59,5 @@ export function ThemeProvider(props: ThemeProviderProps): React.ReactElement {
     </ThemeContext.Provider>
   )
 }
+
+ThemeProvider.displayName = 'ThemeProvider'

--- a/src/core/utils/arrow/arrow.tsx
+++ b/src/core/utils/arrow/arrow.tsx
@@ -119,3 +119,4 @@ export const Arrow = forwardRef(function Arrow(
     </Root>
   )
 })
+Arrow.displayName = 'ForwardRef(Arrow)'

--- a/src/core/utils/boundaryElement/boundaryElementProvider.tsx
+++ b/src/core/utils/boundaryElement/boundaryElementProvider.tsx
@@ -19,3 +19,5 @@ export function BoundaryElementProvider(props: BoundaryElementProviderProps): Re
 
   return <BoundaryElementContext.Provider value={value}>{children}</BoundaryElementContext.Provider>
 }
+
+BoundaryElementProvider.displayName = 'BoundaryElementProvider'

--- a/src/core/utils/conditionalWrapper/conditionalWrapper.tsx
+++ b/src/core/utils/conditionalWrapper/conditionalWrapper.tsx
@@ -16,3 +16,5 @@ export function ConditionalWrapper({
 
   return wrapper(children)
 }
+
+ConditionalWrapper.displayName = 'ConditionalWrapper'

--- a/src/core/utils/elementQuery/elementQuery.tsx
+++ b/src/core/utils/elementQuery/elementQuery.tsx
@@ -50,3 +50,4 @@ export const ElementQuery = forwardRef(function ElementQuery(
     </div>
   )
 })
+ElementQuery.displayName = 'ForwardRef(ElementQuery)'

--- a/src/core/utils/layer/layer.tsx
+++ b/src/core/utils/layer/layer.tsx
@@ -88,3 +88,4 @@ export const Layer = forwardRef(function Layer(
     </LayerProvider>
   )
 })
+Layer.displayName = 'ForwardRef(Layer)'

--- a/src/core/utils/layer/layerProvider.tsx
+++ b/src/core/utils/layer/layerProvider.tsx
@@ -105,3 +105,5 @@ export function LayerProvider(props: LayerProviderProps): React.ReactElement {
 
   return <LayerContext.Provider value={value}>{children}</LayerContext.Provider>
 }
+
+LayerProvider.displayName = 'LayerProvider'

--- a/src/core/utils/portal/portal.ts
+++ b/src/core/utils/portal/portal.ts
@@ -27,3 +27,5 @@ export function Portal(props: PortalProps): React.ReactPortal | null {
 
   return createPortal(children, portalElement)
 }
+
+Portal.displayName = 'Portal'

--- a/src/core/utils/portal/portalProvider.tsx
+++ b/src/core/utils/portal/portalProvider.tsx
@@ -42,6 +42,8 @@ export function PortalProvider(props: PortalProviderProps): React.ReactElement {
   return <PortalContext.Provider value={value}>{children}</PortalContext.Provider>
 }
 
+PortalProvider.displayName = 'PortalProvider'
+
 const emptySubscribe = () => () => {}
 
 /**

--- a/src/core/utils/srOnly/srOnly.tsx
+++ b/src/core/utils/srOnly/srOnly.tsx
@@ -33,3 +33,4 @@ export const SrOnly = forwardRef(function SrOnly(
     </Root>
   )
 })
+SrOnly.displayName = 'ForwardRef(SrOnly)'

--- a/src/core/utils/virtualList/virtualList.tsx
+++ b/src/core/utils/virtualList/virtualList.tsx
@@ -167,3 +167,4 @@ export const VirtualList = forwardRef(function VirtualList(
     </Root>
   )
 })
+VirtualList.displayName = 'ForwardRef(VirtualList)'


### PR DESCRIPTION
Just like https://github.com/sanity-io/icons/pull/92, it's really difficult to make sense of component trees in the React DevTools when function names are minified:

<img width="1413" alt="image" src="https://github.com/user-attachments/assets/af1855b8-9640-446f-a957-a8635fa06148">

After display names are manually added life gets much easier, regardless of how the app that uses `@sanity/ui` is bundling its code for production:

<img width="1419" alt="image" src="https://github.com/user-attachments/assets/cb2925e0-ffab-4a99-8f00-bca064de6340">
