### PR TITLE
fix(primitives): button text ellipsis

### DIFF
--- a/src/core/primitives/button/button.tsx
+++ b/src/core/primitives/button/button.tsx
@@ -149,15 +149,17 @@ export const Button = forwardRef(function Button(
             )}
 
             {text && (
-              <Text
-                muted={muted}
-                align={textAlign}
-                size={fontSize}
-                textOverflow="ellipsis"
-                weight={button.textWeight}
-              >
-                {text}
-              </Text>
+              <Box>
+                <Text
+                  muted={muted}
+                  align={textAlign}
+                  size={fontSize}
+                  textOverflow="ellipsis"
+                  weight={button.textWeight}
+                >
+                  {text}
+                </Text>
+              </Box>
             )}
 
             {IconRightComponent && (


### PR DESCRIPTION
### Description

This pull request fixes an issue where text does not truncate with an ellipsis in the button primitive. The issue appears to have been introduced in #1195 when the element wrapping text was removed.

<img width="1246" alt="text-ellipsis" src="https://github.com/user-attachments/assets/dedf8550-58b0-4145-a1c9-64a0eb1320bf">
