### PR TITLE
fix(Dialog): start alignment on dialog header

### DIFF
--- a/src/core/components/dialog/dialog.tsx
+++ b/src/core/components/dialog/dialog.tsx
@@ -241,7 +241,7 @@ const DialogCard = forwardRef(function DialogCard(
         <DialogLayout direction="column">
           {showHeader && (
             <DialogHeader>
-              <Flex align="center" padding={3}>
+              <Flex align="flex-start" padding={3}>
                 <Box flex={1} padding={2}>
                   {header && (
                     <Text id={labelId} size={1} weight="semibold">


### PR DESCRIPTION
Currently with a long title, the Dialog uses `center` which means the close button moves down from the top.
<img width="374" alt="Screenshot 2024-10-30 at 00 29 07" src="https://github.com/user-attachments/assets/6ca83de9-20f6-4509-bae5-f46086a20509">

Now, these elements are `flex-start` so the close button is always the same padding from the top of the dialog
