### PR TITLE
fix(menuitem): make role configurable

### DIFF
--- a/src/core/components/menu/menuItem.tsx
+++ b/src/core/components/menu/menuItem.tsx
@@ -49,9 +49,9 @@ export type MenuItemOwnProps = GapStyleProps &
 export type MenuItemElementType = 'button' | 'a' | ComponentType
 
 /** @public */
-export type MenuItemProps<E extends MenuItemElementType = MenuItemElementType> = Omit<
-  Props<MenuItemOwnProps, E>,
-  'role'
+export type MenuItemProps<E extends MenuItemElementType = MenuItemElementType> = Props<
+  MenuItemOwnProps,
+  E
 >
 
 /** @public */
@@ -80,6 +80,7 @@ export function MenuItem<E extends MenuItemElementType = typeof DEFAULT_MENU_ITE
     pressed,
     radius = 2,
     ref: forwardedRef,
+    role = 'menuitem',
     selected: selectedProp,
     text,
     tone = 'default',
@@ -140,7 +141,7 @@ export function MenuItem<E extends MenuItemElementType = typeof DEFAULT_MENU_ITE
       onMouseEnter={onItemMouseEnter}
       onMouseLeave={onItemMouseLeave}
       ref={setRef}
-      role="menuitem"
+      role={role}
       tabIndex={-1}
       tone={tone}
       type={as === 'button' ? 'button' : undefined}


### PR DESCRIPTION
### Description

Make `role` configurable on `MenuItem` because `menuitemradio` also exists and in the case of the theme switcher in dashboard that is a more preferable aria-role and if we dont use the MenuItem component the focussing does not work correctly.