### PR TITLE
fix(menu-item): allow setting `role` attribute

### DIFF
--- a/src/core/components/menu/menuItem.tsx
+++ b/src/core/components/menu/menuItem.tsx
@@ -118,6 +118,7 @@ export const MenuItem = forwardRef(function MenuItem(
   return (
     <Selectable
       data-ui="MenuItem"
+      role="menuitem"
       {...restProps}
       aria-pressed={as === 'button' && pressed}
       data-pressed={as !== 'button' && pressed ? '' : undefined}
@@ -133,7 +134,6 @@ export const MenuItem = forwardRef(function MenuItem(
       onMouseEnter={onItemMouseEnter}
       onMouseLeave={onItemMouseLeave}
       ref={setRef}
-      role="menuitem"
       tabIndex={-1}
       type={as === 'button' ? 'button' : undefined}
     >


### PR DESCRIPTION
### Description

This pull request allows setting the `role` attribute on `MenuItem`. While it defaults to `role="menuitem"`, some situations require a different role to ensure proper accessibility, like `role="menuitemradio"`.