### PR TITLE
fix: use stricter type definition for children of <Code>

### DIFF
--- a/src/core/primitives/code/__workshop__/opticalAlignment.tsx
+++ b/src/core/primitives/code/__workshop__/opticalAlignment.tsx
@@ -1,4 +1,3 @@
-import {AddCircleIcon} from '@sanity/icons'
 import {Box, Card, Code, Flex, Stack} from '@sanity/ui'
 
 export default function OpticalAlignment() {
@@ -37,9 +36,7 @@ export default function OpticalAlignment() {
 
         <Flex>
           <Card padding={2} scheme="dark">
-            <Code>
-              <AddCircleIcon />
-            </Code>
+            <Code>{`<AddCircleIcon />`}</Code>
           </Card>
         </Flex>
       </Stack>


### PR DESCRIPTION
Currently, the `<Code>` component accepts any valid `ReactNode`, which means this is works compile time:
```tsx
<Code><b>Ooops</b></Code>
```

But breaks runtime, as the Code component expects `children` to be stringifiable, coerces it to a string runtime and thus render:
```
[object Object]
```

This lead to error messages in the studio showing `[object Object]` instead of the error message, see for example the bug report over at https://github.com/sanity-io/sanity/issues/8712

This fixes the issue by changing the `children` type to something that can safely be stringified, and also considering that `children` can be iterable (e.g. `<Code>The number is {42}</Code>` will make `children` iterable).

Note: _incidentally_, the above snipped actually used to work prior to lazy loading refractor (783942ab82e732a4e258e0d35dff44d0e5d16ca1), because before then, we'd only stringify if refractor was loaded and `language` was passed: https://github.com/sanity-io/ui/blob/7a0231bdc05cc7005c7c1c2c2cda89e9e38a0730/src/primitives/code/code.tsx#L24-L26

This caused inconsistent behavior, so we should stick with always stringifying children.

After this PR, the above code will give a compile error:
```
error TS2322: Type 'Element' is not assignable to type 'StringifiableNode'.

       <b>Ooops</b>
        ~~~~~~~~~~~~

  code.tsx:27:3
      children: StringifiableNode
         ~~~~~~~~
    The expected type comes from property 'children' which is declared here on type 'IntrinsicAttributes & Omit<CodeProps & Omit<HTMLProps<HTMLElement>, "as" | "size" | "children">, "ref"> & RefAttributes<...>'
```
