### PR TITLE
feat: add options prop to useGlobalKeyDown

### DIFF
--- a/src/core/hooks/useGlobalKeyDown.ts
+++ b/src/core/hooks/useGlobalKeyDown.ts
@@ -4,14 +4,17 @@ import {useEffectEvent} from 'use-effect-event'
 /**
  * @beta
  */
-export function useGlobalKeyDown(onKeyDown: (event: KeyboardEvent) => void): void {
+export function useGlobalKeyDown(
+  onKeyDown: (event: KeyboardEvent) => void,
+  options?: AddEventListenerOptions,
+): void {
   const handleKeyDown = useEffectEvent((event: KeyboardEvent) => onKeyDown(event))
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => handleKeyDown(event)
 
-    window.addEventListener('keydown', handler)
+    window.addEventListener('keydown', handler, options)
 
-    return () => window.removeEventListener('keydown', handler)
-  }, [])
+    return () => window.removeEventListener('keydown', handler, options)
+  }, [options])
 }

--- a/src/core/hooks/useGlobalKeyDown.ts
+++ b/src/core/hooks/useGlobalKeyDown.ts
@@ -2,6 +2,10 @@ import {useEffect} from 'react'
 import {useEffectEvent} from 'use-effect-event'
 
 /**
+ * Adds global keydown event listener to the window.
+ *
+ * @param onKeyDown - The function to call when a keydown event is triggered.
+ * @param options - The options to pass to the addEventListener function (example, capture: true)
  * @beta
  */
 export function useGlobalKeyDown(


### PR DESCRIPTION
### Description

Add options as part of the props that you can receive to the useGlobalKeyDown hook. This is particularly important in the studio where we can have multiple GlobalKeyDowns and it's important to add options such as capture: true

This is currently needed to fix a bug in the studio [Sanity PR 10606](https://github.com/sanity-io/sanity/pull/10606)

### What to review

The code, should I add anything, is there any code missing?

### Testing

N/A