### PR TITLE
feat: improve toast, popover, and tooltip motion

### DIFF
--- a/src/core/components/toast/styles.ts
+++ b/src/core/components/toast/styles.ts
@@ -1,64 +1,76 @@
-import {styled, keyframes, css} from 'styled-components'
+import {styled} from 'styled-components'
 import {ThemeColorStateToneKey, getTheme_v2} from '../../../theme'
-import {POPOVER_MOTION_CONTENT_OPACITY_PROPERTY} from '../../constants'
-import {Flex} from '../../primitives'
-import {ThemeProps} from '../../styles'
+import {Card, Flex} from '../../primitives'
+import type {ButtonTone} from '../../types'
+
+const LOADING_BAR_HEIGHT = 2
+
+export const STATUS_CARD_TONE = {
+  error: 'critical',
+  warning: 'caution',
+  success: 'positive',
+  info: 'neutral',
+} satisfies {[key: string]: ThemeColorStateToneKey}
+
+export const BUTTON_TONE = {
+  error: 'critical',
+  warning: 'caution',
+  success: 'positive',
+  info: 'neutral',
+} satisfies {[key: string]: ButtonTone}
 
 export const TextBox = styled(Flex)`
   overflow-x: auto;
 `
 
-const loadingAnimation = keyframes`
-  0% {
-    width: 0;
-  }
-  100% {
-    width: 100%;
+export const StyledToast = styled(Card)`
+  pointer-events: all;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  overflow: clip;
+
+  &[data-has-duration] {
+    padding-bottom: calc(${LOADING_BAR_HEIGHT}px / 2);
   }
 `
 
-const LOADING_BAR_HEIGHT = 2
+export const LoadingBar = styled.div`
+  display: flex;
+  position: absolute;
+  bottom: 0px;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  pointer-events: none;
+  z-index: -1;
+  overflow: hidden;
+  overflow: clip;
+  background: transparent;
+  align-items: flex-end;
+  will-change: opacity;
+`
 
-export function rootStyles(
-  props: {$duration?: number; tone: ThemeColorStateToneKey} & ThemeProps,
-): ReturnType<typeof css> {
-  const {color} = getTheme_v2(props.theme)
+export const LoadingBarMask = styled(Card)`
+  position: absolute;
+  top: 0;
+  left: -${LOADING_BAR_HEIGHT}px;
+  right: -${LOADING_BAR_HEIGHT}px;
+  bottom: ${LOADING_BAR_HEIGHT}px;
+  z-index: 1;
+`
 
-  const loadingBarColor = color.button.default[props.tone].enabled.bg
-
-  if (!props.$duration)
-    return css`
-      pointer-events: all;
-      & > * {
-        opacity: var(${POPOVER_MOTION_CONTENT_OPACITY_PROPERTY}, 1);
-        will-change: opacity;
-      }
-    `
-
-  return css`
-    pointer-events: all;
-    width: 100%;
-    position: relative;
-    overflow: hidden;
-    overflow: clip;
-    padding-bottom: ${LOADING_BAR_HEIGHT}px;
-    &::before {
-      content: '';
-      position: absolute;
-      bottom: 0px;
-      height: ${LOADING_BAR_HEIGHT}px;
-      background: ${loadingBarColor};
-      animation-name: ${loadingAnimation};
-      animation-duration: ${props.$duration}ms;
-      animation-fill-mode: both;
-      animation-timing-function: linear;
-      opacity: var(${POPOVER_MOTION_CONTENT_OPACITY_PROPERTY}, 1);
-      will-change: width;
-    }
-
-    & > * {
-      opacity: var(${POPOVER_MOTION_CONTENT_OPACITY_PROPERTY}, 1);
-      will-change: opacity;
-    }
-  `
+type LoadingBarProgressProps = Omit<React.ComponentProps<typeof Card>, 'tone'> & {
+  tone: ThemeColorStateToneKey
 }
+export const LoadingBarProgress = styled<React.ComponentType<LoadingBarProgressProps>>(Card)`
+  display: block;
+  height: 100%;
+  width: 100%;
+  transform-origin: 0% 50%;
+  background-color: ${(props) => {
+    const {color} = getTheme_v2(props.theme)
+
+    return color.button.default[props.tone].enabled.bg
+  }};
+`

--- a/src/core/components/toast/toast.tsx
+++ b/src/core/components/toast/toast.tsx
@@ -1,10 +1,17 @@
 import {CloseIcon} from '@sanity/icons'
-import {ThemeColorStateToneKey} from '@sanity/ui/theme'
-import {styled} from 'styled-components'
-import {Box, Button, Flex, Stack, Text, Card} from '../../primitives'
-import {ThemeProps} from '../../styles'
-import type {ButtonTone} from '../../types'
-import {rootStyles, TextBox} from './styles'
+import {motion, type Variant, type Variants} from 'framer-motion'
+import {usePrefersReducedMotion} from '../../hooks/usePrefersReducedMotion'
+import {Box, Button, Flex, Stack, Text} from '../../primitives'
+
+import {
+  LoadingBar,
+  LoadingBarProgress,
+  BUTTON_TONE,
+  STATUS_CARD_TONE,
+  TextBox,
+  StyledToast,
+  LoadingBarMask,
+} from './styles'
 
 /**
  * @public
@@ -12,26 +19,13 @@ import {rootStyles, TextBox} from './styles'
 export interface ToastProps {
   closable?: boolean
   description?: React.ReactNode
-  onClose?: () => void
+  onClose: () => void
   radius?: number | number[]
   title?: React.ReactNode
   status?: 'error' | 'warning' | 'success' | 'info'
   duration?: number
+  updatedAt?: number
 }
-
-const STATUS_CARD_TONE: {[key: string]: ThemeColorStateToneKey} = {
-  error: 'critical',
-  warning: 'caution',
-  success: 'positive',
-  info: 'neutral',
-} as const
-
-const BUTTON_TONE = {
-  error: 'critical',
-  warning: 'caution',
-  success: 'positive',
-  info: 'neutral',
-} satisfies {[key: string]: ButtonTone}
 
 const ROLES = {
   error: 'alert',
@@ -40,9 +34,9 @@ const ROLES = {
   info: 'alert',
 } as const
 
-const StyledToast = styled(Card)<{$duration?: number; tone: ThemeColorStateToneKey} & ThemeProps>(
-  rootStyles,
-)
+// Support pattern used by Sanity Studio, that works around the lack of `duration: Infinity` support in older @sanity/ui versions
+// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+const LONG_ENOUGH_BUT_NOT_TOO_LONG = 1000 * 60 * 60 * 24 * 24
 
 /**
  * The `Toast` component gives feedback to users when an action has taken place.
@@ -52,25 +46,63 @@ const StyledToast = styled(Card)<{$duration?: number; tone: ThemeColorStateToneK
  * @public
  */
 export function Toast(
-  props: ToastProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'title'>,
+  props: ToastProps &
+    Omit<
+      React.HTMLProps<HTMLDivElement>,
+      | 'as'
+      | 'height'
+      | 'ref'
+      | 'title'
+      | 'onAnimationStart'
+      | 'onDragStart'
+      | 'onDragEnd'
+      | 'onDrag'
+    >,
 ): React.JSX.Element {
-  const {closable, description, duration, onClose, radius = 3, title, status, ...restProps} = props
+  const {
+    closable,
+    description,
+    duration,
+    onClose,
+    radius = 3,
+    title,
+    status,
+    updatedAt,
+    ...restProps
+  } = props
   const cardTone = status ? STATUS_CARD_TONE[status] : 'default'
   const buttonTone = status ? BUTTON_TONE[status] : 'default'
   const role = status ? ROLES[status] : 'status'
 
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const visualDuration: number = prefersReducedMotion ? 0 : 0.26
+  const transition = visualDuration ? {type: 'spring', visualDuration, bounce: 0.25} : {duration: 0}
+
+  const hasDuration = duration && isFinite(duration) && duration < LONG_ENOUGH_BUT_NOT_TOO_LONG
+  const initial: ContainerVariants[] = ['hidden', 'initial']
+  const animate: ContainerVariants[] = ['visible', 'slideIn']
+  const exit: ContainerVariants[] = ['hidden', 'slideOut']
+
   return (
-    <StyledToast
+    <MotionToast
       data-ui="Toast"
       role={role}
       {...restProps}
-      marginTop={3}
+      data-has-duration={hasDuration ? '' : undefined}
+      custom={visualDuration}
       radius={radius}
       shadow={2}
       tone={cardTone}
-      $duration={duration}
+      forwardedAs="li"
+      layout="position"
+      variants={container}
+      initial={initial}
+      animate={animate}
+      exit={exit}
+      transition={transition}
     >
-      <Flex align="flex-start">
+      <MotionFlex align="flex-start" variants={content} transition={transition}>
         <TextBox flex={1} padding={3}>
           <Stack space={3}>
             {title && (
@@ -79,9 +111,9 @@ export function Toast(
               </Text>
             )}
             {description && (
-              <Text muted size={1}>
+              <MotionText muted size={1} variants={content} transition={transition}>
                 {description}
-              </Text>
+              </MotionText>
             )}
           </Stack>
         </TextBox>
@@ -99,9 +131,66 @@ export function Toast(
             />
           </Box>
         )}
-      </Flex>
-    </StyledToast>
+      </MotionFlex>
+      {hasDuration && (
+        <MotionLoadingBar variants={content} transition={transition}>
+          <LoadingBarMask tone={cardTone} radius={radius} />
+          <MotionLoadingBarProgress
+            key={`progress-${updatedAt}`}
+            tone={cardTone}
+            initial={{scaleX: 0}}
+            animate={{scaleX: 1}}
+            transition={{delay: visualDuration, duration: duration / 1_000, ease: 'linear'}}
+            onAnimationComplete={onClose}
+          />
+        </MotionLoadingBar>
+      )}
+    </MotionToast>
   )
 }
 
 Toast.displayName = 'Toast'
+
+const container = {
+  initial: {y: 32, scale: 0.5, zIndex: 1},
+  hidden: {opacity: 0},
+  visible: (visualDuration: number) => {
+    if (!visualDuration) return {opacity: 1}
+
+    return {
+      opacity: 1,
+      transition: {
+        when: 'beforeChildren',
+        staggerChildren: visualDuration / 3,
+        duration: visualDuration / 3,
+      },
+    }
+  },
+  slideIn: {
+    y: 0,
+    scale: 1,
+  },
+  slideOut: {
+    zIndex: 0,
+    scale: 0.75,
+  },
+} satisfies Variants
+type ContainerVariants = keyof typeof container
+
+const content = {
+  initial: {
+    willChange: 'transform',
+  },
+  hidden: {
+    opacity: 0,
+  },
+  visible: {
+    opacity: 1,
+  },
+} satisfies Partial<Record<ContainerVariants, Variant>>
+
+const MotionToast = motion.create(StyledToast)
+const MotionFlex = motion.create(Flex)
+const MotionText = motion.create(Text)
+const MotionLoadingBar = motion.create(LoadingBar)
+const MotionLoadingBarProgress = motion.create(LoadingBarProgress)

--- a/src/core/components/toast/toastLayer.tsx
+++ b/src/core/components/toast/toastLayer.tsx
@@ -1,0 +1,50 @@
+import {styled} from 'styled-components'
+import {Grid} from '../../primitives/grid'
+import {useLayer} from '../../utils'
+
+/**
+ * @public
+ */
+export interface ToastLayerProps {
+  children: React.ReactNode
+  padding?: number | number[]
+  paddingX?: number | number[]
+  paddingY?: number | number[]
+  gap?: number | number[]
+}
+
+/**
+ * @internal
+ */
+export function ToastLayer(props: ToastLayerProps): React.JSX.Element {
+  const {children, padding = 4, paddingX, paddingY, gap = 3} = props
+  const {zIndex} = useLayer()
+
+  return (
+    <StyledLayer
+      forwardedAs="ul"
+      data-ui="ToastProvider"
+      padding={padding}
+      paddingX={paddingX}
+      paddingY={paddingY}
+      gap={gap}
+      columns={1}
+      style={{zIndex}}
+    >
+      {children}
+    </StyledLayer>
+  )
+}
+
+ToastLayer.displayName = 'ToastLayer'
+
+const StyledLayer = styled(Grid)`
+  box-sizing: border-box;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  list-style: none;
+  pointer-events: none;
+  max-width: 420px;
+  width: 100%;
+`

--- a/src/core/components/toast/types.ts
+++ b/src/core/components/toast/types.ts
@@ -16,5 +16,11 @@ export interface ToastParams {
  */
 export interface ToastContextValue {
   version: 0.0
+  /**
+   * Creates or updates a toast notification.
+   * If a toast with the same ID already exists, it will be updated.
+   * If an ID is not provided, a random one will be generated.
+   * The returned ID can be used to programatically update a toast.
+   */
   push: (params: ToastParams) => string
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -10,47 +10,60 @@ export const EMPTY_ARRAY: never[] = []
  */
 export const EMPTY_RECORD: Record<string, never> = {}
 
-/**
- * @internal
- */
-export const POPOVER_MOTION_CONTENT_OPACITY_PROPERTY = '--motion-content-opacity' as string
+const POPOVER_MOTION_DURATION = 0.2
 
 /**
  * Shared `framer-motion` variants used by `Popover` and `Tooltip` components.
  * @internal
  */
 export const POPOVER_MOTION_PROPS: {
-  animate: Variant
-  initial: Variant
-  exit: Variant
+  card: {
+    initial: Variant
+    hidden: Variant
+    visible: Variant
+    scaleIn: Variant
+    scaleOut: Variant
+  }
+  children: {
+    hidden: Variant
+    visible: Variant
+  }
   transition: Transition
 } = {
-  /**
-   * These variants makes use of special timing, by using a negative opacity as a starting position,
-   * as well as double opacity as the end position.
-   * The purpose of this is to make the tooltip/popover container appear before the content, and when exiting
-   * we want the content to disappear faster than the container.
-   */
-  initial: {
-    opacity: 0.5,
-    // the nagative opacity here, as well as the double opacity further down, are to make the content appear after the backgdrop, and when exiting the content should disappear first.
-    [POPOVER_MOTION_CONTENT_OPACITY_PROPERTY as string]: -1,
-    scale: 0.97,
-    willChange: 'transform',
+  card: {
+    initial: {
+      scale: 0.97,
+      willChange: 'transform',
+    },
+    hidden: {
+      opacity: 0,
+    },
+    visible: {
+      opacity: 1,
+      transition: {
+        when: 'beforeChildren',
+        duration: POPOVER_MOTION_DURATION / 2,
+      },
+    },
+    scaleIn: {
+      scale: 1,
+    },
+    scaleOut: {
+      scale: 0.97,
+    },
   },
-  animate: {
-    opacity: 2,
-    [POPOVER_MOTION_CONTENT_OPACITY_PROPERTY as string]: 1,
-    scale: 1,
-  },
-  exit: {
-    opacity: 0,
-    [POPOVER_MOTION_CONTENT_OPACITY_PROPERTY as string]: -1,
-    scale: 0.97,
+  children: {
+    hidden: {
+      opacity: 0,
+    },
+    visible: {
+      opacity: 1,
+    },
   },
   transition: {
-    duration: 0.4,
     type: 'spring',
+    visualDuration: POPOVER_MOTION_DURATION,
+    bounce: 0.25,
   },
 }
 

--- a/src/core/primitives/popover/popoverCard.tsx
+++ b/src/core/primitives/popover/popoverCard.tsx
@@ -3,7 +3,7 @@ import {ThemeColorSchemeKey} from '@sanity/ui/theme'
 import {type MotionProps, motion} from 'framer-motion'
 import React, {CSSProperties, forwardRef, memo, useMemo} from 'react'
 import {styled} from 'styled-components'
-import {POPOVER_MOTION_CONTENT_OPACITY_PROPERTY, POPOVER_MOTION_PROPS} from '../../constants'
+import {POPOVER_MOTION_PROPS} from '../../constants'
 import {BoxOverflow, CardTone, Placement, PopoverMargins, Radius} from '../../types'
 import {Arrow, useLayer} from '../../utils'
 import {Card, CardProps} from '../card'
@@ -22,10 +22,11 @@ const MotionCard = styled(motion.create(Card))`
   flex-direction: column;
   width: max-content;
   min-width: min-content;
