### PR TITLE
fix: handle `react-hooks/preserve-manual-memoization`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: lts/*
       - run: pnpm install
-      - run: "pnpm lint -f gha --rule 'react-hooks/set-state-in-effect: [off]' --rule 'react-hooks/preserve-manual-memoization: [off]' --max-warnings 0"
+      - run: "pnpm lint -f gha --rule 'react-hooks/set-state-in-effect: [off]' --max-warnings 0"
 
   test:
     needs: [build]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,7 +89,14 @@ export default ts.config(
         'react-hooks-with-use-effect-event/exhaustive-deps': 'error',
         // For now these aren't always actionable, and shouldn't have the same urgency as errors
         'react-hooks/set-state-in-effect': 'warn',
-        'react-hooks/preserve-manual-memoization': 'warn',
+        // Disabled by default, enabled here
+        'react-hooks/hooks': 'error',
+        'react-hooks/capitalized-calls': 'error',
+        'react-hooks/memoized-effect-dependencies': 'error',
+        'react-hooks/no-deriving-state-in-effects': 'error',
+        'react-hooks/invariant': 'error',
+        'react-hooks/todo': 'error',
+        'react-hooks/syntax': 'error',
       },
     },
 
@@ -114,6 +121,7 @@ export default ts.config(
       rules: {
         'react-hooks/set-state-in-effect': 'off',
         'react-hooks/refs': 'off',
+        'react-hooks/hooks': 'off',
       },
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/ui",
-  "version": "3.0.11",
+  "version": "3.0.12-canary.0",
   "keywords": [
     "sanity",
     "ui",
@@ -70,7 +70,7 @@
     "dev": "run-p storybook:dev workshop:dev",
     "figma:pkg:build": "cd figma && pnpm build",
     "format": "prettier --write --cache --ignore-unknown .",
-    "lint": "eslint --cache .",
+    "lint": "eslint .",
     "prepack": "pnpm build",
     "pkg:build": "pkg build --strict",
     "pkg:check": "pkg --strict",

--- a/src/core/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/core/components/breadcrumbs/breadcrumbs.tsx
@@ -42,44 +42,16 @@ export const Breadcrumbs = forwardRef(function Breadcrumbs(
 
   const rawItems = useMemo(() => Children.toArray(children).filter(isValidElement), [children])
 
-  const items = useMemo(() => {
-    const len = rawItems.length
-
-    if (maxLength && len > maxLength) {
-      const beforeLength = Math.ceil(maxLength / 2)
-      const afterLength = Math.floor(maxLength / 2)
-
-      return [
-        ...rawItems.slice(0, beforeLength - 1),
-        <Popover
-          constrainSize
-          content={
-            <Stack as="ol" overflow="auto" padding={space} space={space}>
-              {rawItems.slice(beforeLength - 1, len - afterLength)}
-            </Stack>
-          }
-          key="button"
-          open={open}
-          placement="top"
-          portal
-          ref={popoverElementRef}
-        >
-          <ExpandButton
-            fontSize={1}
-            mode="bleed"
-            onClick={open ? collapse : expand}
-            padding={1}
-            ref={expandElementRef}
-            selected={open}
-            text="…"
-          />
-        </Popover>,
-        ...rawItems.slice(len - afterLength),
-      ]
-    }
-
-    return rawItems
-  }, [collapse, expand, maxLength, open, rawItems, space])
+  const items = useItems({
+    collapse,
+    expand,
+    expandElementRef,
+    maxLength,
+    open,
+    popoverElementRef,
+    rawItems,
+    space,
+  })
 
   return (
     <StyledBreadcrumbs data-ui="Breadcrumbs" {...restProps} ref={ref}>
@@ -97,3 +69,60 @@ export const Breadcrumbs = forwardRef(function Breadcrumbs(
   )
 })
 Breadcrumbs.displayName = 'ForwardRef(Breadcrumbs)'
+
+function useItems({
+  collapse,
+  expand,
+  expandElementRef,
+  maxLength,
+  open,
+  popoverElementRef,
+  rawItems,
+  space,
+}: {
+  collapse: () => void
+  expand: () => void
+  expandElementRef: React.RefObject<HTMLButtonElement | null>
+  maxLength: number | undefined
+  open: boolean
+  popoverElementRef: React.RefObject<HTMLDivElement | null>
+  rawItems: React.ReactElement<unknown, string | React.JSXElementConstructor<any>>[]
+  space: number[]
+}) {
+  const len = rawItems.length
+
+  if (maxLength && len > maxLength) {
+    const beforeLength = Math.ceil(maxLength / 2)
+    const afterLength = Math.floor(maxLength / 2)
+
+    return [
+      ...rawItems.slice(0, beforeLength - 1),
+      <Popover
+        constrainSize
+        content={
+          <Stack as="ol" overflow="auto" padding={space} space={space}>
+            {rawItems.slice(beforeLength - 1, len - afterLength)}
+          </Stack>
+        }
+        key="button"
+        open={open}
+        placement="top"
+        portal
+        ref={popoverElementRef}
+      >
+        <ExpandButton
+          fontSize={1}
+          mode="bleed"
+          onClick={open ? collapse : expand}
+          padding={1}
+          ref={expandElementRef}
+          selected={open}
+          text="…"
+        />
+      </Popover>,
+      ...rawItems.slice(len - afterLength),
+    ]
+  }
+
+  return rawItems
+}

--- a/src/core/components/tree/treeGroup.tsx
+++ b/src/core/components/tree/treeGroup.tsx
@@ -1,5 +1,3 @@
-import {memo} from 'react'
-
 import {Stack} from '../../primitives'
 import {useTree} from './useTree'
 
@@ -7,7 +5,7 @@ export interface TreeGroupProps {
   expanded?: boolean
 }
 
-export const TreeGroup = memo(function TreeGroup(
+export function TreeGroup(
   props: TreeGroupProps &
     Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'role' | 'wrap'>,
 ): React.JSX.Element {
@@ -27,4 +25,4 @@ export const TreeGroup = memo(function TreeGroup(
       {children}
     </Stack>
   )
-})
+}

--- a/src/core/components/tree/treeItem.tsx
+++ b/src/core/components/tree/treeItem.tsx
@@ -1,6 +1,6 @@
 import {ToggleArrowRightIcon} from '@sanity/icons'
 import {ThemeFontWeightKey} from '@sanity/ui/theme'
-import {memo, useCallback, useEffect, useId, useMemo, useRef, useState} from 'react'
+import {useCallback, useEffect, useId, useMemo, useRef, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {Box, BoxProps, Flex, Text} from '../../primitives'
@@ -31,7 +31,7 @@ export interface TreeItemProps {
   weight?: ThemeFontWeightKey
 }
 
-const StyledTreeItem = memo(styled.li(treeItemRootStyle, treeItemRootColorStyle))
+const StyledTreeItem = styled.li(treeItemRootStyle, treeItemRootColorStyle)
 
 const TreeItemBox = styled(Box).attrs({forwardedAs: 'a'})<TreeItemBoxStyleProps>(treeItemBoxStyle)
 
@@ -45,7 +45,7 @@ const ToggleArrowText = styled(Text)`
  * This API might change. DO NOT USE IN PRODUCTION.
  * @beta
  */
