### PR TITLE
fix: support React 19

### DIFF
--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   Middleware,
   RootBoundary,
@@ -359,8 +360,7 @@ export const Popover = memo(
       (node: HTMLElement | null) => {
         refs.setReference(node)
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const childRef = (childProp as any)?.ref
+        const childRef = getElementRef(childProp as any)
 
         if (typeof childRef === 'function') {
           childRef(node)
@@ -455,3 +455,29 @@ export const Popover = memo(
   }),
 )
 Popover.displayName = 'Memo(ForwardRef(Popover))'
+
+// Before React 19 accessing `element.props.ref` will throw a warning and suggest using `element.ref`
+// After React 19 accessing `element.ref` does the opposite.
+// https://github.com/facebook/react/pull/28348
+//
+// Access the ref using the method that doesn't yield a warning.
+function getElementRef(element: React.ReactElement) {
+  // React <=18 in DEV
+  let getter = Object.getOwnPropertyDescriptor(element.props, 'ref')?.get
+  let mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning
+
+  if (mayWarn) {
+    return (element as any).ref
+  }
+
+  // React 19 in DEV
+  getter = Object.getOwnPropertyDescriptor(element, 'ref')?.get
+  mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning
+
+  if (mayWarn) {
+    return element.props.ref
+  }
+
+  // Not DEV
+  return element.props.ref || (element as any).ref
+}


### PR DESCRIPTION
Takes care of warnings about `element.ref`:

```
Accessing element.ref was removed in React 19. ref is now a regular prop. It will be removed from the JSX Element type in a future release.
```