### PR TITLE
fix: use linear timing for toast duration bars

### DIFF
--- a/src/core/components/toast/styles.ts
+++ b/src/core/components/toast/styles.ts
@@ -51,6 +51,9 @@ export function rootStyles(
       animation-name: ${loadingAnimation};
       animation-duration: ${props.$duration}ms;
       animation-fill-mode: both;
+      animation-timing-function: linear;
+      opacity: var(${POPOVER_MOTION_CONTENT_OPACITY_PROPERTY}, 1);
+      will-change: width;
     }
 
     & > * {

--- a/src/core/components/toast/toastProvider.tsx
+++ b/src/core/components/toast/toastProvider.tsx
@@ -57,6 +57,12 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
   const prefersReducedMotion = usePrefersReducedMotion()
   const variants = useMemo<Variants>(
     () => ({
+      /**
+       * These variants makes use of special timing, by using a negative opacity as a starting position,
+       * as well as double opacity as the end position.
+       * The purpose of this is to make the tooltip/popover container appear before the content, and when exiting
+       * we want the content to disappear faster than the container.
+       */
       initial: {
         opacity: 0,
         [POPOVER_MOTION_CONTENT_OPACITY_PROPERTY]: -1,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -25,8 +25,15 @@ export const POPOVER_MOTION_PROPS: {
   exit: Variant
   transition: Transition
 } = {
+  /**
+   * These variants makes use of special timing, by using a negative opacity as a starting position,
+   * as well as double opacity as the end position.
+   * The purpose of this is to make the tooltip/popover container appear before the content, and when exiting
+   * we want the content to disappear faster than the container.
+   */
   initial: {
     opacity: 0.5,
+    // the nagative opacity here, as well as the double opacity further down, are to make the content appear after the backgdrop, and when exiting the content should disappear first.
     [POPOVER_MOTION_CONTENT_OPACITY_PROPERTY as string]: -1,
     scale: 0.97,
     willChange: 'transform',


### PR DESCRIPTION
Changes the timing of the duration bar on toasts so it's linear, and thus predictable, instead of the default timing (which is `animation-timing-function: ease` since we're not defining one).

The `ease` timing slows down both the start of the animation, and the end, quite a bit. It leads to the effect that it's difficult to guess when it's about to close, and how long it'll stay open.

## Before:

Note how it looks like all 4 notifications will close about the same time, even though it's not

https://github.com/user-attachments/assets/2d869210-28e0-4f5f-bca0-06ea27db8f5c


## After:

While now it's clear when they'll close and exactly how long they've been open.


https://github.com/user-attachments/assets/fd5ef4d6-b242-4437-81c8-0bcb29dc54bf


