### PR TITLE
feat: optional support for pointer-blocking popovers

### DIFF
--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -58,13 +58,6 @@ export interface PopoverProps
    */
   animate?: boolean
   arrow?: boolean
-  /**
-   * When true, blocks all pointer interaction with elements beneath the popover until closed.
-   *
-   * @beta
-   * @defaultValue false
-   */
-  blockPointerEvents?: boolean
   /** @deprecated Use `floatingBoundary` and/or `referenceBoundary` instead */
   boundaryElement?: HTMLElement | null
   children?: React.JSX.Element
@@ -93,6 +86,13 @@ export interface PopoverProps
    * @defaultValue false
    */
   matchReferenceWidth?: boolean
+  /**
+   * When true, blocks all pointer interaction with elements beneath the popover until closed.
+   *
+   * @beta
+   * @defaultValue false
+   */
+  modal?: boolean
   open?: boolean
   overflow?: BoxOverflow
   padding?: number | number[]
@@ -139,7 +139,6 @@ export const Popover = memo(
       __unstable_margins: margins = DEFAULT_POPOVER_MARGINS,
       animate: _animate = false,
       arrow: arrowProp = false,
-      blockPointerEvents,
       boundaryElement = boundaryElementContext.element,
       children: childProp,
       constrainSize = false,
@@ -149,6 +148,7 @@ export const Popover = memo(
         DEFAULT_FALLBACK_PLACEMENTS[props.placement ?? 'bottom'],
       matchReferenceWidth,
       floatingBoundary = props.boundaryElement ?? boundaryElementContext.element,
+      modal,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       onActivate,
       open,
@@ -410,7 +410,7 @@ export const Popover = memo(
     const popover = (
       <LayerProvider zOffset={zOffset}>
         {/* Optional transparent blocking overlay at the top-most z-index layer. Must be positioned before the below popover card. */}
-        {blockPointerEvents && <ViewportOverlay />}
+        {modal && <ViewportOverlay />}
 
         <PopoverCard
           {...restProps}

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -27,7 +27,7 @@ import {useArrayProp, useElementSize, useMediaIndex, usePrefersReducedMotion} fr
 import {origin} from '../../middleware/origin'
 import {useTheme_v2} from '../../theme'
 import {BoxOverflow, CardTone, Placement, PopoverMargins} from '../../types'
-import {LayerProps, LayerProvider, Portal, useBoundaryElement} from '../../utils'
+import {LayerProps, LayerProvider, Portal, useBoundaryElement, useLayer} from '../../utils'
 import {getElementRef} from '../../utils/getElementRef'
 import {ResponsiveRadiusProps, ResponsiveShadowProps} from '../types'
 import {
@@ -58,6 +58,13 @@ export interface PopoverProps
    */
   animate?: boolean
   arrow?: boolean
+  /**
+   * When true, blocks all pointer interaction with elements beneath the popover until closed.
+   *
+   * @beta
+   * @defaultValue false
+   */
+  blockPointerEvents?: boolean
   /** @deprecated Use `floatingBoundary` and/or `referenceBoundary` instead */
   boundaryElement?: HTMLElement | null
   children?: React.JSX.Element
@@ -108,6 +115,12 @@ export interface PopoverProps
   width?: PopoverWidth | PopoverWidth[]
 }
 
+const ViewportOverlay = () => {
+  const {zIndex} = useLayer()
+
+  return <div style={{height: '100vh', inset: 0, position: 'fixed', width: '100vw', zIndex}} />
+}
+
 /**
  * The `Popover` component is used to display some content on top of another.
  *
@@ -126,6 +139,7 @@ export const Popover = memo(
       __unstable_margins: margins = DEFAULT_POPOVER_MARGINS,
       animate: _animate = false,
       arrow: arrowProp = false,
+      blockPointerEvents,
       boundaryElement = boundaryElementContext.element,
       children: childProp,
       constrainSize = false,
@@ -395,6 +409,9 @@ export const Popover = memo(
 
     const popover = (
       <LayerProvider zOffset={zOffset}>
+        {/* Optional transparent blocking overlay at the top-most z-index layer. Must be positioned before the below popover card. */}
+        {blockPointerEvents && <ViewportOverlay />}
+
         <PopoverCard
           {...restProps}
           __unstable_margins={margins}

--- a/stories/components/MenuButton.stories.tsx
+++ b/stories/components/MenuButton.stories.tsx
@@ -1,9 +1,16 @@
-import {ClockIcon, CommentIcon, ExpandIcon, SearchIcon} from '@sanity/icons'
+import {
+  ClockIcon,
+  CommentIcon,
+  EllipsisHorizontalIcon,
+  ExpandIcon,
+  LaunchIcon,
+  SearchIcon,
+} from '@sanity/icons'
 import type {Meta, StoryObj} from '@storybook/react'
 import {expect, fn} from '@storybook/test'
 import {userEvent, within} from '@storybook/test'
 import {Menu, MenuButton, MenuDivider, MenuGroup, MenuItem} from '../../src/core/components'
-import {Button, Flex} from '../../src/core/primitives'
+import {Box, Button, Card, Flex, Stack, Text} from '../../src/core/primitives'
 
 const meta: Meta<typeof MenuButton> = {
   args: {
@@ -110,5 +117,83 @@ export const WithSelectedItem: Story = {
 
     // Assertion: <Menu> with a selected item should not be visible when clicking the original <MenuButton> to close
     expect(menu).toBeNull()
+  },
+}
+
+export const PopoverBlockPointerEvents: Story = {
+  args: {
+    menu: (
+      <Menu data-testid="menu">
+        <MenuItem id="menu-item-1" selected text="Search" />
+        <MenuItem id="menu-item-2" text="Clock" />
+        <MenuDivider />
+        <MenuItem id="menu-item-3" text="Comment" />
+        <MenuItem id="menu-item-4" text="Expand" />
+      </Menu>
+    ),
+  },
+  render: (props) => {
+    return (
+      <Stack space={4}>
+        <Flex gap={4} wrap="wrap">
+          <MenuButton
+            {...props}
+            button={<Button data-testid="default-menu-button" text="Default " />}
+          />
+          <MenuButton
+            {...props}
+            button={
+              <Button
+                data-testid="block-pointer-events-menu-button"
+                text="Block pointer events"
+                tone="primary"
+              />
+            }
+            popover={{blockPointerEvents: true, portal: false}}
+          />
+          <MenuButton
+            {...props}
+            button={<Button text="Block pointer events (portalled)" tone="primary" />}
+            popover={{blockPointerEvents: true, portal: true}}
+          />
+          <Button
+            as="a"
+            href="https://www.sanity.io"
+            iconRight={LaunchIcon}
+            mode="ghost"
+            target="_blank"
+            text="Open sanity.io in a new window"
+          />
+        </Flex>
+
+        <Card
+          as="a"
+          border
+          href="https://www.sanity.io"
+          padding={2}
+          radius={3}
+          target="_blank"
+          tone="default"
+        >
+          <Flex align="center" gap={2} justify="space-between">
+            <Box padding={2}>
+              <Text size={1}>Open sanity.io in a new window</Text>
+            </Box>
+            <div
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+              }}
+            >
+              <MenuButton
+                {...props}
+                button={<Button icon={EllipsisHorizontalIcon} mode="bleed" />}
+                popover={{blockPointerEvents: true}}
+              />
+            </div>
+          </Flex>
+        </Card>
+      </Stack>
+    )
   },
 }

--- a/stories/components/MenuButton.stories.tsx
+++ b/stories/components/MenuButton.stories.tsx
@@ -120,7 +120,7 @@ export const WithSelectedItem: Story = {
   },
 }
 
-export const PopoverBlockPointerEvents: Story = {
+export const PopoverModal: Story = {
   args: {
     menu: (
       <Menu data-testid="menu">
@@ -136,25 +136,16 @@ export const PopoverBlockPointerEvents: Story = {
     return (
       <Stack space={4}>
         <Flex gap={4} wrap="wrap">
+          <MenuButton {...props} button={<Button text="Default " />} />
           <MenuButton
             {...props}
-            button={<Button data-testid="default-menu-button" text="Default " />}
+            button={<Button text="Modal popover" tone="primary" />}
+            popover={{modal: true, portal: false}}
           />
           <MenuButton
             {...props}
-            button={
-              <Button
-                data-testid="block-pointer-events-menu-button"
-                text="Block pointer events"
-                tone="primary"
-              />
-            }
-            popover={{blockPointerEvents: true, portal: false}}
-          />
-          <MenuButton
-            {...props}
-            button={<Button text="Block pointer events (portalled)" tone="primary" />}
-            popover={{blockPointerEvents: true, portal: true}}
+            button={<Button text="Modal popover (portalled)" tone="primary" />}
+            popover={{modal: true, portal: true}}
           />
           <Button
             as="a"
@@ -188,7 +179,7 @@ export const PopoverBlockPointerEvents: Story = {
               <MenuButton
                 {...props}
                 button={<Button icon={EllipsisHorizontalIcon} mode="bleed" />}
-                popover={{blockPointerEvents: true}}
+                popover={{modal: true}}
               />
             </div>
           </Flex>


### PR DESCRIPTION
https://github.com/user-attachments/assets/e00d9bd8-f344-4bbf-b389-80cc3fdad634

## Description

This PR adds support for rendering popovers that prevents pointer interaction with all outside elements until closed.

Popovers rendered with `popover={{modal: true}}` will now include a hidden, full viewport overlay that blocks all pointer events. Clicking anywhere in the viewport will then close the popover as normal.

This can be especially useful in interfaces where popovers appear over the top of other interactive elements (such as links), making it much more forgiving for users to close popovers without fear of unwanted side effects. This is the default behaviour for contextual menus in OS X and a number of other popular apps.

As this is opt-in, existing popovers and components that use them (`<MenuButton>`, `<Autocomplete>`) are unaffected.

## What to test

- A [story](https://sanity-ui-storybook-git-feat-blocking-popovers.sanity.dev/?path=/story/components-menubutton--popover-modal) has been created with an example scenario. Compare behaviour between the default menu button and those with blocked pointer events. Does it feel intuitive to you?
- ~~`blockPointerEvents` may not be the best name for this, open to suggestions!~~ Renamed to `modal` at Marius' request
