### PR TITLE
fix(skeleton): pass all props to skeleton className function

### DIFF
--- a/src/core/primitives/skeleton/skeleton.tsx
+++ b/src/core/primitives/skeleton/skeleton.tsx
@@ -36,7 +36,6 @@ export function Skeleton<E extends SkeletonElementType = typeof DEFAULT_SKELETON
     animated = false,
     className,
     delay,
-    radius,
     ...rest
   } = props as SkeletonProps<typeof DEFAULT_SKELETON_ELEMENT>
 
@@ -62,7 +61,7 @@ export function Skeleton<E extends SkeletonElementType = typeof DEFAULT_SKELETON
       {...rest}
       className={skeleton({
         className,
-        radius,
+        ...rest,
       })}
       data-animated={animated ? '' : undefined}
       data-visible={visible ? '' : undefined}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Skeleton accepts props like `flex` which are utilised by the `flex` class function, but these props are never passed to the `skeleton` className function so they never take effect. This PR fixes this by passing `rest` to the className function.