-export const TreeItem = memo(function TreeItem(
+export function TreeItem(
   props: TreeItemProps & Omit<React.HTMLProps<HTMLLIElement>, 'as' | 'ref' | 'role'>,
 ): React.JSX.Element {
   const {
@@ -203,5 +203,5 @@ export const TreeItem = memo(function TreeItem(
       </TreeContext.Provider>
     </StyledTreeItem>
   )
-})
-TreeItem.displayName = 'Memo(TreeItem)'
+}
+TreeItem.displayName = 'TreeItem'

--- a/src/core/primitives/popover/floating-ui/size.ts
+++ b/src/core/primitives/popover/floating-ui/size.ts
@@ -1,23 +1,28 @@
-import {detectOverflow, Elements, Middleware} from '@floating-ui/react-dom'
+import {detectOverflow, Middleware} from '@floating-ui/react-dom'
 
 import {PopoverMargins} from '../../../types'
 
-export interface SizeMiddlewareApplyOptions {
-  availableWidth: number
-  availableHeight: number
-  elements: Elements
-  referenceWidth: number
-}
-
 export function size(options: {
-  apply: (args: SizeMiddlewareApplyOptions) => void
   boundaryElement?: HTMLElement | null
   constrainSize: boolean
   margins: PopoverMargins
   matchReferenceWidth?: boolean
+  maxWidthRef: React.RefObject<number | undefined>
   padding?: number
+  referenceWidthRef: React.RefObject<number | undefined>
+  setReferenceWidth: (referenceWidth: number) => void
+  widthRef: React.RefObject<number | undefined>
 }): Middleware {
-  const {apply, margins, padding = 0} = options
+  const {
+    constrainSize,
+    margins,
+    matchReferenceWidth,
+    maxWidthRef,
+    padding = 0,
+    referenceWidthRef,
+    setReferenceWidth,
+    widthRef,
+  } = options
 
   return {
     name: '@sanity/ui/size',
@@ -61,12 +66,23 @@ export function size(options: {
 
       // IMPORTANT – APPLY ELEMENT STYLES HERE
       // Elements need to be resized BEFORE the `platform.getDimensions` call below
-      apply({
-        availableWidth: maxWidth - margins[1] - margins[3],
-        availableHeight: maxHeight - margins[0] - margins[2],
-        elements,
-        referenceWidth: reference.width - margins[1] - margins[3],
-      })
+      const availableWidth = maxWidth - margins[1] - margins[3]
+      const availableHeight = maxHeight - margins[0] - margins[2]
+      const referenceWidth = reference.width - margins[1] - margins[3]
+      referenceWidthRef.current = referenceWidth
+      setReferenceWidth(referenceWidth)
+
+      if (matchReferenceWidth) {
+        elements.floating.style.width = `${referenceWidth}px`
+      } else if (widthRef.current !== undefined) {
+        elements.floating.style.width = `${widthRef.current}px`
+      }
+
+      if (constrainSize) {
+        elements.floating.style.maxWidth = `${Math.min(availableWidth, maxWidthRef.current ?? Infinity)}px`
+
+        elements.floating.style.maxHeight = `${availableHeight}px`
+      }
 
       const nextDimensions = await platform.getDimensions(elements.floating)
 

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -15,14 +15,13 @@ import {AnimatePresence} from 'framer-motion'
 import {
   cloneElement,
   forwardRef,
-  memo,
-  MutableRefObject,
-  RefCallback,
+  type Ref,
   useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 
 import {useArrayProp, useElementSize, useMediaIndex, usePrefersReducedMotion} from '../../hooks'
@@ -119,9 +118,7 @@ export interface PopoverProps
   scheme?: ThemeColorSchemeKey
   tone?: CardTone
   /** @beta */
-  updateRef?:
-    | MutableRefObject<PopoverUpdateCallback | undefined>
-    | RefCallback<PopoverUpdateCallback | undefined>
+  updateRef?: Ref<PopoverUpdateCallback | undefined>
   width?: PopoverWidth | PopoverWidth[]
 }
 
@@ -136,349 +133,378 @@ const ViewportOverlay = () => {
  *
  * @public
  */
-export const Popover = memo(
-  forwardRef(function Popover(
-    props: PopoverProps &
-      Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content' | 'width'>,
-    forwardedRef: React.ForwardedRef<HTMLDivElement>,
-  ): React.JSX.Element {
-    const {container, layer} = useTheme_v2()
-    const boundaryElementContext = useBoundaryElement()
+export const Popover = forwardRef(function Popover(
+  props: PopoverProps &
+    Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content' | 'width'>,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+): React.JSX.Element {
+  const {container, layer} = useTheme_v2()
+  const boundaryElementContext = useBoundaryElement()
 
-    const {
-      __unstable_margins: margins = DEFAULT_POPOVER_MARGINS,
-      animate: _animate = false,
-      arrow: arrowProp = false,
-      boundaryElement = boundaryElementContext.element,
-      children: childProp,
-      constrainSize = false,
-      content,
-      disabled,
-      fallbackPlacements = props.fallbackPlacements ??
-        DEFAULT_FALLBACK_PLACEMENTS[props.placement ?? 'bottom'],
-      matchReferenceWidth,
-      floatingBoundary = props.boundaryElement ?? boundaryElementContext.element,
-      modal,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      onActivate,
-      open,
-      overflow = 'hidden',
-      padding: paddingProp,
-      placement: placementProp = 'bottom',
-      placementStrategy = 'flip',
-      portal,
-      preventOverflow = true,
-      radius: radiusProp = 3,
-      referenceBoundary = props.boundaryElement ?? boundaryElementContext.element,
-      referenceElement,
-      scheme,
-      shadow: shadowProp = 3,
-      tone = 'inherit',
-      width: widthProp = 'auto',
-      zOffset: zOffsetProp = layer.popover.zOffset,
-      updateRef,
-      ...restProps
-    } = props
-    const prefersReducedMotion = usePrefersReducedMotion()
-    const animate = prefersReducedMotion ? false : _animate
-    const boundarySize = useElementSize(boundaryElement)?.border
-    const padding = useArrayProp(paddingProp)
-    const radius = useArrayProp(radiusProp)
-    const shadow = useArrayProp(shadowProp)
-    const widthArrayProp = useArrayProp(widthProp)
-    const zOffset = useArrayProp(zOffsetProp)
-    const ref = useRef<HTMLDivElement | null>(null)
-    const arrowRef = useRef<HTMLDivElement | null>(null)
-    const rootBoundary: RootBoundary = 'viewport'
+  const {
+    __unstable_margins: margins = DEFAULT_POPOVER_MARGINS,
+    animate: _animate = false,
+    arrow: arrowProp = false,
+    boundaryElement: _boundaryElement,
+    children: childProp,
+    constrainSize = false,
+    content,
+    disabled,
+    fallbackPlacements: _fallbackPlacements,
+    matchReferenceWidth,
+    floatingBoundary: _floatingBoundary,
+    modal,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onActivate,
+    open,
+    overflow = 'hidden',
+    padding: paddingProp,
+    placement: placementProp = 'bottom',
+    placementStrategy = 'flip',
+    portal,
+    preventOverflow = true,
+    radius: radiusProp = 3,
+    referenceBoundary: _referenceBoundary,
+    referenceElement,
+    scheme,
+    shadow: shadowProp = 3,
+    tone = 'inherit',
+    width: widthProp = 'auto',
+    zOffset: _zOffsetProp,
+    updateRef,
+    ...restProps
+  } = props
+  const boundaryElement = _boundaryElement ?? boundaryElementContext?.element
+  const fallbackPlacements =
+    _fallbackPlacements ?? DEFAULT_FALLBACK_PLACEMENTS[props.placement ?? 'bottom']
+  const floatingBoundary =
+    _floatingBoundary ?? props.boundaryElement ?? boundaryElementContext.element
+  const referenceBoundary =
+    _referenceBoundary ?? props.boundaryElement ?? boundaryElementContext.element
+  const zOffsetProp = _zOffsetProp ?? layer.popover.zOffset
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const animate = prefersReducedMotion ? false : _animate
+  const boundarySize = useElementSize(boundaryElement)?.border
+  const padding = useArrayProp(paddingProp)
+  const radius = useArrayProp(radiusProp)
+  const shadow = useArrayProp(shadowProp)
+  const widthArrayProp = useArrayProp(widthProp)
+  const zOffset = useArrayProp(zOffsetProp)
+  const ref = useRef<HTMLDivElement | null>(null)
+  const arrowRef = useRef<HTMLDivElement | null>(null)
+  const rootBoundary: RootBoundary = 'viewport'
 
-    useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
-      forwardedRef,
-      () => ref.current,
-    )
+  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(forwardedRef, () => ref.current)
 
-    const mediaIndex = useMediaIndex()
-    const boundaryWidth = constrainSize || preventOverflow ? boundarySize?.width : undefined
+  const mediaIndex = useMediaIndex()
+  const boundaryWidth = constrainSize || preventOverflow ? boundarySize?.width : undefined
 
-    // Update width when
-    // - media index changes
-    // - `width` property changes
-    const width = calcCurrentWidth({
-      container,
-      mediaIndex,
-      width: widthArrayProp,
-    })
-    const widthRef = useRef(width)
+  // Update width when
+  // - media index changes
+  // - `width` property changes
+  const width = calcCurrentWidth({
+    container,
+    mediaIndex,
+    width: widthArrayProp,
+  })
+  const widthRef = useRef(width)
 
-    useEffect(() => {
-      widthRef.current = width
-    }, [width])
+  useEffect(() => {
+    widthRef.current = width
+  }, [width])
 
-    // Update max width when
-    // - boundary width changes
-    // - `width` property changes
-    const maxWidth = calcMaxWidth({boundaryWidth, currentWidth: width})
-    const maxWidthRef = useRef(maxWidth)
+  // Update max width when
+  // - boundary width changes
+  // - `width` property changes
+  const maxWidth = calcMaxWidth({boundaryWidth, currentWidth: width})
+  const maxWidthRef = useRef(maxWidth)
 
-    useEffect(() => {
-      maxWidthRef.current = maxWidth
-    }, [maxWidth])
+  useEffect(() => {
+    maxWidthRef.current = maxWidth
+  }, [maxWidth])
 
-    // Keep track of reference element width (see `size` middleware below)
-    const referenceWidthRef = useRef<number>(undefined)
+  // Keep track of reference element width (see `size` middleware below)
+  const referenceWidthRef = useRef<number>(undefined)
 
-    // Force apply width & max width to floating element
-    useEffect(() => {
-      const floatingElement = ref.current
+  // Force apply width & max width to floating element
+  useEffect(() => {
+    const floatingElement = ref.current
 
-      if (!open || !floatingElement) return
+    if (!open || !floatingElement) return
 
-      const referenceWidth = referenceWidthRef.current
+    const referenceWidth = referenceWidthRef.current
 
-      if (matchReferenceWidth) {
-        if (referenceWidth !== undefined) {
-          floatingElement.style.width = `${referenceWidth}px`
-        }
-      } else if (width !== undefined) {
-        floatingElement.style.width = `${width}px`
+    if (matchReferenceWidth) {
+      if (referenceWidth !== undefined) {
+        floatingElement.style.width = `${referenceWidth}px`
       }
-
-      if (typeof maxWidth === 'number') {
-        floatingElement.style.maxWidth = `${maxWidth}px`
-      }
-    }, [width, matchReferenceWidth, maxWidth, open])
-
-    const middleware = useMemo(() => {
-      const ret: Middleware[] = []
-
-      // Flip the floating element when leaving the boundary box
-      if (constrainSize || preventOverflow) {
-        if (placementStrategy === 'autoPlacement') {
-          ret.push(
-            autoPlacement({
-              allowedPlacements: [placementProp].concat(fallbackPlacements),
-            }),
-          )
-        } else {
-          ret.push(
-            flip({
-              boundary: floatingBoundary || undefined,
-              fallbackPlacements,
-              padding: DEFAULT_POPOVER_PADDING,
-              rootBoundary,
-            }),
-          )
-        }
-      }
-
-      // Define distance between reference and floating element
-      ret.push(offset({mainAxis: DEFAULT_POPOVER_DISTANCE}))
-
-      // Track sizes
-      if (constrainSize || matchReferenceWidth) {
-        ret.push(
-          size({
-            apply({availableWidth, availableHeight, elements, referenceWidth}) {
-              // not fresh, so use refs
-
-              referenceWidthRef.current = referenceWidth
-
-              const _currentWidth = widthRef.current
-              const _maxWidth = maxWidthRef.current
-
-              if (matchReferenceWidth) {
-                elements.floating.style.width = `${referenceWidth}px`
-              } else if (_currentWidth !== undefined) {
-                elements.floating.style.width = `${_currentWidth}px`
-              }
-
-              if (constrainSize) {
-                elements.floating.style.maxWidth = `${Math.min(
-                  availableWidth,
-                  _maxWidth ?? Infinity,
-                )}px`
-
-                elements.floating.style.maxHeight = `${availableHeight}px`
-              }
-            },
-            boundaryElement: floatingBoundary || undefined,
-            constrainSize,
-            margins,
-            matchReferenceWidth,
-            padding: DEFAULT_POPOVER_PADDING,
-          }),
-        )
-      }
-
-      // Shift the popover so its sits within the boundary element
-      if (preventOverflow) {
-        ret.push(
-          shift({
-            boundary: floatingBoundary || undefined,
-            rootBoundary,
-            padding: DEFAULT_POPOVER_PADDING,
-          }),
-        )
-      }
-
-      // Place arrow
-      if (arrowProp) {
-        ret.push(
-          arrow({
-            element: arrowRef,
-            padding: DEFAULT_POPOVER_PADDING,
-          }),
-        )
-      }
-
-      // Determine the origin to scale from.
-      // Must be placed after `@sanity/ui/size` and `shift` middleware.
-      if (animate) {
-        ret.push(origin)
-      }
-
-      ret.push(
-        hide({
-          boundary: referenceBoundary || undefined,
-          padding: DEFAULT_POPOVER_PADDING,
-          strategy: 'referenceHidden',
-        }),
-      )
-
-      return ret
-    }, [
-      animate,
-      arrowProp,
-      constrainSize,
-      fallbackPlacements,
-      placementProp,
-      placementStrategy,
-      floatingBoundary,
-      margins,
-      matchReferenceWidth,
-      preventOverflow,
-      referenceBoundary,
-    ])
-
-    const {x, y, middlewareData, placement, refs, strategy, update} = useFloating({
-      middleware,
-      placement: placementProp,
-      whileElementsMounted: autoUpdate,
-      elements: referenceElement
-        ? {
-            reference: referenceElement,
-          }
-        : undefined,
-    })
-
-    const referenceHidden = middlewareData.hide?.referenceHidden
-
-    const arrowX = middlewareData.arrow?.x
-    const arrowY = middlewareData.arrow?.y
-
-    const originX = middlewareData['@sanity/ui/origin']?.originX
-    const originY = middlewareData['@sanity/ui/origin']?.originY
-
-    const setArrow = useCallback((arrowEl: HTMLDivElement | null) => {
-      arrowRef.current = arrowEl
-    }, [])
-
-    const setFloating = useCallback(
-      (node: HTMLDivElement | null) => {
-        ref.current = node
-        refs.setFloating(node)
-      },
-      [refs],
-    )
-
-    const setReference = useCallback(
-      (node: HTMLElement | null) => {
-        refs.setReference(node)
-
-        const childRef = getElementRef(childProp as any)
-
-        if (typeof childRef === 'function') {
-          childRef(node)
-        } else if (childRef) {
-          childRef.current = node
-        }
-      },
-      [childProp, refs],
-    )
-
-    const child = useMemo(() => {
-      // If a reference element is defined, we don't need to clone the child
-      if (referenceElement) return childProp
-
-      if (!childProp) return null
-
-      return cloneElement(childProp, {ref: setReference})
-    }, [childProp, referenceElement, setReference])
-
-    useEffect(() => {
-      if (updateRef) {
-        if (typeof updateRef === 'function') {
-          updateRef(update)
-        } else if (updateRef) {
-          updateRef.current = update
-        }
-      }
-    }, [update, updateRef])
-
-    if (disabled) {
-      return childProp || <></>
+    } else if (width !== undefined) {
+      floatingElement.style.width = `${width}px`
     }
 
-    const popover = (
-      <LayerProvider zOffset={zOffset}>
-        {/* Optional transparent blocking overlay at the top-most z-index layer. Must be positioned before the below popover card. */}
-        {modal && <ViewportOverlay />}
+    if (typeof maxWidth === 'number') {
+      floatingElement.style.maxWidth = `${maxWidth}px`
+    }
+  }, [width, matchReferenceWidth, maxWidth, open])
 
-        <PopoverCard
-          {...restProps}
-          __unstable_margins={margins}
-          animate={animate}
-          arrow={arrowProp}
-          arrowRef={setArrow}
-          arrowX={arrowX}
-          arrowY={arrowY}
-          hidden={referenceHidden}
-          overflow={overflow}
-          padding={padding}
-          placement={placement}
-          radius={radius}
-          ref={setFloating}
-          scheme={scheme}
-          shadow={shadow}
-          originX={originX}
-          originY={originY}
-          strategy={strategy}
-          tone={tone}
-          width={matchReferenceWidth ? referenceWidthRef.current : width}
-          x={x}
-          y={y}
-        >
-          {content}
-        </PopoverCard>
-      </LayerProvider>
+  const [referenceWidth, setReferenceWidth] = useState<number | undefined>(undefined)
+  const middleware = useMiddleware({
+    animate,
+    arrowProp,
+    arrowRef,
+    constrainSize,
+    fallbackPlacements,
+    floatingBoundary,
+    margins,
+    matchReferenceWidth,
+    maxWidthRef,
+    placementProp,
+    placementStrategy,
+    preventOverflow,
+    referenceBoundary,
+    referenceWidthRef,
+    rootBoundary,
+    setReferenceWidth,
+    widthRef,
+  })
+
+  const {x, y, middlewareData, placement, refs, strategy, update} = useFloating({
+    middleware,
+    placement: placementProp,
+    whileElementsMounted: autoUpdate,
+    elements: referenceElement
+      ? {
+          reference: referenceElement,
+        }
+      : undefined,
+  })
+
+  const referenceHidden = middlewareData.hide?.referenceHidden
+
+  const arrowX = middlewareData.arrow?.x
+  const arrowY = middlewareData.arrow?.y
+
+  const originX = middlewareData['@sanity/ui/origin']?.originX
+  const originY = middlewareData['@sanity/ui/origin']?.originY
+
+  const setArrow = useCallback((arrowEl: HTMLDivElement | null) => {
+    arrowRef.current = arrowEl
+  }, [])
+
+  const setFloating = useCallback(
+    (node: HTMLDivElement | null) => {
+      ref.current = node
+      refs.setFloating(node)
+    },
+    [refs],
+  )
+
+  // If there's a child then we need to set the reference element to the cloned child ref
+  // and if child changes we make sure to update or remove the reference element.
+  useImperativeHandle(childProp ? getElementRef(childProp) : null, () => refs.reference.current)
+
+  const child = useMemo(() => {
+    // If a reference element is defined, we don't need to clone the child
+    if (referenceElement) return childProp
+
+    if (!childProp) return null
+
+    return cloneElement(childProp, {ref: refs.setReference})
+  }, [childProp, referenceElement, refs.setReference])
+
+  useImperativeHandle(updateRef, () => update, [update])
+
+  if (disabled) {
+    return childProp || <></>
+  }
+
+  const popover = (
+    <LayerProvider zOffset={zOffset}>
+      {/* Optional transparent blocking overlay at the top-most z-index layer. Must be positioned before the below popover card. */}
+      {modal && <ViewportOverlay />}
+
+      <PopoverCard
+        {...restProps}
+        __unstable_margins={margins}
+        animate={animate}
+        arrow={arrowProp}
+        arrowRef={setArrow}
+        arrowX={arrowX}
+        arrowY={arrowY}
+        hidden={referenceHidden}
+        overflow={overflow}
+        padding={padding}
+        placement={placement}
+        radius={radius}
+        ref={setFloating}
+        scheme={scheme}
+        shadow={shadow}
+        originX={originX}
+        originY={originY}
+        strategy={strategy}
+        tone={tone}
+        width={matchReferenceWidth ? referenceWidth : width}
+        x={x}
+        y={y}
+      >
+        {content}
+      </PopoverCard>
+    </LayerProvider>
+  )
+
+  const children =
+    open &&
+    (portal ? (
+      <Portal __unstable_name={typeof portal === 'string' ? portal : undefined}>{popover}</Portal>
+    ) : (
+      popover
+    ))
+
+  return (
+    <>
+      {/* the popover */}
+      {animate ? <AnimatePresence>{children}</AnimatePresence> : children}
+
+      {/* the referred element */}
+      {child}
+    </>
+  )
+})
+Popover.displayName = 'ForwardRef(Popover)'
+
+function useMiddleware({
+  animate,
+  arrowProp,
+  arrowRef,
+  constrainSize,
+  fallbackPlacements,
+  floatingBoundary,
+  margins,
+  matchReferenceWidth,
+  maxWidthRef,
+  placementProp,
+  placementStrategy,
+  preventOverflow,
+  referenceBoundary,
+  referenceWidthRef,
+  rootBoundary,
+  setReferenceWidth,
+  widthRef,
+}: {
+  animate: boolean
+  arrowProp: boolean
+  arrowRef: React.RefObject<HTMLDivElement | null>
+  constrainSize: boolean
+  fallbackPlacements: Placement[]
+  floatingBoundary: HTMLElement | null
+  margins: PopoverMargins
+  matchReferenceWidth: boolean | undefined
+  maxWidthRef: React.RefObject<number | undefined>
+  placementProp: Placement
+  placementStrategy: 'flip' | 'autoPlacement'
+  preventOverflow: boolean
+  referenceBoundary: HTMLElement | null
+  referenceWidthRef: React.RefObject<number | undefined>
+  rootBoundary: RootBoundary
+  setReferenceWidth: (referenceWidth: number) => void
+  widthRef: React.RefObject<number | undefined>
+}) {
+  return useMemo(() => {
+    const ret: Middleware[] = []
+
+    // Flip the floating element when leaving the boundary box
+    if (constrainSize || preventOverflow) {
+      if (placementStrategy === 'autoPlacement') {
+        ret.push(
+          autoPlacement({
+            allowedPlacements: [placementProp].concat(fallbackPlacements),
+          }),
+        )
+      } else {
+        ret.push(
+          flip({
+            boundary: floatingBoundary || undefined,
+            fallbackPlacements,
+            padding: DEFAULT_POPOVER_PADDING,
+            rootBoundary,
+          }),
+        )
+      }
+    }
+
+    // Define distance between reference and floating element
+    ret.push(offset({mainAxis: DEFAULT_POPOVER_DISTANCE}))
+
+    // Track sizes
+    if (constrainSize || matchReferenceWidth) {
+      ret.push(
+        size({
+          boundaryElement: floatingBoundary || undefined,
+          constrainSize,
+          margins,
+          matchReferenceWidth,
+          maxWidthRef,
+          padding: DEFAULT_POPOVER_PADDING,
+          referenceWidthRef,
+          setReferenceWidth,
+          widthRef,
+        }),
+      )
+    }
+
+    // Shift the popover so its sits within the boundary element
+    if (preventOverflow) {
+      ret.push(
+        shift({
+          boundary: floatingBoundary || undefined,
+          rootBoundary,
+          padding: DEFAULT_POPOVER_PADDING,
+        }),
+      )
+    }
+
+    // Place arrow
+    if (arrowProp) {
+      ret.push(
+        arrow({
+          element: arrowRef,
+          padding: DEFAULT_POPOVER_PADDING,
+        }),
+      )
+    }
+
+    // Determine the origin to scale from.
+    // Must be placed after `@sanity/ui/size` and `shift` middleware.
+    if (animate) {
+      ret.push(origin)
+    }
+
+    ret.push(
+      hide({
+        boundary: referenceBoundary || undefined,
+        padding: DEFAULT_POPOVER_PADDING,
+        strategy: 'referenceHidden',
+      }),
     )
 
-    const children =
-      open &&
-      (portal ? (
-        <Portal __unstable_name={typeof portal === 'string' ? portal : undefined}>{popover}</Portal>
-      ) : (
-        popover
-      ))
-
-    return (
-      <>
-        {/* the popover */}
-        {animate ? <AnimatePresence>{children}</AnimatePresence> : children}
-
-        {/* the referred element */}
-        {child}
-      </>
-    )
-  }),
-)
-Popover.displayName = 'Memo(ForwardRef(Popover))'
+    return ret
+  }, [
+    animate,
+    arrowProp,
+    arrowRef,
+    constrainSize,
+    fallbackPlacements,
+    floatingBoundary,
+    margins,
+    matchReferenceWidth,
+    maxWidthRef,
+    placementProp,
+    placementStrategy,
+    preventOverflow,
+    referenceBoundary,
+    referenceWidthRef,
+    rootBoundary,
+    setReferenceWidth,
+    widthRef,
+  ])
+}

--- a/src/core/primitives/popover/popoverCard.tsx
+++ b/src/core/primitives/popover/popoverCard.tsx
@@ -1,7 +1,7 @@
 import {Strategy} from '@floating-ui/react-dom'
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'
 import {motion, type MotionProps} from 'framer-motion'
-import React, {CSSProperties, forwardRef, memo, useMemo} from 'react'
+import React, {CSSProperties, forwardRef, useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {POPOVER_MOTION_PROPS} from '../../constants'
@@ -33,136 +33,134 @@ const MotionFlex = styled(motion.create(Flex))`
 /**
  * @internal
  */
-export const PopoverCard = memo(
-  forwardRef(function PopoverCard(
-    props: {
-      /** @beta*/
-      __unstable_margins?: PopoverMargins
-      animate?: boolean
-      arrow: boolean
-      arrowRef: React.Ref<HTMLDivElement>
-      arrowX?: number
-      arrowY?: number
-      originX?: number
-      originY?: number
-      overflow?: BoxOverflow
-      padding?: number | number[]
-      placement: Placement
-      radius?: Radius | Radius[]
-      scheme?: ThemeColorSchemeKey
-      shadow?: number | number[]
-      strategy: Strategy
-      tone: CardTone
-      width: number | undefined
-      x: number | null
-      y: number | null
-    } & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
-    ref: React.ForwardedRef<HTMLDivElement>,
-  ) {
-    const {
-      __unstable_margins: marginsProp,
-      animate,
-      arrow,
-      arrowRef,
-      arrowX,
-      arrowY,
-      children,
-      padding,
-      placement,
+export const PopoverCard = forwardRef(function PopoverCard(
+  props: {
+    /** @beta*/
+    __unstable_margins?: PopoverMargins
+    animate?: boolean
+    arrow: boolean
+    arrowRef: React.Ref<HTMLDivElement>
+    arrowX?: number
+    arrowY?: number
+    originX?: number
+    originY?: number
+    overflow?: BoxOverflow
+    padding?: number | number[]
+    placement: Placement
+    radius?: Radius | Radius[]
+    scheme?: ThemeColorSchemeKey
+    shadow?: number | number[]
+    strategy: Strategy
+    tone: CardTone
+    width: number | undefined
+    x: number | null
+    y: number | null
+  } & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {
+    __unstable_margins: marginsProp,
+    animate,
+    arrow,
+    arrowRef,
+    arrowX,
+    arrowY,
+    children,
+    padding,
+    placement,
+    originX,
+    originY,
+    overflow,
+    radius,
+    scheme,
+    shadow,
+    strategy,
+    style,
+    tone,
+    width,
+    x: xProp,
+    y: yProp,
+    ...restProps
+  } = props
+
+  const {zIndex} = useLayer()
+
+  // Get margins: [top, right, bottom, left]
+  const margins: PopoverMargins = useMemo(
+    () => marginsProp || DEFAULT_POPOVER_MARGINS,
+    [marginsProp],
+  )
+
+  // Translate according to margins
+  const x = (xProp ?? 0) + margins[3]
+  const y = (yProp ?? 0) + margins[0]
+
+  const rootStyle: CSSProperties = useMemo(
+    () => ({
+      left: x,
       originX,
       originY,
-      overflow,
-      radius,
-      scheme,
-      shadow,
-      strategy,
-      style,
-      tone,
+      position: strategy,
+      top: y,
       width,
-      x: xProp,
-      y: yProp,
-      ...restProps
-    } = props
+      zIndex,
+      willChange: animate ? 'transform' : undefined,
+      ...style,
+    }),
+    [animate, originX, originY, strategy, style, width, x, y, zIndex],
+  )
 
-    const {zIndex} = useLayer()
+  const arrowStyle: CSSProperties = useMemo(
+    () => ({
+      left: arrowX !== null ? arrowX : undefined,
+      top: arrowY !== null ? arrowY : undefined,
+      right: undefined,
+      bottom: undefined,
+    }),
+    [arrowX, arrowY],
+  )
 
-    // Get margins: [top, right, bottom, left]
-    const margins: PopoverMargins = useMemo(
-      () => marginsProp || DEFAULT_POPOVER_MARGINS,
-      [marginsProp],
-    )
-
-    // Translate according to margins
-    const x = (xProp ?? 0) + margins[3]
-    const y = (yProp ?? 0) + margins[0]
-
-    const rootStyle: CSSProperties = useMemo(
-      () => ({
-        left: x,
-        originX,
-        originY,
-        position: strategy,
-        top: y,
-        width,
-        zIndex,
-        willChange: animate ? 'transform' : undefined,
-        ...style,
-      }),
-      [animate, originX, originY, strategy, style, width, x, y, zIndex],
-    )
-
-    const arrowStyle: CSSProperties = useMemo(
-      () => ({
-        left: arrowX !== null ? arrowX : undefined,
-        top: arrowY !== null ? arrowY : undefined,
-        right: undefined,
-        bottom: undefined,
-      }),
-      [arrowX, arrowY],
-    )
-
-    return (
-      <MotionCard
-        data-ui="Popover"
-        {...(restProps as CardProps & MotionProps)}
-        data-placement={placement}
-        radius={radius}
-        ref={ref}
-        scheme={scheme}
-        shadow={shadow}
-        sizing="border"
-        style={rootStyle}
-        tone={tone}
-        variants={POPOVER_MOTION_PROPS.card}
+  return (
+    <MotionCard
+      data-ui="Popover"
+      {...(restProps as CardProps & MotionProps)}
+      data-placement={placement}
+      radius={radius}
+      ref={ref}
+      scheme={scheme}
+      shadow={shadow}
+      sizing="border"
+      style={rootStyle}
+      tone={tone}
+      variants={POPOVER_MOTION_PROPS.card}
+      transition={POPOVER_MOTION_PROPS.transition}
+      initial={animate ? ['hidden', 'initial'] : undefined}
+      animate={animate ? ['visible', 'scaleIn'] : undefined}
+      exit={animate ? ['hidden', 'scaleOut'] : undefined}
+    >
+      <MotionFlex
+        data-ui="Popover__wrapper"
+        direction="column"
+        flex={1}
+        overflow={overflow}
+        variants={POPOVER_MOTION_PROPS.children}
         transition={POPOVER_MOTION_PROPS.transition}
-        initial={animate ? ['hidden', 'initial'] : undefined}
-        animate={animate ? ['visible', 'scaleIn'] : undefined}
-        exit={animate ? ['hidden', 'scaleOut'] : undefined}
       >
-        <MotionFlex
-          data-ui="Popover__wrapper"
-          direction="column"
-          flex={1}
-          overflow={overflow}
-          variants={POPOVER_MOTION_PROPS.children}
-          transition={POPOVER_MOTION_PROPS.transition}
-        >
-          <Flex direction="column" flex={1} padding={padding}>
-            {children}
-          </Flex>
-        </MotionFlex>
+        <Flex direction="column" flex={1} padding={padding}>
+          {children}
+        </Flex>
+      </MotionFlex>
 
-        {arrow && (
-          <Arrow
-            ref={arrowRef}
-            style={arrowStyle}
-            width={DEFAULT_POPOVER_ARROW_WIDTH}
-            height={DEFAULT_POPOVER_ARROW_HEIGHT}
-            radius={DEFAULT_POPOVER_ARROW_RADIUS}
-          />
-        )}
-      </MotionCard>
-    )
-  }),
-)
-PopoverCard.displayName = 'Memo(ForwardRef(PopoverCard))'
+      {arrow && (
+        <Arrow
+          ref={arrowRef}
+          style={arrowStyle}
+          width={DEFAULT_POPOVER_ARROW_WIDTH}
+          height={DEFAULT_POPOVER_ARROW_HEIGHT}
+          radius={DEFAULT_POPOVER_ARROW_RADIUS}
+        />
+      )}
+    </MotionCard>
+  )
+})
+PopoverCard.displayName = 'ForwardRef(PopoverCard)'

--- a/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/src/core/primitives/tooltip/tooltipCard.tsx
@@ -1,6 +1,6 @@
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'
 import {motion, type MotionProps} from 'framer-motion'
-import React, {CSSProperties, forwardRef, memo, useMemo} from 'react'
+import React, {CSSProperties, forwardRef, useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {POPOVER_MOTION_PROPS} from '../../constants'
@@ -20,92 +20,90 @@ const MotionCard = styled(motion.create(Card))`
 /**
  * @internal
  */
-export const TooltipCard = memo(
-  forwardRef(function TooltipCard(
-    props: {
-      animate?: boolean
-      arrow: boolean
-      arrowRef: React.Ref<HTMLDivElement>
-      arrowX?: number
-      arrowY?: number
-      originX?: number
-      originY?: number
-      padding?: number | number[]
-      placement?: Placement
-      radius?: Radius | Radius[]
-      scheme?: ThemeColorSchemeKey
-      shadow?: number | number[]
-    } & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
-    ref: React.ForwardedRef<HTMLDivElement>,
-  ) {
-    const {
-      animate,
-      arrow,
-      arrowRef,
-      arrowX,
-      arrowY,
-      children,
+export const TooltipCard = forwardRef(function TooltipCard(
+  props: {
+    animate?: boolean
+    arrow: boolean
+    arrowRef: React.Ref<HTMLDivElement>
+    arrowX?: number
+    arrowY?: number
+    originX?: number
+    originY?: number
+    padding?: number | number[]
+    placement?: Placement
+    radius?: Radius | Radius[]
+    scheme?: ThemeColorSchemeKey
+    shadow?: number | number[]
+  } & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {
+    animate,
+    arrow,
+    arrowRef,
+    arrowX,
+    arrowY,
+    children,
+    originX,
+    originY,
+    padding,
+    placement,
+    radius,
+    scheme,
+    shadow,
+    style,
+    ...restProps
+  } = props
+
+  const rootStyle: CSSProperties = useMemo(
+    () => ({
       originX,
       originY,
-      padding,
-      placement,
-      radius,
-      scheme,
-      shadow,
-      style,
-      ...restProps
-    } = props
+      willChange: animate ? 'transform' : undefined,
+      ...style,
+    }),
+    [animate, originX, originY, style],
+  )
 
-    const rootStyle: CSSProperties = useMemo(
-      () => ({
-        originX,
-        originY,
-        willChange: animate ? 'transform' : undefined,
-        ...style,
-      }),
-      [animate, originX, originY, style],
-    )
+  const arrowStyle: CSSProperties = useMemo(
+    () => ({
+      left: arrowX !== null ? arrowX : undefined,
+      top: arrowY !== null ? arrowY : undefined,
+      right: undefined,
+      bottom: undefined,
+    }),
+    [arrowX, arrowY],
+  )
 
-    const arrowStyle: CSSProperties = useMemo(
-      () => ({
-        left: arrowX !== null ? arrowX : undefined,
-        top: arrowY !== null ? arrowY : undefined,
-        right: undefined,
-        bottom: undefined,
-      }),
-      [arrowX, arrowY],
-    )
+  return (
+    <MotionCard
+      data-ui="Tooltip__card"
+      {...(restProps as CardProps & MotionProps)}
+      data-placement={placement}
+      padding={padding}
+      radius={radius}
+      ref={ref}
+      scheme={scheme}
+      shadow={shadow}
+      style={rootStyle}
+      variants={POPOVER_MOTION_PROPS.card}
+      transition={POPOVER_MOTION_PROPS.transition}
+      initial={animate ? ['hidden', 'initial'] : undefined}
+      animate={animate ? ['visible', 'scaleIn'] : undefined}
+      exit={animate ? ['hidden', 'scaleOut'] : undefined}
+    >
+      {children}
 
-    return (
-      <MotionCard
-        data-ui="Tooltip__card"
-        {...(restProps as CardProps & MotionProps)}
-        data-placement={placement}
-        padding={padding}
-        radius={radius}
-        ref={ref}
-        scheme={scheme}
-        shadow={shadow}
-        style={rootStyle}
-        variants={POPOVER_MOTION_PROPS.card}
-        transition={POPOVER_MOTION_PROPS.transition}
-        initial={animate ? ['hidden', 'initial'] : undefined}
-        animate={animate ? ['visible', 'scaleIn'] : undefined}
-        exit={animate ? ['hidden', 'scaleOut'] : undefined}
-      >
-        {children}
-
-        {arrow && (
-          <Arrow
-            ref={arrowRef}
-            style={arrowStyle}
-            width={DEFAULT_TOOLTIP_ARROW_WIDTH}
-            height={DEFAULT_TOOLTIP_ARROW_HEIGHT}
-            radius={DEFAULT_TOOLTIP_ARROW_RADIUS}
-          />
-        )}
-      </MotionCard>
-    )
-  }),
-)
-TooltipCard.displayName = 'Memo(ForwardRef(TooltipCard))'
+      {arrow && (
+        <Arrow
+          ref={arrowRef}
+          style={arrowStyle}
+          width={DEFAULT_TOOLTIP_ARROW_WIDTH}
+          height={DEFAULT_TOOLTIP_ARROW_HEIGHT}
+          radius={DEFAULT_TOOLTIP_ARROW_RADIUS}
+        />
+      )}
+    </MotionCard>
+  )
+})
+TooltipCard.displayName = 'ForwardRef(TooltipCard)'

--- a/src/core/utils/virtualList/virtualList.tsx
+++ b/src/core/utils/virtualList/virtualList.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState} from 'react'
+import {forwardRef, useEffect, useImperativeHandle, useRef, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {_isScrollable} from '../../helpers'
@@ -131,37 +131,62 @@ export const VirtualList = forwardRef(function VirtualList(
     onChange({fromIndex, gap: space[gap], itemHeight, scrollHeight, scrollTop, toIndex})
   }, [fromIndex, gap, itemHeight, onChange, scrollHeight, scrollTop, space, toIndex])
 
-  const children = useMemo(() => {
-    if (!renderItem || items.length === 0) return null
-
-    if (itemHeight === -1) {
-      return [<ItemWrapper key={0}>{renderItem(items[0])}</ItemWrapper>]
-    }
-
-    return items.slice(fromIndex, toIndex).map((item, _itemIndex) => {
-      const itemIndex = fromIndex + _itemIndex
-      const node = renderItem(item)
-      const key = getItemKey ? getItemKey(item, itemIndex) : itemIndex
-
-      return (
-        <ItemWrapper key={key} style={{top: itemIndex * (itemHeight + space[gap])}}>
-          {node}
-        </ItemWrapper>
-      )
-    })
-  }, [fromIndex, gap, getItemKey, itemHeight, items, renderItem, space, toIndex])
-
-  const wrapperStyle = useMemo(() => ({height}), [height])
+  const children = useChildren({
+    fromIndex,
+    gap,
+    itemHeight,
+    space,
+    toIndex,
+    getItemKey,
+    items,
+    renderItem,
+  })
 
   return (
     <StyledVirtualList as={as} data-ui="VirtualList" {...restProps} ref={ref}>
-      <div ref={wrapperRef} style={wrapperStyle}>
+      <div ref={wrapperRef} style={{height}}>
         {children}
       </div>
     </StyledVirtualList>
   )
 })
 VirtualList.displayName = 'ForwardRef(VirtualList)'
+
+function useChildren({
+  fromIndex,
+  gap,
+  getItemKey,
+  itemHeight,
+  items,
+  renderItem,
+  space,
+  toIndex,
+}: Pick<VirtualListProps, 'getItemKey' | 'renderItem'> &
+  Required<Pick<VirtualListProps, 'items'>> & {
+    fromIndex: number
+    gap: number
+    itemHeight: number
+    space: number[]
+    toIndex: number
+  }) {
+  if (!renderItem || items.length === 0) return null
+
+  if (itemHeight === -1) {
+    return [<ItemWrapper key={0}>{renderItem(items[0])}</ItemWrapper>]
+  }
+
+  return items.slice(fromIndex, toIndex).map((item, _itemIndex) => {
+    const itemIndex = fromIndex + _itemIndex
+    const node = renderItem(item)
+    const key = getItemKey ? getItemKey(item, itemIndex) : itemIndex
+
+    return (
+      <ItemWrapper key={key} style={{top: itemIndex * (itemHeight + space[gap])}}>
+        {node}
+      </ItemWrapper>
+    )
+  })
+}
 
 function findScrollable(parentNode: ParentNode | null) {
   let _scrollEl = parentNode


### PR DESCRIPTION
With this PR 100% of `@sanity/ui` is optimized with React Compiler, notably this includes `<Tooltip>` and `<Popover>`, which has previously never been optimized due to reading refs during render, as well as due to memoization mismatches.
https://npmdiff.dev/%40sanity%2Fui/3.0.11/3.0.12-canary.0/package/dist/_chunks-es/_visual-editing.mjs/