### PR TITLE
fix: pin framer-motion

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,6 @@
       "semanticCommitType": "fix",
       "rangeStrategy": "bump"
     }
-  ]
+  ],
+  "ignoreDeps": ["framer-motion"]
 }

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@sanity/color": "^3.0.6",
     "@sanity/icons": "^3.5.7",
     "csstype": "^3.1.3",
-    "framer-motion": "^12.4.2",
+    "framer-motion": "12.4.2",
     "react-compiler-runtime": "19.0.0-beta-30d8a17-20250209",
     "react-refractor": "^2.2.0",
     "use-effect-event": "^1.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       framer-motion:
-        specifier: ^12.4.2
+        specifier: 12.4.2
         version: 12.4.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-compiler-runtime:
         specifier: 19.0.0-beta-30d8a17-20250209


### PR DESCRIPTION
We are seeing that version `12.4.3` of framer-motion is causing this error for all new installs. Pinning the version to a working version until resolved.
<img width="983" alt="Screenshot 2025-02-15 at 16 02 30" src="https://github.com/user-attachments/assets/014718e2-0c1a-4c0e-9d59-92a96e5aabcd" />