-  & > * {
-    opacity: var(${POPOVER_MOTION_CONTENT_OPACITY_PROPERTY}, 1);
-    will-change: opacity;
-  }
+  will-change: transform;
+`
+
+const MotionFlex = styled(motion.create(Flex))`
+  will-change: opacity;
 `
 
 /**
@@ -131,13 +132,24 @@ export const PopoverCard = memo(
         sizing="border"
         style={rootStyle}
         tone={tone}
-        {...(animate ? POPOVER_MOTION_PROPS : {})}
+        variants={POPOVER_MOTION_PROPS.card}
+        transition={POPOVER_MOTION_PROPS.transition}
+        initial={animate ? ['hidden', 'initial'] : undefined}
+        animate={animate ? ['visible', 'scaleIn'] : undefined}
+        exit={animate ? ['hidden', 'scaleOut'] : undefined}
       >
-        <Flex data-ui="Popover__wrapper" direction="column" flex={1} overflow={overflow}>
+        <MotionFlex
+          data-ui="Popover__wrapper"
+          direction="column"
+          flex={1}
+          overflow={overflow}
+          variants={POPOVER_MOTION_PROPS.children}
+          transition={POPOVER_MOTION_PROPS.transition}
+        >
           <Flex direction="column" flex={1} padding={padding}>
             {children}
           </Flex>
-        </Flex>
+        </MotionFlex>
 
         {arrow && (
           <Arrow

--- a/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/src/core/primitives/tooltip/tooltipCard.tsx
@@ -2,7 +2,7 @@ import {ThemeColorSchemeKey} from '@sanity/ui/theme'
 import {type MotionProps, motion} from 'framer-motion'
 import React, {CSSProperties, forwardRef, memo, useMemo} from 'react'
 import {styled} from 'styled-components'
-import {POPOVER_MOTION_CONTENT_OPACITY_PROPERTY, POPOVER_MOTION_PROPS} from '../../constants'
+import {POPOVER_MOTION_PROPS} from '../../constants'
 import {Placement, Radius} from '../../types'
 import {Arrow} from '../../utils'
 import {Card, CardProps} from '../card'
@@ -13,10 +13,7 @@ import {
 } from './constants'
 
 const MotionCard = styled(motion.create(Card))`
