### PR TITLE
feat: allow popover to use auto placement strategy

### DIFF
--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -7,6 +7,7 @@ import {
   offset,
   RootBoundary,
   shift,
+  autoPlacement,
   useFloating,
 } from '@floating-ui/react-dom'
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'
@@ -96,6 +97,16 @@ export interface PopoverProps
   overflow?: BoxOverflow
   padding?: number | number[]
   placement?: Placement
+  /**
+   * When 'flip' (default), the placement is determined from the initial placement and the
+   * fallback placements in order. Whichever fits in the viewport first.
+   *
+   * When 'autoPlacement', the initial placement and all fallback placements are evaluated
+   * and the placement with the most viewport space available.
+   *
+   * Option is only relevant if either `constrainSize` or `preventOverflow` is `true`
+   */
+  placementStrategy?: 'flip' | 'autoPlacement'
   /** Whether or not to render the popover in a portal element. */
   portal?: boolean | string
   preventOverflow?: boolean
@@ -154,6 +165,7 @@ export const Popover = memo(
       overflow = 'hidden',
       padding: paddingProp,
       placement: placementProp = 'bottom',
+      placementStrategy = 'flip',
       portal,
       preventOverflow = true,
       radius: radiusProp = 3,
@@ -240,14 +252,22 @@ export const Popover = memo(
 
       // Flip the floating element when leaving the boundary box
       if (constrainSize || preventOverflow) {
-        ret.push(
-          flip({
-            boundary: floatingBoundary || undefined,
-            fallbackPlacements,
-            padding: DEFAULT_POPOVER_PADDING,
-            rootBoundary,
-          }),
-        )
+        if (placementStrategy === 'autoPlacement') {
+          ret.push(
+            autoPlacement({
+              allowedPlacements: [placementProp].concat(fallbackPlacements),
+            }),
+          )
+        } else {
+          ret.push(
+            flip({
+              boundary: floatingBoundary || undefined,
+              fallbackPlacements,
+              padding: DEFAULT_POPOVER_PADDING,
+              rootBoundary,
+            }),
+          )
+        }
       }
 
       // Define distance between reference and floating element
@@ -330,6 +350,8 @@ export const Popover = memo(
       arrowProp,
       constrainSize,
       fallbackPlacements,
+      placementProp,
+      placementStrategy,
       floatingBoundary,
       margins,
       matchReferenceWidth,

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -1,5 +1,6 @@
 import {
   arrow,
+  autoPlacement,
   autoUpdate,
   flip,
   hide,
@@ -7,7 +8,6 @@ import {
   offset,
   RootBoundary,
   shift,
-  autoPlacement,
   useFloating,
 } from '@floating-ui/react-dom'
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'

--- a/stories/primitives/Popover.stories.tsx
+++ b/stories/primitives/Popover.stories.tsx
@@ -1,7 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react'
-import {useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 
-import {Box, Button, Card, Popover, Text} from '../../src/core/primitives'
+import {Box, Button, Card, Flex, Popover, Text} from '../../src/core/primitives'
 import {PLACEMENT_OPTIONS, RADII} from '../constants'
 import {getRadiusControls, getShadowControls, getSpaceControls} from '../controls'
 import {rowBuilder} from '../helpers/rowBuilder'
@@ -146,29 +146,56 @@ export const WithReferenceElement: Story = {
   },
 }
 
-export const AutoPlacement: Story = {
-  render: () => {
+export const PlacementStrategy: Story = {
+  args: {
+    children: (
+      <Button text="The popover will position itself on the side with the most viewport space" />
+    ),
+    constrainSize: true,
+    content: <Text size={1}>popover content</Text>,
+    fallbackPlacements: ['bottom-start'],
+    open: true,
+    placement: 'top-start',
+    placementStrategy: 'autoPlacement',
+  },
+  parameters: {
+    controls: {
+      include: ['fallbackPlacements', 'placement', 'placementStrategy'],
+    },
+  },
+  render: (props) => {
+    const [height, setHeight] = useState(100)
+
+    const handleUpdate = useCallback(() => {
+      setHeight(height === 100 ? 800 : 100)
+    }, [height])
+
+    useEffect(() => {
+      const interval = setInterval(handleUpdate, 2000)
+      return () => {
+        clearInterval(interval)
+      }
+    }, [handleUpdate])
+
     return (
       <Box
-        style={{display: 'flex', justifyContent: 'center', alignItems: 'center', height: '120vh'}}
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '120vh',
+        }}
       >
-        <Box padding={4}>
-          <Popover
-            content={<Text size={[2, 2, 3, 4]}>Hello, world</Text>}
-            fallbackPlacements={['bottom-start']}
-            padding={4}
-            placement="top-start"
-            placementStrategy="autoPlacement"
-            portal
-            open
-          >
-            <Button
-              mode="ghost"
-              padding={[3, 3, 4]}
-              text="The popover will position itself on the side with the most viewport space"
-            />
-          </Popover>
-        </Box>
+        <Popover
+          {...props}
+          content={
+            <Card style={{height: `${height}px`, resize: 'vertical'}}>
+              <Flex align="center" justify="center" height="fill">
+                <Text>Popover content</Text>
+              </Flex>
+            </Card>
+          }
+        />
       </Box>
     )
   },

--- a/stories/primitives/Popover.stories.tsx
+++ b/stories/primitives/Popover.stories.tsx
@@ -145,3 +145,31 @@ export const WithReferenceElement: Story = {
     )
   },
 }
+
+export const AutoPlacement: Story = {
+  render: () => {
+    return (
+      <Box
+        style={{display: 'flex', justifyContent: 'center', alignItems: 'center', height: '120vh'}}
+      >
+        <Box padding={4} style={{textAlign: 'center', verticalAlign: 'middle'}}>
+          <Popover
+            content={<Text size={[2, 2, 3, 4]}>Hello, world</Text>}
+            fallbackPlacements={['bottom-start']}
+            padding={4}
+            placement="top-start"
+            placementStrategy="autoPlacement"
+            portal
+            open
+          >
+            <Button
+              mode="ghost"
+              padding={[3, 3, 4]}
+              text="The popover will position itself on the side with the most viewport space"
+            />
+          </Popover>
+        </Box>
+      </Box>
+    )
+  },
+}

--- a/stories/primitives/Popover.stories.tsx
+++ b/stories/primitives/Popover.stories.tsx
@@ -152,7 +152,7 @@ export const AutoPlacement: Story = {
       <Box
         style={{display: 'flex', justifyContent: 'center', alignItems: 'center', height: '120vh'}}
       >
-        <Box padding={4} style={{textAlign: 'center', verticalAlign: 'middle'}}>
+        <Box padding={4}>
           <Popover
             content={<Text size={[2, 2, 3, 4]}>Hello, world</Text>}
             fallbackPlacements={['bottom-start']}


### PR DESCRIPTION
https://github.com/user-attachments/assets/c5aeac8f-edee-4961-8553-7ba18914ee57

## Description
This PR adds the ability to choose positioning strategy for the `Popover` component.

It can either use `flip` (the currently used and the default after this PR), or the user can optionally pick `autoPlacement`. Which uses the [autoPlacement](https://floating-ui.com/docs/autoPlacement) middleware.

`autoPlacement` can be useful in interfaces where the popover content is dynamic (eg. filtering) and there is a desire for the first picked placement to be retained while the user filters the content.

**Example**
When using `flip` placement strategy with these props
```
fallbackPlacements={['top', 'top-end', 'bottom-start', 'bottom', 'bottom-end']}
placement="top-start"
```

And the initial content cannot be placed at the `top`, `flip` will automatically place it at `bottom`.
If the user is filtering the content by typing, once it becomes small enough to fit `top`, the placement will shift while the user is still typing.

Using `autoPlacement`, the position will be based on where the most available viewport space is, and it won't matter what the height of the content is. So the originally picked placement will be retained while the user types (or until the user scrolls the viewport enough, so that the most available viewport space change).

## Testing
A story named `Auto Placement` has been created for the `Popover` component which shows the behavior.