### PR TITLE
feat(menuItem): allow the ability to prevent default behaviour

### DIFF
--- a/src/core/components/menu/menu.tsx
+++ b/src/core/components/menu/menu.tsx
@@ -19,7 +19,7 @@ export type MenuOwnProps = PaddingStyleProps & {
   'gap'?: ResponsiveProp<Space>
   'onClickOutside'?: (event: MouseEvent) => void
   'onEscape'?: () => void
-  'onItemClick'?: () => void
+  'onItemClick'?: (event: React.MouseEvent<HTMLButtonElement>) => void
   'onItemSelect'?: (index: number) => void
   'originElement'?: HTMLElement | null
   'registerElement'?: (el: HTMLElement) => () => void

--- a/src/core/components/menu/menuButton.tsx
+++ b/src/core/components/menu/menuButton.tsx
@@ -159,11 +159,16 @@ export function MenuButton(props: MenuButtonProps): React.JSX.Element {
     [menuElements],
   )
 
-  const handleItemClick = useCallback(() => {
-    setOpen(false)
-    if (disableRestoreFocusOnClose) return
-    if (buttonElement) buttonElement.focus()
-  }, [buttonElement, disableRestoreFocusOnClose])
+  const handleItemClick = useCallback(
+    (e: ReactMouseEvent<HTMLButtonElement>) => {
+      if (e.defaultPrevented) return
+
+      setOpen(false)
+      if (disableRestoreFocusOnClose) return
+      if (buttonElement) buttonElement.focus()
+    },
+    [buttonElement, disableRestoreFocusOnClose],
+  )
 
   const registerElement = useCallback((el: HTMLElement) => {
     setChildMenuElements((els) => els.concat([el]))

--- a/src/core/components/menu/menuContext.ts
+++ b/src/core/components/menu/menuContext.ts
@@ -9,7 +9,7 @@ export interface MenuContextValue {
   mount: (element: HTMLElement | null, selected?: boolean) => () => void
   onClickOutside?: (event: MouseEvent) => void
   onEscape?: () => void
-  onItemClick?: () => void
+  onItemClick?: (event: ReactMouseEvent<HTMLButtonElement>) => void
   onItemMouseEnter?: (event: ReactMouseEvent<HTMLElement>) => void
   onItemMouseLeave?: (event: ReactMouseEvent<HTMLElement>) => void
   registerElement?: (el: HTMLElement) => () => void

--- a/src/core/components/menu/menuItem.tsx
+++ b/src/core/components/menu/menuItem.tsx
@@ -104,7 +104,7 @@ export function MenuItem<E extends MenuItemElementType = typeof DEFAULT_MENU_ITE
     (event: MouseEvent<HTMLButtonElement>) => {
       if (disabled) return
       if (onClick) onClick(event)
-      if (onItemClick) onItemClick()
+      if (onItemClick) onItemClick(event)
     },
     [disabled, onClick, onItemClick],
   )


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

_Sometimes_ you don't want your menu to close. We can easily achieve this by calling `event.preventDefault` on the `onClick` handler MenuItem accepts and calls _before_ `onItemClick` and then check in the latter callback thus preventing the menu closing.

### Related Issues

* DASH-459

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Does it make more sense to check `defaultPrevented` in the `handleClick` function of `MenuITem`?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I did add a test, but popover's don't render in the test environment because of their `referenceHidden` middleware, maybe something we want to look at if we want more unit tests?
