### PR TITLE
fix: remove `useArrayProp` usage

### DIFF
--- a/src/core/components/autocomplete/autocomplete.tsx
+++ b/src/core/components/autocomplete/autocomplete.tsx
@@ -21,7 +21,6 @@ import {
 
 import {EMPTY_ARRAY, EMPTY_RECORD} from '../../constants'
 import {_hasFocus, _raf, focusFirstDescendant} from '../../helpers'
-import {useArrayProp} from '../../hooks'
 import {
   Box,
   BoxProps,
@@ -33,6 +32,7 @@ import {
   Text,
   TextInput,
 } from '../../primitives'
+import {_getArrayProp} from '../../styles'
 import {Radius} from '../../types'
 import {AnimatedSpinnerIcon, ListBox, StyledAutocomplete} from './autocomplete.styles'
 import {AutocompleteOption} from './autocompleteOption'
@@ -214,7 +214,7 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
 
   const listBoxId = `${id}-listbox`
   const options = Array.isArray(optionsProp) ? optionsProp : EMPTY_ARRAY
-  const padding = useArrayProp(paddingProp)
+  const padding = _getArrayProp(paddingProp)
   const currentOption = useMemo(
     () => (value !== null ? options.find((o) => o.value === value) : undefined),
     [options, value],
@@ -470,18 +470,14 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
     return undefined
   }, [disabled, handleClearButtonFocus, loading, value])
 
-  const openButtonBoxPadding = useMemo(
-    () =>
-      padding.map((v) => {
-        if (v === 0) return 0
-        if (v === 1) return 1
-        if (v === 2) return 1
+  const openButtonBoxPadding = padding.map((v) => {
+    if (v === 0) return 0
+    if (v === 1) return 1
+    if (v === 2) return 1
 
-        return v - 2
-      }),
-    [padding],
-  )
-  const openButtonPadding = useMemo(() => padding.map((v) => Math.max(v - 1, 0)), [padding])
+    return v - 2
+  })
+  const openButtonPadding = padding.map((v) => Math.max(v - 1, 0))
   const openButtonProps: AutocompleteOpenButtonProps = useMemo(
     () => (typeof openButton === 'object' ? openButton : EMPTY_RECORD),
     [openButton],

--- a/src/core/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/core/components/breadcrumbs/breadcrumbs.tsx
@@ -9,8 +9,9 @@ import {
   useState,
 } from 'react'
 
-import {useArrayProp, useClickOutsideEvent} from '../../hooks'
+import {useClickOutsideEvent} from '../../hooks'
 import {Box, Popover, Stack, Text} from '../../primitives'
+import {_getArrayProp} from '../../styles'
 import {ExpandButton, StyledBreadcrumbs} from './breadcrumbs.styles'
 
 /**
@@ -30,7 +31,7 @@ export const Breadcrumbs = forwardRef(function Breadcrumbs(
   ref: React.ForwardedRef<HTMLOListElement>,
 ) {
   const {children, maxLength, separator, space: spaceRaw = 2, ...restProps} = props
-  const space = useArrayProp(spaceRaw)
+  const space = _getArrayProp(spaceRaw)
   const [open, setOpen] = useState(false)
   const expandElementRef = useRef<HTMLButtonElement | null>(null)
   const popoverElementRef = useRef<HTMLDivElement | null>(null)

--- a/src/core/components/dialog/dialog.tsx
+++ b/src/core/components/dialog/dialog.tsx
@@ -9,14 +9,10 @@ import {
   focusLastDescendant,
   isHTMLElement,
 } from '../../helpers'
-import {
-  useArrayProp,
-  useClickOutsideEvent,
-  useGlobalKeyDown,
-  usePrefersReducedMotion,
-} from '../../hooks'
+import {useClickOutsideEvent, useGlobalKeyDown, usePrefersReducedMotion} from '../../hooks'
 import {Box, Button, Card, Container, Flex, Text} from '../../primitives'
 import {ResponsivePaddingProps, ResponsiveWidthProps} from '../../primitives/types'
+import {_getArrayProp} from '../../styles'
 import {responsivePaddingStyle, ResponsivePaddingStyleProps} from '../../styles/internal'
 import {useTheme_v2} from '../../theme'
 import {DialogPosition, Radius} from '../../types'
@@ -172,9 +168,9 @@ const DialogCard = forwardRef(function DialogCard(
   const portal = usePortal()
   const portalElement = portalProp ? portal.elements?.[portalProp] || null : portal.element
   const boundaryElement = useBoundaryElement().element
-  const radius = useArrayProp(radiusProp)
-  const shadow = useArrayProp(shadowProp)
-  const width = useArrayProp(widthProp)
+  const radius = _getArrayProp(radiusProp)
+  const shadow = _getArrayProp(shadowProp)
+  const width = _getArrayProp(widthProp)
   const ref = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const layer = useLayer()
@@ -320,11 +316,11 @@ export const Dialog = forwardRef(function Dialog(
   const portal = usePortal()
   const portalElement = portalProp ? portal.elements?.[portalProp] || null : portal.element
   const boundaryElement = useBoundaryElement().element
-  const cardRadius = useArrayProp(cardRadiusProp)
-  const padding = useArrayProp(paddingProp)
-  const position = useArrayProp(positionProp)
-  const width = useArrayProp(widthProp)
-  const zOffset = useArrayProp(zOffsetProp)
+  const cardRadius = _getArrayProp(cardRadiusProp)
+  const padding = _getArrayProp(paddingProp)
+  const position = _getArrayProp(positionProp)
+  const width = _getArrayProp(widthProp)
+  const zOffset = _getArrayProp(zOffsetProp)
   const preDivRef = useRef<HTMLDivElement | null>(null)
   const postDivRef = useRef<HTMLDivElement | null>(null)
   const cardRef = useRef<HTMLDivElement | null>(null)

--- a/src/core/components/hotkeys/hotkeys.tsx
+++ b/src/core/components/hotkeys/hotkeys.tsx
@@ -1,8 +1,8 @@
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
 import {Inline, KBD} from '../../primitives'
+import {_getArrayProp} from '../../styles'
 import {Radius} from '../../types'
 
 /**
@@ -41,7 +41,7 @@ export const Hotkeys = forwardRef(function Hotkeys(
   ref: React.Ref<HTMLElement>,
 ) {
   const {fontSize, keys, padding, radius, space: spaceProp = 0.5, ...restProps} = props
-  const space = useArrayProp(spaceProp)
+  const space = _getArrayProp(spaceProp)
 
   if (!keys || keys.length === 0) {
     return <></>

--- a/src/core/components/menu/menuGroup.tsx
+++ b/src/core/components/menu/menuGroup.tsx
@@ -2,9 +2,9 @@ import {ChevronRightIcon} from '@sanity/icons'
 import {isValidElement, useCallback, useEffect, useState} from 'react'
 import {isValidElementType} from 'react-is'
 
-import {useArrayProp} from '../../hooks'
 import {Box, Flex, Popover, PopoverProps, Text} from '../../primitives'
 import {Selectable} from '../../primitives/_selectable'
+import {_getArrayProp} from '../../styles'
 import {useRootTheme} from '../../theme'
 import {Radius, SelectableTone} from '../../types'
 import {Menu, MenuProps} from './menu'
@@ -183,7 +183,7 @@ export function MenuGroup(
         aria-pressed={as === 'button' ? withinMenu : undefined}
         data-pressed={as !== 'button' ? withinMenu : undefined}
         data-selected={!withinMenu && active ? '' : undefined}
-        $radius={useArrayProp(radius)}
+        $radius={_getArrayProp(radius)}
         $tone={tone}
         $scheme={scheme}
         onClick={handleClick}

--- a/src/core/components/menu/menuItem.tsx
+++ b/src/core/components/menu/menuItem.tsx
@@ -10,10 +10,10 @@ import {
 } from 'react'
 import {isValidElementType} from 'react-is'
 
-import {useArrayProp} from '../../hooks'
 import {Box, Flex, Text} from '../../primitives'
 import {Selectable} from '../../primitives/_selectable'
 import {ResponsivePaddingProps, ResponsiveRadiusProps} from '../../primitives/types'
+import {_getArrayProp} from '../../styles'
 import {useRootTheme} from '../../theme'
 import {SelectableTone} from '../../types/selectable'
 import {Hotkeys} from '../hotkeys'
@@ -108,7 +108,7 @@ export const MenuItem = forwardRef(function MenuItem(
     [padding, paddingX, paddingY, paddingTop, paddingRight, paddingBottom, paddingLeft],
   )
 
-  const hotkeysFontSize = useArrayProp(fontSize).map((s) => s - 1)
+  const hotkeysFontSize = _getArrayProp(fontSize).map((s) => s - 1)
 
   const setRef = useCallback((el: HTMLDivElement | null) => {
     ref.current = el
@@ -124,8 +124,8 @@ export const MenuItem = forwardRef(function MenuItem(
       data-selected={active ? '' : undefined}
       data-disabled={disabled ? '' : undefined}
       forwardedAs={as}
-      $radius={useArrayProp(radius)}
-      $padding={useArrayProp(0)}
+      $radius={_getArrayProp(radius)}
+      $padding={_getArrayProp(0)}
       $tone={disabled ? 'default' : tone}
       $scheme={scheme}
       disabled={disabled}

--- a/src/core/components/skeleton/skeleton.tsx
+++ b/src/core/components/skeleton/skeleton.tsx
@@ -1,8 +1,8 @@
 import {forwardRef, useEffect, useState} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
 import {Box, BoxProps, ResponsiveRadiusProps} from '../../primitives'
+import {_getArrayProp} from '../../styles'
 import {responsiveRadiusStyle, ResponsiveRadiusStyleProps} from '../../styles/internal'
 import {skeletonStyle} from './styles'
 
@@ -48,7 +48,7 @@ export const Skeleton = forwardRef(function Skeleton(
     <StyledSkeleton
       {...restProps}
       $animated={animated}
-      $radius={useArrayProp(radius)}
+      $radius={_getArrayProp(radius)}
       $visible={delay ? visible : true}
       ref={ref}
     />

--- a/src/core/components/skeleton/textSkeleton.tsx
+++ b/src/core/components/skeleton/textSkeleton.tsx
@@ -2,8 +2,7 @@ import {getTheme_v2, ThemeFontKey} from '@sanity/ui/theme'
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
-import {_responsive, ThemeProps} from '../../styles'
+import {_getArrayProp, _responsive, ThemeProps} from '../../styles'
 import {Skeleton, SkeletonProps} from './skeleton'
 
 const StyledSkeleton = styled(Skeleton)<{$size: number[]; $style: ThemeFontKey}>((
@@ -68,7 +67,7 @@ export const TextSkeleton = forwardRef(function TextSkeleton(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const {size = 2, ...restProps} = props
-  const $size = useArrayProp(size)
+  const $size = _getArrayProp(size)
 
   return <StyledSkeleton {...restProps} $size={$size} ref={ref} $style="text" />
 })
@@ -84,7 +83,7 @@ export const LabelSkeleton = forwardRef(function TextSkeleton(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const {size = 2, ...restProps} = props
-  const $size = useArrayProp(size)
+  const $size = _getArrayProp(size)
 
   return <StyledSkeleton {...restProps} $size={$size} ref={ref} $style="label" />
 })
@@ -100,7 +99,7 @@ export const HeadingSkeleton = forwardRef(function TextSkeleton(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const {size = 2, ...restProps} = props
-  const $size = useArrayProp(size)
+  const $size = _getArrayProp(size)
 
   return <StyledSkeleton {...restProps} $size={$size} ref={ref} $style="heading" />
 })
@@ -116,7 +115,7 @@ export const CodeSkeleton = forwardRef(function TextSkeleton(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const {size = 2, ...restProps} = props
-  const $size = useArrayProp(size)
+  const $size = _getArrayProp(size)
 
   return <StyledSkeleton {...restProps} $size={$size} ref={ref} $style="code" />
 })

--- a/src/core/hooks/index.ts
+++ b/src/core/hooks/index.ts
@@ -1,4 +1,4 @@
-export * from './useArrayProp'
+export {type ArrayPropPrimitive, useArrayProp} from './useArrayProp'
 export * from './useClickOutside'
 export * from './useClickOutsideEvent'
 export * from './useCustomValidity'

--- a/src/core/hooks/useArrayProp.ts
+++ b/src/core/hooks/useArrayProp.ts
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import {useMemo} from 'react'
 
 import {_getArrayProp} from '../styles'
 
@@ -6,26 +6,12 @@ import {_getArrayProp} from '../styles'
 export type ArrayPropPrimitive = string | number | boolean | undefined | null
 
 /**
- * This API might change. DO NOT USE IN PRODUCTION.
+ * @deprecated instead of `useArrayProp(width)` use `Array.isArray(width) ? width : [width]` instead
  * @beta
  */
 export function useArrayProp<T extends ArrayPropPrimitive = ArrayPropPrimitive>(
   val: T | T[] | undefined,
   defaultVal?: T[],
 ): T[] {
-  const [[cachedVal, cachedHash], setCache] = useState<[T[], string]>(() => [
-    _getArrayProp(val, defaultVal),
-    JSON.stringify(val ?? defaultVal),
-  ])
-
-  const hash = JSON.stringify(val ?? defaultVal)
-
-  if (hash !== cachedHash) {
-    // If the cached hash has changed, update the cache right away.
-    // Calling setState during render is fine in this case, and preferred over a useEffect loop
-    // https://19.react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-    setCache([_getArrayProp(val, defaultVal), hash])
-  }
-
-  return cachedVal
+  return useMemo(() => _getArrayProp(val, defaultVal), [val, defaultVal])
 }

--- a/src/core/primitives/avatar/avatar.tsx
+++ b/src/core/primitives/avatar/avatar.tsx
@@ -1,9 +1,9 @@
 import {ThemeColorAvatarColorKey} from '@sanity/ui/theme'
-import {forwardRef, useCallback, useEffect, useId, useMemo, useState} from 'react'
+import {forwardRef, useCallback, useEffect, useId, useState} from 'react'
 import ReactIs from 'react-is'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {useTheme_v2} from '../../theme'
 import {AvatarPosition, AvatarSize, AvatarStatus} from '../../types'
 import {Label} from '../label'
@@ -75,7 +75,7 @@ export const Avatar = forwardRef(function Avatar(
   } = props
   const {avatar} = useTheme_v2()
   const as = ReactIs.isValidElementType(asProp) ? asProp : 'div'
-  const size = useArrayProp(sizeProp)
+  const size = _getArrayProp(sizeProp)
 
   // eslint-disable-next-line no-warning-comments
   // @todo: remove this
@@ -113,18 +113,6 @@ export const Avatar = forwardRef(function Avatar(
       onImageLoadError(new Error('Avatar: the image failed to load'))
     }
   }, [onImageLoadError])
-
-  const initialsSize = useMemo(
-    () =>
-      size.map((s) => {
-        if (s === 1) return 1
-        if (s === 2) return 3
-        if (s === 3) return 5
-
-        return 0
-      }),
-    [size],
-  )
 
   return (
     <StyledAvatar
@@ -182,7 +170,17 @@ export const Avatar = forwardRef(function Avatar(
       {(imageFailed || !src) && initials && (
         <>
           <Initials>
-            <InitialsLabel forwardedAs="span" size={initialsSize} weight="medium">
+            <InitialsLabel
+              forwardedAs="span"
+              size={size.map((s) => {
+                if (s === 1) return 1
+                if (s === 2) return 3
+                if (s === 3) return 5
+
+                return 0
+              })}
+              weight="medium"
+            >
               {initials}
             </InitialsLabel>
           </Initials>

--- a/src/core/primitives/avatar/avatarCounter.tsx
+++ b/src/core/primitives/avatar/avatarCounter.tsx
@@ -1,10 +1,9 @@
 import {getTheme_v2} from '@sanity/ui/theme'
-import {forwardRef, useMemo} from 'react'
+import {forwardRef} from 'react'
 import {css, styled} from 'styled-components'
 
 import {EMPTY_RECORD} from '../../constants'
-import {useArrayProp} from '../../hooks'
-import {_responsive, rem, ThemeProps} from '../../styles'
+import {_getArrayProp, _responsive, rem, ThemeProps} from '../../styles'
 import {AvatarSize} from '../../types'
 import {Label} from '../label'
 
@@ -69,23 +68,21 @@ export const AvatarCounter = forwardRef(function AvatarCounter(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const {count, size: sizeProp = 1} = props
-  const size = useArrayProp(sizeProp)
-
-  const fontSize = useMemo(
-    () =>
-      size.map((s) => {
-        if (s === 1) return 1
-        if (s === 2) return 3
-        if (s === 3) return 5
-
-        return 0
-      }),
-    [size],
-  )
+  const size = _getArrayProp(sizeProp)
 
   return (
     <StyledAvatarCounter $size={size} data-ui="AvatarCounter" ref={ref}>
-      <Label as="span" size={fontSize} weight="medium">
+      <Label
+        as="span"
+        size={size.map((s) => {
+          if (s === 1) return 1
+          if (s === 2) return 3
+          if (s === 3) return 5
+
+          return 0
+        })}
+        weight="medium"
+      >
         {count}
       </Label>
     </StyledAvatarCounter>

--- a/src/core/primitives/avatar/avatarStack.tsx
+++ b/src/core/primitives/avatar/avatarStack.tsx
@@ -3,8 +3,7 @@ import {Children, cloneElement, forwardRef, isValidElement} from 'react'
 import {css, styled} from 'styled-components'
 
 import {EMPTY_RECORD} from '../../constants'
-import {useArrayProp} from '../../hooks'
-import {_responsive, rem, ThemeProps} from '../../styles'
+import {_getArrayProp, _responsive, rem, ThemeProps} from '../../styles'
 import {AvatarSize} from '../../types'
 import {AvatarCounter} from './avatarCounter'
 
@@ -71,7 +70,7 @@ export const AvatarStack = forwardRef(function AvatarStack(
   } = props
   const children: React.JSX.Element[] = Children.toArray(childrenProp).filter(isValidElement)
   const maxLength = Math.max(maxLengthProp, 0)
-  const size = useArrayProp(sizeProp)
+  const size = _getArrayProp(sizeProp)
 
   const len = children.length
   const visibleCount = maxLength - 1

--- a/src/core/primitives/badge/badge.tsx
+++ b/src/core/primitives/badge/badge.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {responsiveRadiusStyle, ResponsiveRadiusStyleProps} from '../../styles/internal'
 import {BadgeMode, BadgeTone} from '../../types'
 import {Box, BoxProps} from '../box'
@@ -51,8 +51,8 @@ export const Badge = forwardRef(function Badge(
       data-ui="Badge"
       {...restProps}
       $tone={tone}
-      $radius={useArrayProp(radius)}
-      padding={useArrayProp(padding)}
+      $radius={_getArrayProp(radius)}
+      padding={_getArrayProp(padding)}
       ref={ref}
     >
       <Text size={fontSize}>{children}</Text>

--- a/src/core/primitives/box/box.tsx
+++ b/src/core/primitives/box/box.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {
   boxStyle,
   flexItemStyle,
@@ -96,31 +96,31 @@ export const Box = forwardRef(function Box(
       data-as={typeof asProp === 'string' ? asProp : undefined}
       data-ui="Box"
       {...restProps}
-      $column={useArrayProp(column)}
-      $columnStart={useArrayProp(columnStart)}
-      $columnEnd={useArrayProp(columnEnd)}
-      $display={useArrayProp(display)}
-      $flex={useArrayProp(flex)}
-      $height={useArrayProp(height)}
-      $margin={useArrayProp(margin)}
-      $marginX={useArrayProp(marginX)}
-      $marginY={useArrayProp(marginY)}
-      $marginTop={useArrayProp(marginTop)}
-      $marginRight={useArrayProp(marginRight)}
-      $marginBottom={useArrayProp(marginBottom)}
-      $marginLeft={useArrayProp(marginLeft)}
-      $overflow={useArrayProp(overflow)}
-      $padding={useArrayProp(padding)}
-      $paddingX={useArrayProp(paddingX)}
-      $paddingY={useArrayProp(paddingY)}
-      $paddingTop={useArrayProp(paddingTop)}
-      $paddingRight={useArrayProp(paddingRight)}
-      $paddingBottom={useArrayProp(paddingBottom)}
-      $paddingLeft={useArrayProp(paddingLeft)}
-      $row={useArrayProp(row)}
-      $rowStart={useArrayProp(rowStart)}
-      $rowEnd={useArrayProp(rowEnd)}
-      $sizing={useArrayProp(sizing)}
+      $column={_getArrayProp(column)}
+      $columnStart={_getArrayProp(columnStart)}
+      $columnEnd={_getArrayProp(columnEnd)}
+      $display={_getArrayProp(display)}
+      $flex={_getArrayProp(flex)}
+      $height={_getArrayProp(height)}
+      $margin={_getArrayProp(margin)}
+      $marginX={_getArrayProp(marginX)}
+      $marginY={_getArrayProp(marginY)}
+      $marginTop={_getArrayProp(marginTop)}
+      $marginRight={_getArrayProp(marginRight)}
+      $marginBottom={_getArrayProp(marginBottom)}
+      $marginLeft={_getArrayProp(marginLeft)}
+      $overflow={_getArrayProp(overflow)}
+      $padding={_getArrayProp(padding)}
+      $paddingX={_getArrayProp(paddingX)}
+      $paddingY={_getArrayProp(paddingY)}
+      $paddingTop={_getArrayProp(paddingTop)}
+      $paddingRight={_getArrayProp(paddingRight)}
+      $paddingBottom={_getArrayProp(paddingBottom)}
+      $paddingLeft={_getArrayProp(paddingLeft)}
+      $row={_getArrayProp(row)}
+      $rowStart={_getArrayProp(rowStart)}
+      $rowEnd={_getArrayProp(rowEnd)}
+      $sizing={_getArrayProp(sizing)}
       as={asProp}
       ref={ref}
     >

--- a/src/core/primitives/button/button.tsx
+++ b/src/core/primitives/button/button.tsx
@@ -3,8 +3,7 @@ import {forwardRef, isValidElement, useMemo} from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
-import {ThemeProps} from '../../styles'
+import {_getArrayProp, ThemeProps} from '../../styles'
 import {responsiveRadiusStyle, ResponsiveRadiusStyleProps} from '../../styles/internal'
 import {useTheme_v2} from '../../theme'
 import {ButtonMode, ButtonTextAlign, ButtonTone, ButtonWidth, FlexJustify} from '../../types'
@@ -97,16 +96,16 @@ export const Button = forwardRef(function Button(
   } = props
   const {button} = useTheme_v2()
 
-  const justify = useArrayProp(justifyProp)
-  const padding = useArrayProp(paddingProp)
-  const paddingX = useArrayProp(paddingXProp)
-  const paddingY = useArrayProp(paddingYProp)
-  const paddingTop = useArrayProp(paddingTopProp)
-  const paddingBottom = useArrayProp(paddingBottomProp)
-  const paddingLeft = useArrayProp(paddingLeftProp)
-  const paddingRight = useArrayProp(paddingRightProp)
-  const radius = useArrayProp(radiusProp)
-  const space = useArrayProp(spaceProp)
+  const justify = _getArrayProp(justifyProp)
+  const padding = _getArrayProp(paddingProp)
+  const paddingX = _getArrayProp(paddingXProp)
+  const paddingY = _getArrayProp(paddingYProp)
+  const paddingTop = _getArrayProp(paddingTopProp)
+  const paddingBottom = _getArrayProp(paddingBottomProp)
+  const paddingLeft = _getArrayProp(paddingLeftProp)
+  const paddingRight = _getArrayProp(paddingRightProp)
+  const radius = _getArrayProp(radiusProp)
+  const space = _getArrayProp(spaceProp)
 
   const boxProps = useMemo(
     () => ({

--- a/src/core/primitives/card/card.tsx
+++ b/src/core/primitives/card/card.tsx
@@ -3,7 +3,7 @@ import {forwardRef} from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {
   responsiveBorderStyle,
   ResponsiveBorderStyleProps,
@@ -93,16 +93,16 @@ export const Card = forwardRef(function Card(
         data-ui="Card"
         data-tone={tone}
         {...restProps}
-        $border={useArrayProp(border)}
-        $borderTop={useArrayProp(borderTop)}
-        $borderRight={useArrayProp(borderRight)}
-        $borderBottom={useArrayProp(borderBottom)}
-        $borderLeft={useArrayProp(borderLeft)}
+        $border={_getArrayProp(border)}
+        $borderTop={_getArrayProp(borderTop)}
+        $borderRight={_getArrayProp(borderRight)}
+        $borderBottom={_getArrayProp(borderBottom)}
+        $borderLeft={_getArrayProp(borderLeft)}
         $checkered={checkered}
         $focusRing={focusRing}
         $muted={muted}
-        $radius={useArrayProp(radius)}
-        $shadow={useArrayProp(shadow)}
+        $radius={_getArrayProp(radius)}
+        $shadow={_getArrayProp(shadow)}
         $tone={tone}
         data-checkered={checkered ? '' : undefined}
         data-pressed={pressed ? '' : undefined}

--- a/src/core/primitives/code/code.tsx
+++ b/src/core/primitives/code/code.tsx
@@ -1,7 +1,7 @@
 import {forwardRef, lazy, Suspense} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {responsiveCodeFontStyle, ResponsiveFontStyleProps} from '../../styles/internal'
 import {codeBaseStyle} from './styles'
 
@@ -30,7 +30,13 @@ export const Code = forwardRef(function Code(
   const {children, language, size = 2, weight, ...restProps} = props
 
   return (
-    <StyledCode data-ui="Code" {...restProps} $size={useArrayProp(size)} $weight={weight} ref={ref}>
+    <StyledCode
+      data-ui="Code"
+      {...restProps}
+      $size={_getArrayProp(size)}
+      $weight={weight}
+      ref={ref}
+    >
       <Suspense fallback={<code>{children}</code>}>
         <LazyRefractor language={language} value={children} />
       </Suspense>

--- a/src/core/primitives/container/container.tsx
+++ b/src/core/primitives/container/container.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {Box, BoxProps} from '../box'
 import {ResponsiveWidthProps} from '../types'
 import {containerBaseStyle, responsiveContainerWidthStyle} from './styles'
@@ -32,7 +32,7 @@ export const Container = forwardRef(function Container(
     <StyledContainer
       data-ui="Container"
       {...restProps}
-      $width={useArrayProp(width)}
+      $width={_getArrayProp(width)}
       forwardedAs={as}
       ref={ref}
     />

--- a/src/core/primitives/flex/flex.tsx
+++ b/src/core/primitives/flex/flex.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {
   flexItemStyle,
   FlexItemStyleProps,
@@ -41,11 +41,11 @@ export const Flex = forwardRef(function Flex(
     <StyledFlex
       data-ui="Flex"
       {...restProps}
-      $align={useArrayProp(align)}
-      $direction={useArrayProp(direction)}
-      $gap={useArrayProp(gap)}
-      $justify={useArrayProp(justify)}
-      $wrap={useArrayProp(wrap)}
+      $align={_getArrayProp(align)}
+      $direction={_getArrayProp(direction)}
+      $gap={_getArrayProp(gap)}
+      $justify={_getArrayProp(justify)}
+      $wrap={_getArrayProp(wrap)}
       forwardedAs={as}
       ref={ref}
     />

--- a/src/core/primitives/grid/grid.tsx
+++ b/src/core/primitives/grid/grid.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {responsiveGridStyle, ResponsiveGridStyleProps} from '../../styles/internal'
 import {Box, BoxProps} from '../box'
 import {ResponsiveGridProps} from '../types'
@@ -30,14 +30,14 @@ export const Grid = forwardRef(function Grid(
       data-as={typeof as === 'string' ? as : undefined}
       data-ui="Grid"
       {...restProps}
-      $autoRows={useArrayProp(autoRows)}
-      $autoCols={useArrayProp(autoCols)}
-      $autoFlow={useArrayProp(autoFlow)}
-      $columns={useArrayProp(columns)}
-      $gap={useArrayProp(gap)}
-      $gapX={useArrayProp(gapX)}
-      $gapY={useArrayProp(gapY)}
-      $rows={useArrayProp(rows)}
+      $autoRows={_getArrayProp(autoRows)}
+      $autoCols={_getArrayProp(autoCols)}
+      $autoFlow={_getArrayProp(autoFlow)}
+      $columns={_getArrayProp(columns)}
+      $gap={_getArrayProp(gap)}
+      $gapX={_getArrayProp(gapX)}
+      $gapY={_getArrayProp(gapY)}
+      $rows={_getArrayProp(rows)}
       forwardedAs={as}
       ref={ref}
     >

--- a/src/core/primitives/heading/heading.tsx
+++ b/src/core/primitives/heading/heading.tsx
@@ -2,7 +2,7 @@ import {ThemeFontWeightKey} from '@sanity/ui/theme'
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {
   ResponsiveFontStyleProps,
   responsiveHeadingFont,
@@ -67,9 +67,9 @@ export const Heading = forwardRef(function Heading(
       data-ui="Heading"
       {...restProps}
       $accent={accent}
-      $align={useArrayProp(align)}
+      $align={_getArrayProp(align)}
       $muted={muted}
-      $size={useArrayProp(size)}
+      $size={_getArrayProp(size)}
       $weight={weight}
       ref={ref}
     >

--- a/src/core/primitives/inline/inline.tsx
+++ b/src/core/primitives/inline/inline.tsx
@@ -1,7 +1,7 @@
 import {Children, forwardRef, useMemo} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {Box, BoxProps} from '../box'
 import {inlineBaseStyle, inlineSpaceStyle} from './styles'
 import {ResponsiveInlineSpaceStyleProps} from './types'
@@ -36,7 +36,7 @@ export const Inline = forwardRef(function Inline(
     <StyledInline
       data-ui="Inline"
       {...restProps}
-      $space={useArrayProp(space)}
+      $space={_getArrayProp(space)}
       forwardedAs={as}
       ref={ref as any}
     >

--- a/src/core/primitives/kbd/kbd.tsx
+++ b/src/core/primitives/kbd/kbd.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react'
 import {css, styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {responsiveRadiusStyle, ResponsiveRadiusStyleProps} from '../../styles/internal'
 import {Radius} from '../../types'
 import {Box} from '../box'
@@ -49,7 +49,7 @@ export const KBD = forwardRef(function KBD(
   const {children, fontSize = 0, padding = 1, radius = 2, ...restProps} = props
 
   return (
-    <StyledKBD data-ui="KBD" {...restProps} $radius={useArrayProp(radius)} ref={ref}>
+    <StyledKBD data-ui="KBD" {...restProps} $radius={_getArrayProp(radius)} ref={ref}>
       <Box as="span" padding={padding}>
         <Text as="span" size={fontSize} weight="semibold">
           {children}

--- a/src/core/primitives/label/label.tsx
+++ b/src/core/primitives/label/label.tsx
@@ -2,7 +2,7 @@ import {ThemeFontWeightKey} from '@sanity/ui/theme'
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {responsiveLabelFont, responsiveTextAlignStyle} from '../../styles/internal'
 import {TextAlign} from '../../types'
 import {SpanWithTextOverflow} from '../../utils/spanWithTextOverflow'
@@ -66,9 +66,9 @@ export const Label = forwardRef(function Label(
       data-ui="Label"
       {...restProps}
       $accent={accent}
-      $align={useArrayProp(align)}
+      $align={_getArrayProp(align)}
       $muted={muted}
-      $size={useArrayProp(size)}
+      $size={_getArrayProp(size)}
       $weight={weight}
       ref={ref}
     >

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -24,8 +24,9 @@ import {
   useState,
 } from 'react'
 
-import {useArrayProp, useElementSize, useMediaIndex, usePrefersReducedMotion} from '../../hooks'
+import {useElementSize, useMediaIndex, usePrefersReducedMotion} from '../../hooks'
 import {origin} from '../../middleware/origin'
+import {_getArrayProp} from '../../styles'
 import {useTheme_v2} from '../../theme'
 import {BoxOverflow, CardTone, Placement, PopoverMargins} from '../../types'
 import {LayerProps, LayerProvider, Portal, useBoundaryElement, useLayer} from '../../utils'
@@ -185,11 +186,11 @@ export const Popover = forwardRef(function Popover(
   const prefersReducedMotion = usePrefersReducedMotion()
   const animate = prefersReducedMotion ? false : _animate
   const boundarySize = useElementSize(boundaryElement)?.border
-  const padding = useArrayProp(paddingProp)
-  const radius = useArrayProp(radiusProp)
-  const shadow = useArrayProp(shadowProp)
-  const widthArrayProp = useArrayProp(widthProp)
-  const zOffset = useArrayProp(zOffsetProp)
+  const padding = _getArrayProp(paddingProp)
+  const radius = _getArrayProp(radiusProp)
+  const shadow = _getArrayProp(shadowProp)
+  const widthArrayProp = _getArrayProp(widthProp)
+  const zOffset = _getArrayProp(zOffsetProp)
   const ref = useRef<HTMLDivElement | null>(null)
   const arrowRef = useRef<HTMLDivElement | null>(null)
   const rootBoundary: RootBoundary = 'viewport'

--- a/src/core/primitives/select/select.tsx
+++ b/src/core/primitives/select/select.tsx
@@ -2,7 +2,8 @@ import {ChevronDownIcon} from '@sanity/icons'
 import {forwardRef, useImperativeHandle, useRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp, useCustomValidity} from '../../hooks'
+import {useCustomValidity} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {Radius} from '../../types'
 import {Box} from '../box'
 import {Text} from '../text'
@@ -66,10 +67,10 @@ export const Select = forwardRef(function Select(
         data-read-only={!disabled && readOnly ? '' : undefined}
         data-ui="Select"
         {...restProps}
-        $fontSize={useArrayProp(fontSize)}
-        $padding={useArrayProp(padding)}
-        $radius={useArrayProp(radius)}
-        $space={useArrayProp(space)}
+        $fontSize={_getArrayProp(fontSize)}
+        $padding={_getArrayProp(padding)}
+        $radius={_getArrayProp(radius)}
+        $space={_getArrayProp(space)}
         disabled={disabled || readOnly}
         ref={ref}
       >

--- a/src/core/primitives/stack/stack.tsx
+++ b/src/core/primitives/stack/stack.tsx
@@ -1,7 +1,7 @@
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {Box, BoxProps} from '../box'
 import {responsiveStackSpaceStyle, ResponsiveStackSpaceStyleProps, stackBaseStyle} from './styles'
 
@@ -34,7 +34,7 @@ export const Stack = forwardRef(function Stack(
       data-as={typeof as === 'string' ? as : undefined}
       data-ui="Stack"
       {...restProps}
-      $space={useArrayProp(space)}
+      $space={_getArrayProp(space)}
       forwardedAs={as}
       ref={ref}
     />

--- a/src/core/primitives/text/text.tsx
+++ b/src/core/primitives/text/text.tsx
@@ -2,7 +2,7 @@ import {ThemeFontWeightKey} from '@sanity/ui/theme'
 import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {
   ResponsiveFontStyleProps,
   responsiveTextAlignStyle,
@@ -68,10 +68,10 @@ export const Text = forwardRef(function Text(
       data-ui="Text"
       {...restProps}
       $accent={accent}
-      $align={useArrayProp(align)}
+      $align={_getArrayProp(align)}
       $muted={muted}
       ref={ref}
-      $size={useArrayProp(size)}
+      $size={_getArrayProp(size)}
       $weight={weight}
     >
       <span>{children}</span>

--- a/src/core/primitives/textArea/textArea.tsx
+++ b/src/core/primitives/textArea/textArea.tsx
@@ -2,7 +2,8 @@ import {ThemeFontWeightKey} from '@sanity/ui/theme'
 import {forwardRef, useImperativeHandle, useRef} from 'react'
 import {styled} from 'styled-components'
 
-import {useArrayProp, useCustomValidity} from '../../hooks'
+import {useCustomValidity} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {
   responsiveInputPaddingStyle,
   responsiveRadiusStyle,
@@ -94,17 +95,17 @@ export const TextArea = forwardRef(function TextArea(
           data-scheme={rootTheme.scheme}
           data-tone={rootTheme.tone}
           {...restProps}
-          $fontSize={useArrayProp(fontSize)}
-          $padding={useArrayProp(padding)}
+          $fontSize={_getArrayProp(fontSize)}
+          $padding={_getArrayProp(padding)}
           $scheme={rootTheme.scheme}
-          $space={useArrayProp(0)}
+          $space={_getArrayProp(0)}
           $tone={rootTheme.tone}
           $weight={weight}
           disabled={disabled}
           ref={ref}
         />
         <Presentation
-          $radius={useArrayProp(radius)}
+          $radius={_getArrayProp(radius)}
           $unstableDisableFocusRing={__unstable_disableFocusRing}
           $scheme={rootTheme.scheme}
           $tone={rootTheme.tone}

--- a/src/core/primitives/textInput/textInput.tsx
+++ b/src/core/primitives/textInput/textInput.tsx
@@ -5,7 +5,8 @@ import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 
 import {EMPTY_RECORD} from '../../constants'
-import {useArrayProp, useCustomValidity} from '../../hooks'
+import {useCustomValidity} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {
   responsiveInputPaddingStyle,
   responsiveRadiusStyle,
@@ -179,10 +180,10 @@ export const TextInput = forwardRef(function TextInput(
 
   const rootTheme = useRootTheme()
 
-  const fontSize = useArrayProp(fontSizeProp)
-  const padding = useArrayProp(paddingProp)
-  const radius = useArrayProp(radiusProp)
-  const space = useArrayProp(spaceProp)
+  const fontSize = _getArrayProp(fontSizeProp)
+  const padding = _getArrayProp(paddingProp)
+  const radius = _getArrayProp(radiusProp)
+  const space = _getArrayProp(spaceProp)
 
   // Transient properties
   const $hasClearButton = Boolean(clearButton)

--- a/src/core/primitives/tooltip/tooltip.tsx
+++ b/src/core/primitives/tooltip/tooltip.tsx
@@ -25,9 +25,10 @@ import {
 import {styled} from 'styled-components'
 import {useEffectEvent} from 'use-effect-event'
 
-import {useArrayProp, usePrefersReducedMotion} from '../../hooks'
+import {usePrefersReducedMotion} from '../../hooks'
 import {useDelayedState} from '../../hooks/useDelayedState'
 import {origin} from '../../middleware/origin'
+import {_getArrayProp} from '../../styles'
 import {useTheme_v2} from '../../theme'
 import type {Placement} from '../../types'
 import {Layer, type LayerProps, Portal, useBoundaryElement, usePortal} from '../../utils'
@@ -119,7 +120,7 @@ export const Tooltip = forwardRef(function Tooltip(
   const zOffset = _zOffset ?? layer.tooltip.zOffset
   const prefersReducedMotion = usePrefersReducedMotion()
   const animate = prefersReducedMotion ? false : _animate
-  const fallbackPlacements = useArrayProp(fallbackPlacementsProp)
+  const fallbackPlacements = _getArrayProp(fallbackPlacementsProp)
   const ref = useRef<HTMLDivElement | null>(null)
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
   const arrowRef = useRef<HTMLDivElement | null>(null)

--- a/src/core/utils/layer/layerProvider.tsx
+++ b/src/core/utils/layer/layerProvider.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useContext, useEffect, useMemo, useState} from 'react'
 
-import {useArrayProp, useMediaIndex} from '../../hooks'
+import {useMediaIndex} from '../../hooks'
+import {_getArrayProp} from '../../styles'
 import {getLayerContext} from './getLayerContext'
 import {LayerContext} from './layerContext'
 import {LayerContextValue} from './types'
@@ -29,7 +30,7 @@ export function LayerProvider(props: LayerProviderProps): React.JSX.Element {
   const level = parentLevel + 1
 
   // Get z-index offset
-  const zOffset = useArrayProp(zOffsetProp)
+  const zOffset = _getArrayProp(zOffsetProp)
 
   // Get responsive z-index value
   const maxMediaIndex = zOffset.length - 1


### PR DESCRIPTION
The React Compiler is able to conditionally memoize props that call `getArrayProp`, while `useArrayProp` has to follow the rules of hooks.