-  & > * {
-    opacity: var(${POPOVER_MOTION_CONTENT_OPACITY_PROPERTY}, 1);
-    will-change: opacity;
-  }
+  will-change: transform;
 `
 
 /**
@@ -89,7 +86,11 @@ export const TooltipCard = memo(
         scheme={scheme}
         shadow={shadow}
         style={rootStyle}
-        {...(animate ? POPOVER_MOTION_PROPS : {})}
+        variants={POPOVER_MOTION_PROPS.card}
+        transition={POPOVER_MOTION_PROPS.transition}
+        initial={animate ? ['hidden', 'initial'] : undefined}
+        animate={animate ? ['visible', 'scaleIn'] : undefined}
+        exit={animate ? ['hidden', 'scaleOut'] : undefined}
       >
         {children}
 


### PR DESCRIPTION
Updates the Motion transitions we have for Toasts, Popovers and Tooltips to be more fluid and responsive. Removes `opacity: -1` and `opacity: 2` hacks.

They're very smooth in slow motion:


https://github.com/user-attachments/assets/b6219c83-7a13-4e97-8d5c-539a31a7a20e


# Tooltip

Left side is before, right side after. The animation no longer have this "flick" or "flash" effect as the text fades in.

https://github.com/user-attachments/assets/420f9b64-cd92-4543-83e8-e2e36a604e21


# Popover

Fade in is slowed down here as well, while the overall animation is sped up.


https://github.com/user-attachments/assets/9085c1d4-9a15-40d7-aeba-ebde83e06f0d

# Toasts

The `AnimatePresence` now uses `mode="popLayout", which animates sibling toasts right away instead of waiting for it to fade out:


