### PR TITLE
fix: consistent delayed tooltip group behavior

### DIFF
--- a/src/core/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupProvider.tsx
+++ b/src/core/primitives/tooltip/tooltipDelayGroup/tooltipDelayGroupProvider.tsx
@@ -39,7 +39,6 @@ export function TooltipDelayGroupProvider(
 
   const value: TooltipDelayGroupContextValue = useMemo(
     () => ({
-      isGroupActive: isGroupActive,
       setIsGroupActive: setIsGroupActive,
       openTooltipId: openTooltipId,
       setOpenTooltipId: setOpenTooltipId,

--- a/src/core/primitives/tooltip/tooltipDelayGroup/types.ts
+++ b/src/core/primitives/tooltip/tooltipDelayGroup/types.ts
@@ -2,7 +2,6 @@
  * @beta
  */
 export interface TooltipDelayGroupContextValue {
-  isGroupActive: boolean
   setIsGroupActive: (nextState: React.SetStateAction<boolean>, delay?: number | undefined) => void
   setOpenTooltipId: (nextId: string | null, delay?: number | undefined) => void
   openDelay: number


### PR DESCRIPTION
There's a race condition in `<Tooltip />`, unclear when it snuck into the codebase, but it's causing only every second or so tooltip to actually open if you move the cursor in a group quickly enough:


https://github.com/user-attachments/assets/4cc87045-8cbd-4ba3-8eb7-da343c899177

Here it is with the fix:



https://github.com/user-attachments/assets/a610916c-8352-4bca-a34a-219c5b79d98b

We should come back and fix the state management and cleanup `<Tooltip />` in general, it's really complex. For now this fix should do.

I removed the `isGroupActive` state from the context provider since it's not actually used anywhere.