### PR TITLE
fix: narrow down `popover` property type

### DIFF
--- a/src/core/components/autocomplete/autocomplete.tsx
+++ b/src/core/components/autocomplete/autocomplete.tsx
@@ -63,7 +63,7 @@ export type AutocompleteOwnProps<O extends BaseAutocompleteOption = BaseAutocomp
     /** The options to render. */
     options?: O[]
     padding?: ResponsiveProp<Space>
-    popover?: Omit<Props<PopoverProps, 'div'>, 'content' | 'onMouseEnter' | 'onMouseLeave' | 'open'>
+    popover?: Omit<PopoverProps<'div'>, 'content' | 'onMouseEnter' | 'onMouseLeave' | 'open'>
     prefix?: ReactNode
     radius?: Radius | Radius[]
     /** @beta */

--- a/src/core/components/menu/menuButton.tsx
+++ b/src/core/components/menu/menuButton.tsx
@@ -29,7 +29,7 @@ export type MenuButtonProps = {
   menu?: ReactElement
   onClose?: () => void
   onOpen?: () => void
-  popover?: Omit<PopoverProps, 'content' | 'open'>
+  popover?: Omit<PopoverProps<'div'>, 'content' | 'open'>
 
   ref?: ForwardedRef<HTMLButtonElement | null>
 }

--- a/src/core/components/menu/menuGroup.tsx
+++ b/src/core/components/menu/menuGroup.tsx
@@ -43,7 +43,7 @@ export type MenuGroupOwnProps = RadiusStyleProps & {
     | 'onBlurCapture'
   >
   padding?: ResponsiveProp<Space>
-  popover?: Omit<PopoverProps, 'content' | 'open'>
+  popover?: Omit<PopoverProps<'div'>, 'content' | 'open'>
   text?: ReactNode
   tone?: ElementTone
 }


### PR DESCRIPTION
The new prop types which infers properties based on the provided `as` element type has some limitations.

If you want to use e.g. the `PopoverProps` type directly, you’ll need to define the element type generic – `PopoverProps<'div'>` – to get proper types (not sure yet why).
