### PR TITLE
fix: react 18 regression

### DIFF
--- a/src/core/components/autocomplete/autocomplete.tsx
+++ b/src/core/components/autocomplete/autocomplete.tsx
@@ -10,6 +10,7 @@ import {
   MouseEvent,
   ReactNode,
   Ref,
+  startTransition,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -191,7 +192,16 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
   const inputElementRef = useRef<HTMLInputElement | null>(null)
   const listBoxElementRef = useRef<HTMLDivElement | null>(null)
   // Element refs that need to be accessed during render
-  const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null)
+  const [inputElement, _setInputElement] = useState<HTMLInputElement | null>(null)
+  /**
+   * The startTransition wrapper here is to avoid an issue when on React 18 where this error can happen:
+   * >Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
+   * This doesn't happen on React 19 due to automatic batching of all state updates, the startTransition wrapper here gives a type of batching for 18 users in a way that still works with 19.
+   * NOTE: The startTransition wrapper is not needed in UI v4, since the baseline there is React 19.
+   */
+  const setInputElement = useCallback((node: HTMLInputElement | null) => {
+    startTransition(() => _setInputElement(node))
+  }, [])
 
   // Value refs
   const listFocusedRef = useRef(false)

--- a/src/core/components/tree/treeItem.tsx
+++ b/src/core/components/tree/treeItem.tsx
@@ -1,6 +1,6 @@
 import {ToggleArrowRightIcon} from '@sanity/icons'
 import {ThemeFontWeightKey} from '@sanity/ui/theme'
-import {useCallback, useEffect, useId, useMemo, useRef, useState} from 'react'
+import {startTransition, useCallback, useEffect, useId, useMemo, useRef, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {Box, BoxProps, Flex, Text} from '../../primitives'
@@ -65,7 +65,17 @@ export function TreeItem(
     weight,
     ...restProps
   } = props
-  const [rootElement, setRootElement] = useState<HTMLLIElement | null>(null)
+  const [rootElement, _setRootElement] = useState<HTMLLIElement | null>(null)
+  /**
+   * The startTransition wrapper here is to avoid an issue when on React 18 where this error can happen:
+   * >Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
+   * This doesn't happen on React 19 due to automatic batching of all state updates, the startTransition wrapper here gives a type of batching for 18 users in a way that still works with 19.
+   * NOTE: The startTransition wrapper is not needed in UI v4, since the baseline there is React 19.
+   */
+  const setRootElement = useCallback((node: HTMLLIElement | null) => {
+    startTransition(() => _setRootElement(node))
+  }, [])
+
   const treeitemRef = useRef<HTMLDivElement | null>(null)
   const tree = useTree()
   const {path, registerItem, setExpanded, setFocusedElement} = tree


### PR DESCRIPTION
### Description

v3.0.11 introduced a regression affecting Sanity Studios running on React 18. It did not impact users on React 19.
The issue was inputs using `<Autocomplete>` often crashing with this error:
```bash
react-dom.development.js:27331 Uncaught Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
    at checkForNestedUpdates (react-dom.development.js:27331:11)
    at scheduleUpdateOnFiber (react-dom.development.js:25514:3)
    at dispatchSetState (react-dom.development.js:16708:7)
    at refObject (react-dom.development.js:16316:7)
    at safelyCallDestroy (react-dom.development.js:22971:5)
    at commitHookEffectListUnmount (react-dom.development.js:23139:11)
    at commitMutationEffectsOnFiber (react-dom.development.js:24351:15)
    at recursivelyTraverseMutationEffects (react-dom.development.js:24312:7)
    at commitMutationEffectsOnFiber (react-dom.development.js:24385:9)
    at recursivelyTraverseMutationEffects (react-dom.development.js:24312:7)
```

[I made a throwaway deploy of our test studio on react 18, where this can be reproduced by interacting with the reference input](https://test-studio-5irgqrjzz.sanity.dev/test/structure/input-standard;referenceTest;44c5f6df-cd64-4065-849c-3131094292f1):

https://github.com/user-attachments/assets/cb34d205-d9d7-4fa1-85d4-7e2f59ca87f2



[I published a canary of the fix on this branch (`@sanity/ui@3.1.1-canary.1`) and updated the throwaway deployment](https://test-studio-c7cyojsf4.sanity.dev/test/structure/input-standard;referenceTest;44c5f6df-cd64-4065-849c-3131094292f1):

https://github.com/user-attachments/assets/002d7a59-a8ed-4ba6-b3ec-f3d898fe1f8a



[After going down the rabbit hole it turns out the crash is triggered by the `setInputElement` state call in `<Autocomplete>`](https://github.com/sanity-io/ui/pull/2075/files#diff-b8a5bcd0a99517221ed21de4177ef74ca220ac41d34b05d63b662b5e23180330), though only on React 18 and not React 19.
[Given that 19 batches all state updates](https://github.com/facebook/react/pull/25700), while 18 only batches state updates it started making sense.
With the batching in 19 state update is scheduled and thus the recursion limit isn't hit, while in 18 it's sync and now it crashes.

By wrapping it in `startTransition` it opts-in to batching in 18, while behaving mostly the same in 19. The difference being that react might choose to delay rendering with the `referenceElement` set if other state updates happen that respond to user input and such. In this case that's fine, if the user is typing in a text input it's more important to update the text input, than render the popover right away.

Alternatively we could use `import {unstable_batchedUpdates} from 'react-dom'`, but I decided against it since it's not only prefixed `unstable`, it's also [undocumented](https://react.dev/reference/react-dom/client/unstable_batchedUpdates).



### What to review

Is there enough context in the code comments? 
I've applied the same fix to `<TreeItem>`, though we don't use it in the Studio codebase apps that use it run a similar risk on React 18 as `<Autocomplete>`.

### Testing

Existing test suite is enough to cover 19. I've manually tested 18, and there's a test deployment you can use to confirm:
- [Test Studio on React 18 without the fix](https://test-studio-5irgqrjzz.sanity.dev)
- [With `@sanity/ui@3.1.1-canary.1` on React 18](https://test-studio-c7cyojsf4.sanity.dev)