https://github.com/user-attachments/assets/2bd7da0e-766e-46f5-9342-f6c2ec25c90a


It works really well when there's multiple toasts of diverse colors and various duration timing set:


https://github.com/user-attachments/assets/6772a562-2005-4f03-ab05-843b7d8e4b82


When a toast is mutated (using a shared `id`) the progress bar resets to reflect the actual time left before the toast auto dismisses:


https://github.com/user-attachments/assets/6ba53556-1afc-46a2-8215-bf20c0251037


It's now possible to use `toast.push({duration: Infinite})` to make a toast stay open until the user dismisses it:

 

https://github.com/user-attachments/assets/ab40d85e-471a-4187-b945-52158a364fb1


Due to a lack of support for `duration: Infinite`, the Sanity Studio codebase has long used workarounds where the duration is set to the highest possible number that setTimeout allows, this pattern is still supported to ensure we don't break BC:


https://github.com/user-attachments/assets/bcd87663-fd03-4f1f-b36f-e0ed38f56cae


`@sanity/ui` doesn't yet support programmatically closing a toast by `id`. The studio codebase gets around this by setting a really short duration of `0.01`. This pattern is still supported to ensure full backwards compatibility:


https://github.com/user-attachments/assets/c7af23b3-9e24-4a61-a0d5-6964ef1bcc22

