### PR TITLE
fix: lighten tab hover and selected colors in dark mode

### DIFF
--- a/src/theme/defaults/colorTokens.ts
+++ b/src/theme/defaults/colorTokens.ts
@@ -368,12 +368,12 @@ export const defaultColorTokens: ThemeColorTokens = {
           },
         },
         'hovered': {
-          bg: ['50', '950'],
+          bg: ['50', '900'],
           fg: ['800', '200'],
           icon: ['800 70%', '300 70%'],
         },
         'pressed': {
-          bg: ['100', '900'],
+          bg: ['100', '800'],
           fg: ['800', '200'],
           icon: ['800 70%', '200 70%'],
         },


### PR DESCRIPTION
Adjusts background color tokens for the 'bleed' button mode, used by Tab components, to improve visibility and contrast in the dark theme.

- Hovered state background (dark mode): gray/950 -> gray/900
- Pressed state (selected tabs) background (dark mode): gray/900 -> gray/800

These changes make hover and selected states one step lighter in the gray scale, enhancing user experience by making active and hovered tabs more distinct.

Bumps background-background contrast from ~1.15 to ~1.34 


<img width="836" alt="Screenshot 2025-05-06 at 8 50 27 PM" src="https://github.com/user-attachments/assets/4be5e61b-7641-42bb-baaa-cdede95cd5d1" />