### PR TITLE
fix(popover): pass tone to PopoverLayer

### DIFF
--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -408,6 +408,7 @@ export function Popover<E extends PopoverElementType = typeof DEFAULT_POPOVER_EL
         shadow={shadow}
         originX={originX}
         originY={originY}
+        tone={tone}
         strategy={strategy}
         x={x}
         y={y}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We used to pass `tone` to PopoverLayer and we still should because otherwise the tone is never passed correctly and everything is stuck with `initial`.