### PR TITLE
fix(performance): revert auto memoize `Autocomplete`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - run: pnpm install
       - name: Register Problem Matcher for ESLint that handles -f compact and shows warnings and errors inline on PRs
         run: echo "::add-matcher::.github/eslint-compact.json"
-      - run: "pnpm lint -f compact --rule 'no-warning-comments: [off]' --max-warnings 6"
+      - run: "pnpm lint -f compact --rule 'no-warning-comments: [off]' --max-warnings 7"
 
   test:
     needs: [build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - run: pnpm install
       - name: Register Problem Matcher for ESLint that handles -f compact and shows warnings and errors inline on PRs
         run: echo "::add-matcher::.github/eslint-compact.json"
-      - run: "pnpm lint -f compact --rule 'no-warning-comments: [off]' --max-warnings 7"
+      - run: "pnpm lint -f compact --rule 'no-warning-comments: [off]' --max-warnings 10"
 
   test:
     needs: [build]


### PR DESCRIPTION
Reverts sanity-io/ui#1464, it broke keyboard nav somehow in the Studio as reported by the E2E suite: https://github.com/sanity-io/sanity/actions/runs/11742335916/job/32713032284

And manually verified:
https://github.com/user-attachments/assets/96d2edbc-8538-4b60-a36a-e1854615c33c

It's unclear why the E2E tests running on this repo failed to capture the failing test suite 🤔 