### PR TITLE
chore(ci): add pkg-pr-new workflow

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,46 @@
+name: Publish Pull Requests with pkg.pr.new
+
+permissions:
+  pull-requests: write
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+jobs:
+  publish:
+    if: >
+      github.repository == 'sanity-io/ui' &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger: preview')))
+
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+
+      - name: Install project dependencies
+        run: pnpm install
+
+      - id: pre-flight
+        run: |
+          VERSION="$(jq -r .version package.json)-pkg.pr.new@$(git rev-parse --short HEAD)"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - run: pnpm build
+        env:
+          PKG_VERSION: ${{ steps.pre-flight.outputs.version }}
+
+      - run: |
+          echo "Publishing to pkg.pr.new"
+          pnpm pnpx pkg-pr-new publish --no-template @sanity/ui

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -43,4 +43,4 @@ jobs:
 
       - run: |
           echo "Publishing to pkg.pr.new"
-          pnpm pnpx pkg-pr-new publish --no-template @sanity/ui
+          pnpm pnpx pkg-pr-new publish


### PR DESCRIPTION
Adds a CI workflow for [pkg.pr.new](https://pkg.pr.new/), based on the configuration we use in sanity-io/sanity.

Publish will be triggered by adding the `trigger: preview`-label to the PR

