### PR TITLE
fix: data props

### DIFF
--- a/src/core/components/menu/MenuItem.tsx
+++ b/src/core/components/menu/MenuItem.tsx
@@ -132,8 +132,6 @@ export function MenuItem<E extends MenuItemElementType = typeof DEFAULT_MENU_ITE
       data-ui="MenuItem"
       {...rest}
       as={as}
-      data-pressed={pressed ? '' : undefined}
-      data-disabled={disabled ? '' : undefined}
       radius={radius}
       disabled={disabled}
       onClick={handleClick}

--- a/src/core/components/menu/__workshop__/DataProps.tsx
+++ b/src/core/components/menu/__workshop__/DataProps.tsx
@@ -1,0 +1,27 @@
+import {Menu, MenuItem, Text} from '@sanity/ui'
+import type {ElementTone} from '@sanity/ui/theme'
+import {useSelect} from '@sanity/ui-workshop'
+
+import {WORKSHOP_BUTTON_TONE_OPTIONS} from '$workshop'
+
+export default function DataPropsStory(): React.JSX.Element {
+  // @ts-expect-error - TODO: fix this
+  const tone = useSelect('Tone', WORKSHOP_BUTTON_TONE_OPTIONS, 'default') as ElementTone | undefined
+
+  return (
+    <Menu gap={4} padding={4}>
+      <MenuItem data-enabled="" padding={3} tone={tone}>
+        <Text>MenuItem</Text>
+      </MenuItem>
+      <MenuItem data-hovered="" padding={3} tone={tone}>
+        <Text>MenuItem</Text>
+      </MenuItem>
+      <MenuItem data-pressed="" padding={3} tone={tone}>
+        <Text>MenuItem</Text>
+      </MenuItem>
+      <MenuItem data-selected="" padding={3} tone={tone}>
+        <Text>MenuItem</Text>
+      </MenuItem>
+    </Menu>
+  )
+}

--- a/src/core/components/menu/__workshop__/index.ts
+++ b/src/core/components/menu/__workshop__/index.ts
@@ -71,7 +71,7 @@ const scope: WorkshopScope = {
       component: lazy(() => import('./OnCloseMenuButton')),
     },
     {
-      name: 'shouldFocus',
+      name: 'should-focus',
       title: 'Menu with shouldFocus',
       component: lazy(() => import('./ShouldFocus')),
     },
@@ -84,6 +84,11 @@ const scope: WorkshopScope = {
       name: 'custom-selected-state',
       title: 'Custom selected state',
       component: lazy(() => import('./CustomSelectedState')),
+    },
+    {
+      name: 'data-props',
+      title: 'Data props',
+      component: lazy(() => import('./DataProps')),
     },
   ],
 }

--- a/src/core/primitives/button/Button.tsx
+++ b/src/core/primitives/button/Button.tsx
@@ -103,8 +103,8 @@ export function Button<E extends ButtonElementType = typeof DEFAULT_BUTTON_ELEME
       data-ui="Button"
       {...rest}
       className={button({className, flex, mode, radius, tone, width})}
-      data-disabled={loading || disabled ? '' : undefined}
-      data-selected={selected ? '' : undefined}
+      data-disabled={loading || disabled ? '' : props['data-disabled']}
+      data-selected={selected ? '' : props['data-selected']}
       disabled={Boolean(loading || disabled)}
       // @ts-expect-error - TODO: fix this
       href={disabled ? undefined : href}

--- a/src/core/primitives/button/__workshop__/DataProps.tsx
+++ b/src/core/primitives/button/__workshop__/DataProps.tsx
@@ -1,0 +1,22 @@
+import {Button, Stack} from '@sanity/ui'
+import type {ButtonMode, ElementTone} from '@sanity/ui/theme'
+import {useSelect} from '@sanity/ui-workshop'
+
+import {WORKSHOP_BUTTON_MODE_OPTIONS, WORKSHOP_BUTTON_TONE_OPTIONS} from '$workshop'
+
+export default function DataPropsStory(): React.JSX.Element {
+  // @ts-expect-error - TODO: fix this
+  const mode = useSelect('Mode', WORKSHOP_BUTTON_MODE_OPTIONS, 'default') as ButtonMode | undefined
+
+  // @ts-expect-error - TODO: fix this
+  const tone = useSelect('Tone', WORKSHOP_BUTTON_TONE_OPTIONS, 'default') as ElementTone | undefined
+
+  return (
+    <Stack gap={4} padding={4}>
+      <Button data-enabled="" mode={mode} text="Button" tone={tone} />
+      <Button data-hovered="" mode={mode} text="Button" tone={tone} />
+      <Button data-pressed="" mode={mode} text="Button" tone={tone} />
+      <Button data-selected="" mode={mode} text="Button" tone={tone} />
+    </Stack>
+  )
+}

--- a/src/core/primitives/button/__workshop__/index.ts
+++ b/src/core/primitives/button/__workshop__/index.ts
@@ -60,6 +60,11 @@ const scope: WorkshopScope = {
       title: 'Text overflow',
       component: lazy(() => import('./TextOverflow')),
     },
+    {
+      name: 'data-props',
+      title: 'Data props',
+      component: lazy(() => import('./DataProps')),
+    },
   ],
 }
 

--- a/src/core/primitives/card/Card.tsx
+++ b/src/core/primitives/card/Card.tsx
@@ -72,10 +72,10 @@ export function Card<E extends CardElementType = typeof DEFAULT_CARD_ELEMENT>(
       })}
       data-checkered={checkered ? '' : undefined}
       // Extract the disabled prop without removing it from `...rest` so that the underlying <button> or <a> has `[disabled]` when needed
-      data-disabled={props.disabled ? '' : undefined}
-      data-focus-ring={focusRing ? '' : undefined}
-      data-pressed={pressed ? '' : undefined}
-      data-selected={selected ? '' : undefined}
+      data-disabled={props.disabled ? '' : props['data-disabled']}
+      data-focus-ring={focusRing ? '' : props['data-focus-ring']}
+      data-pressed={pressed ? '' : props['data-pressed']}
+      data-selected={selected ? '' : props['data-selected']}
       radius={radius}
       style={style}
     />

--- a/src/core/primitives/card/__workshop__/DataProps.tsx
+++ b/src/core/primitives/card/__workshop__/DataProps.tsx
@@ -1,0 +1,30 @@
+import {Card, Stack, Text} from '@sanity/ui'
+import type {CardTone} from '@sanity/ui/theme'
+import {useSelect} from '@sanity/ui-workshop'
+
+import {WORKSHOP_CARD_TONE_OPTIONS} from '$workshop'
+
+export default function DataPropsStory(): React.JSX.Element {
+  // @ts-expect-error - TODO: fix this
+  const tone = useSelect('Tone', WORKSHOP_CARD_TONE_OPTIONS, 'default') as CardTone | undefined
+
+  return (
+    <Stack gap={1} padding={4}>
+      <Card as="button" data-enabled="" padding={3} tone={tone}>
+        <Text>Card</Text>
+      </Card>
+      <Card as="button" data-hovered="" padding={3} tone={tone}>
+        <Text>Card</Text>
+      </Card>
+      <Card as="button" data-pressed="" padding={3} tone={tone}>
+        <Text>Card</Text>
+      </Card>
+      <Card as="button" data-selected="" padding={3} tone={tone}>
+        <Text>Card</Text>
+      </Card>
+      <Card as="button" data-disabled="" padding={3} tone={tone}>
+        <Text>Card</Text>
+      </Card>
+    </Stack>
+  )
+}

--- a/src/core/primitives/card/__workshop__/index.ts
+++ b/src/core/primitives/card/__workshop__/index.ts
@@ -14,6 +14,7 @@ const scope: WorkshopScope = {
     {name: 'checkered', title: 'Checkered', component: lazy(() => import('./Checkered'))},
     {name: 'as-component', title: 'As component', component: lazy(() => import('./AsComponent'))},
     {name: 'selected', title: 'Selected', component: lazy(() => import('./Selected'))},
+    {name: 'data-props', title: 'Data props', component: lazy(() => import('./DataProps'))},
   ],
 }
 

--- a/src/core/primitives/selectable/Selectable.tsx
+++ b/src/core/primitives/selectable/Selectable.tsx
@@ -44,7 +44,7 @@ export function Selectable<E extends SelectableElementType = typeof DEFAULT_SELE
       {...rest}
       as={as}
       className={_selectable({className, radius, tone})}
-      data-selected={selected ? '' : undefined}
+      data-selected={selected ? '' : props['data-selected']}
     />
   )
 }

--- a/src/core/primitives/selectable/__workshop__/DataProps.tsx
+++ b/src/core/primitives/selectable/__workshop__/DataProps.tsx
@@ -1,0 +1,27 @@
+import {Selectable, Stack, Text} from '@sanity/ui'
+import type {ElementTone} from '@sanity/ui/theme'
+import {useSelect} from '@sanity/ui-workshop'
+
+import {WORKSHOP_BUTTON_TONE_OPTIONS} from '$workshop'
+
+export default function DataPropsStory(): React.JSX.Element {
+  // @ts-expect-error - TODO: fix this
+  const tone = useSelect('Tone', WORKSHOP_BUTTON_TONE_OPTIONS, 'default') as ElementTone | undefined
+
+  return (
+    <Stack gap={4} padding={4}>
+      <Selectable data-enabled="" padding={3} tone={tone}>
+        <Text>Selectable</Text>
+      </Selectable>
+      <Selectable data-hovered="" padding={3} tone={tone}>
+        <Text>Selectable</Text>
+      </Selectable>
+      <Selectable data-pressed="" padding={3} tone={tone}>
+        <Text>Selectable</Text>
+      </Selectable>
+      <Selectable data-selected="" padding={3} tone={tone}>
+        <Text>Selectable</Text>
+      </Selectable>
+    </Stack>
+  )
+}

--- a/src/core/primitives/selectable/__workshop__/index.ts
+++ b/src/core/primitives/selectable/__workshop__/index.ts
@@ -1,0 +1,14 @@
+import {defineScope} from '@sanity/ui-workshop'
+import {lazy} from 'react'
+
+export default defineScope({
+  name: 'primitives/selectable',
+  title: 'Selectable',
+  stories: [
+    {
+      name: 'data-props',
+      title: 'Data props',
+      component: lazy(() => import('./DataProps')),
+    },
+  ],
+})

--- a/src/css/primitives/button/button.css.ts
+++ b/src/css/primitives/button/button.css.ts
@@ -70,215 +70,287 @@ export const tones: Record<ElementTone, string> = {
       const solid = vars.color.solid[t]
       const tinted = vars.color.tinted[t]
 
+      const stateVars = {
+        default: {
+          enabled: {
+            [vars.color.bg]: solid.bg[0],
+            [vars.color.border]: solid.border[1],
+            [vars.color.code.bg]: solid.bg[1],
+            [vars.color.code.fg]: solid.fg[4],
+            [vars.color.fg]: solid.fg[0],
+            [vars.color.muted.bg]: solid.bg[1],
+            [vars.color.muted.fg]: solid.fg[4],
+            [vars.button.boxShadow]: 'none',
+          },
+
+          hovered: {
+            [vars.color.bg]: solid.bg[1],
+            [vars.color.border]: solid.border[2],
+            [vars.color.code.bg]: solid.bg[2],
+            [vars.color.code.fg]: solid.fg[4],
+            [vars.color.fg]: solid.fg[0],
+            [vars.color.muted.bg]: solid.bg[2],
+            [vars.color.muted.fg]: solid.fg[4],
+          },
+
+          // NOTE: also used for `selected` state
+          pressed: {
+            [vars.color.bg]: solid.bg[2],
+            [vars.color.border]: solid.border[3],
+            [vars.color.code.bg]: solid.bg[3],
+            [vars.color.code.fg]: solid.fg[4],
+            [vars.color.fg]: solid.fg[0],
+            [vars.color.muted.bg]: solid.bg[3],
+            [vars.color.muted.fg]: solid.fg[4],
+          },
+
+          disabled: {
+            ..._fromEntries(
+              AVATAR_COLORS.map((c) => [vars.color.avatar[c].bg, vars.color.tinted.default.bg[3]]),
+            ),
+
+            [vars.color.bg]: vars.color.tinted.default.bg[1],
+            [vars.color.border]: vars.color.tinted.default.border[1],
+            [vars.color.code.bg]: vars.color.tinted.default.bg[2],
+            [vars.color.code.fg]: vars.color.tinted.default.border[4],
+            [vars.color.fg]: vars.color.tinted.default.border[4],
+            [vars.color.muted.bg]: vars.color.tinted.default.bg[2],
+            [vars.color.muted.fg]: vars.color.tinted.default.border[4],
+          },
+        },
+
+        ghost: {
+          enabled: {
+            [vars.color.bg]: `color-mix(in srgb, transparent, ${tinted.bg[1]} 50%)`,
+            [vars.color.border]: tinted.border[0],
+            [vars.color.fg]: tinted.fg[2],
+            [vars.color.code.bg]: tinted.bg[2],
+            [vars.color.code.fg]: tinted.fg[4],
+            [vars.color.muted.bg]: tinted.bg[2],
+            [vars.color.muted.fg]: tinted.fg[4],
+            [vars.button.boxShadow]: `inset 0 0 0 ${vars.button.border.width} ${vars.color.border}`,
+          },
+
+          hovered: {
+            [vars.color.bg]: tinted.bg[1],
+            [vars.color.border]: tinted.border[1],
+            [vars.color.code.bg]: tinted.bg[3],
+            [vars.color.code.fg]: tinted.fg[3],
+            [vars.color.fg]: tinted.fg[1],
+            [vars.color.muted.bg]: tinted.bg[3],
+            [vars.color.muted.fg]: tinted.fg[3],
+          },
+
+          // NOTE: also used for `selected` state
+          pressed: {
+            [vars.color.bg]: tinted.bg[2],
+            [vars.color.border]: tinted.border[2],
+            [vars.color.code.bg]: tinted.bg[4],
+            [vars.color.code.fg]: tinted.fg[3],
+            [vars.color.fg]: tinted.fg[1],
+            [vars.color.muted.bg]: tinted.bg[4],
+            [vars.color.muted.fg]: tinted.fg[3],
+            [vars.button.boxShadow]: `inset 0 0 0 ${vars.button.border.width} ${vars.color.border}`,
+          },
+
+          disabled: {
+            ..._fromEntries(
+              AVATAR_COLORS.map((c) => [vars.color.avatar[c].bg, vars.color.tinted.default.bg[2]]),
+            ),
+
+            [vars.color.bg]: vars.color.tinted.default.bg[0],
+            [vars.color.border]: vars.color.tinted.default.border[0],
+            [vars.color.code.bg]: vars.color.tinted.default.bg[1],
+            [vars.color.code.fg]: vars.color.tinted.default.border[3],
+            [vars.color.fg]: vars.color.tinted.default.border[4],
+            [vars.color.muted.bg]: vars.color.tinted.default.bg[1],
+            [vars.color.muted.fg]: vars.color.tinted.default.border[3],
+          },
+        },
+
+        bleed: {
+          enabled: {
+            [vars.color.bg]: tinted.bg[0],
+            [vars.color.border]: tinted.border[1],
+            [vars.color.fg]: tinted.fg[2],
+            [vars.color.muted.bg]: tinted.bg[1],
+            [vars.color.muted.fg]: tinted.fg[4],
+            [vars.button.boxShadow]: 'none',
+          },
+
+          hovered: {
+            [vars.color.bg]: tinted.bg[1],
+            [vars.color.border]: tinted.border[2],
+            [vars.color.fg]: tinted.fg[1],
+            [vars.color.muted.bg]: tinted.bg[2],
+            [vars.color.muted.fg]: tinted.fg[3],
+          },
+
+          // NOTE: also used for `selected` state
+          pressed: {
+            [vars.color.bg]: tinted.bg[2],
+            [vars.color.border]: tinted.border[3],
+            [vars.color.fg]: tinted.fg[1],
+            [vars.color.muted.bg]: tinted.bg[3],
+            [vars.color.muted.fg]: tinted.fg[3],
+          },
+
+          disabled: {
+            ..._fromEntries(
+              AVATAR_COLORS.map((c) => [vars.color.avatar[c].bg, vars.color.tinted.default.bg[2]]),
+            ),
+
+            [vars.color.bg]: vars.color.tinted.default.bg[0],
+            [vars.color.border]: vars.color.tinted.default.border[0],
+            [vars.color.code.bg]: vars.color.tinted.default.bg[1],
+            [vars.color.code.fg]: vars.color.tinted.default.border[3],
+            [vars.color.fg]: vars.color.tinted.default.border[4],
+            [vars.color.muted.bg]: vars.color.tinted.default.bg[1],
+            [vars.color.muted.fg]: vars.color.tinted.default.border[3],
+          },
+        },
+      }
+
       return [
         t,
         _style(layers.primitives, {
-          selectors: {
-            // default
+          '@media': {
+            '(hover: hover)': {
+              selectors: {
+                [[
+                  `&.${modes.default}`,
+                  ':not(:active)',
+                  ':not(:focus)',
+                  ':not(:disabled)',
+                  ':not([aria-pressed="true"])',
+                  ':not([data-pressed])',
+                  ':not([data-focused])',
+                  ':not([data-selected])',
+                  ':not([data-disabled])',
+                  ':hover',
+                ].join('')]: {
+                  vars: stateVars.default.hovered,
+                },
 
-            [`&.${modes.default}`]: {
-              vars: {
-                [vars.color.bg]: solid.bg[0],
-                [vars.color.border]: solid.border[1],
-                [vars.color.code.bg]: solid.bg[1],
-                [vars.color.code.fg]: solid.fg[4],
-                [vars.color.fg]: solid.fg[0],
-                [vars.color.muted.bg]: solid.bg[1],
-                [vars.color.muted.fg]: solid.fg[4],
-                [vars.button.boxShadow]: 'none',
+                [[
+                  `&.${modes.ghost}`,
+                  ':not(:active)',
+                  ':not(:focus)',
+                  ':not(:disabled)',
+                  ':not([aria-pressed="true"])',
+                  ':not([data-pressed])',
+                  ':not([data-focused])',
+                  ':not([data-selected])',
+                  ':not([data-disabled])',
+                  ':hover',
+                ].join('')]: {
+                  vars: stateVars.ghost.hovered,
+                },
+
+                [[
+                  `&.${modes.bleed}`,
+                  ':not(:active)',
+                  ':not(:focus)',
+                  ':not(:disabled)',
+                  ':not([aria-pressed="true"])',
+                  ':not([data-pressed])',
+                  ':not([data-focused])',
+                  ':not([data-selected])',
+                  ':not([data-disabled])',
+                  ':hover',
+                ].join('')]: {
+                  vars: stateVars.bleed.hovered,
+                },
               },
             },
+          },
 
-            [`&.${modes.default}:not([data-disabled]):hover`]: {
-              vars: {
-                [vars.color.bg]: solid.bg[1],
-                [vars.color.border]: solid.border[2],
-                [vars.color.code.bg]: solid.bg[2],
-                [vars.color.code.fg]: solid.fg[4],
-                [vars.color.fg]: solid.fg[0],
-                [vars.color.muted.bg]: solid.bg[2],
-                [vars.color.muted.fg]: solid.fg[4],
-              },
+          'selectors': {
+            // default - enabled
+            [`&.${modes.default}:not([data-disabled])`]: {
+              vars: stateVars.default.enabled,
             },
 
-            [`&.${modes.default}:not([data-disabled]):active`]: {
-              vars: {
-                [vars.color.bg]: solid.bg[2],
-                [vars.color.border]: solid.border[3],
-                [vars.color.code.bg]: solid.bg[3],
-                [vars.color.code.fg]: solid.fg[4],
-                [vars.color.fg]: solid.fg[0],
-                [vars.color.muted.bg]: solid.bg[3],
-                [vars.color.muted.fg]: solid.fg[4],
-              },
+            // default - hovered
+            [[
+              // `&.${modes.default}:not([data-disabled]):hover`,
+              `&.${modes.default}:not([data-disabled])[data-hovered]`,
+            ].join(',')]: {
+              vars: stateVars.default.hovered,
             },
 
-            [`&.${modes.default}:not([data-disabled])[data-selected]`]: {
-              vars: {
-                [vars.color.bg]: solid.bg[2],
-                [vars.color.border]: solid.border[3],
-                [vars.color.code.bg]: solid.bg[3],
-                [vars.color.code.fg]: solid.fg[4],
-                [vars.color.fg]: solid.fg[0],
-                [vars.color.muted.bg]: solid.bg[3],
-                [vars.color.muted.fg]: solid.fg[4],
-              },
+            // default - pressed
+            // default - selected
+            [[
+              `&.${modes.default}:not([data-disabled]):active`,
+              `&.${modes.default}:not([data-disabled])[aria-pressed="true"]`,
+              `&.${modes.default}:not([data-disabled])[data-pressed]`,
+              `&.${modes.default}:not([data-disabled])[data-selected]`,
+            ].join(',')]: {
+              vars: stateVars.default.pressed,
             },
 
-            [`&.${modes.default}[data-disabled]`]: {
-              vars: {
-                ..._fromEntries(
-                  AVATAR_COLORS.map((c) => [
-                    vars.color.avatar[c].bg,
-                    vars.color.tinted.default.bg[3],
-                  ]),
-                ),
-
-                [vars.color.bg]: vars.color.tinted.default.bg[1],
-                [vars.color.border]: vars.color.tinted.default.border[1],
-                [vars.color.code.bg]: vars.color.tinted.default.bg[2],
-                [vars.color.code.fg]: vars.color.tinted.default.border[4],
-                [vars.color.fg]: vars.color.tinted.default.border[4],
-                [vars.color.muted.bg]: vars.color.tinted.default.bg[2],
-                [vars.color.muted.fg]: vars.color.tinted.default.border[4],
-              },
+            // default - disabled
+            [[`&.${modes.default}:disabled`, `&.${modes.default}[data-disabled]`].join(',')]: {
+              vars: stateVars.default.disabled,
             },
 
-            // ghost
-
-            [`&.${modes.ghost}`]: {
-              vars: {
-                [vars.color.bg]: `color-mix(in srgb, transparent, ${tinted.bg[1]} 50%)`,
-                [vars.color.border]: tinted.border[0],
-                [vars.color.fg]: tinted.fg[2],
-                [vars.color.code.bg]: tinted.bg[2],
-                [vars.color.code.fg]: tinted.fg[4],
-                [vars.color.muted.bg]: tinted.bg[2],
-                [vars.color.muted.fg]: tinted.fg[4],
-                [vars.button.boxShadow]:
-                  `inset 0 0 0 ${vars.button.border.width} ${vars.color.border}`,
-              },
+            // ghost - enabled
+            [`&.${modes.ghost}:not([data-disabled])`]: {
+              vars: stateVars.ghost.enabled,
             },
 
-            [`&.${modes.ghost}:not([data-disabled]):hover`]: {
-              vars: {
-                [vars.color.bg]: tinted.bg[1],
-                [vars.color.border]: tinted.border[1],
-                [vars.color.code.bg]: tinted.bg[3],
-                [vars.color.code.fg]: tinted.fg[3],
-                [vars.color.fg]: tinted.fg[1],
-                [vars.color.muted.bg]: tinted.bg[3],
-                [vars.color.muted.fg]: tinted.fg[3],
-              },
+            // ghost - hovered
+            [[
+              // `&.${modes.ghost}:not([data-disabled]):hover`,
+              `&.${modes.ghost}:not([data-disabled])[data-hovered]`,
+            ].join(',')]: {
+              vars: stateVars.ghost.hovered,
             },
 
-            [`&.${modes.ghost}:not([data-disabled]):active`]: {
-              vars: {
-                [vars.color.bg]: tinted.bg[2],
-                [vars.color.border]: tinted.border[2],
-                [vars.color.code.bg]: tinted.bg[4],
-                [vars.color.code.fg]: tinted.fg[3],
-                [vars.color.fg]: tinted.fg[1],
-                [vars.color.muted.bg]: tinted.bg[4],
-                [vars.color.muted.fg]: tinted.fg[3],
-                [vars.button.boxShadow]:
-                  `inset 0 0 0 ${vars.button.border.width} ${vars.color.border}`,
-              },
+            // ghost - pressed
+            // ghost - selected
+            [[
+              `&.${modes.ghost}:not([data-disabled]):active`,
+              `&.${modes.ghost}:not([data-disabled])[aria-pressed="true"]`,
+              `&.${modes.ghost}:not([data-disabled])[data-pressed]`,
+              `&.${modes.ghost}:not([data-disabled])[data-selected]`,
+            ].join(',')]: {
+              vars: stateVars.ghost.pressed,
             },
 
-            [`&.${modes.ghost}:not([data-disabled])[data-selected]`]: {
-              vars: {
-                [vars.color.bg]: tinted.bg[2],
-                [vars.color.border]: tinted.border[2],
-                [vars.color.code.bg]: tinted.bg[4],
-                [vars.color.code.fg]: tinted.fg[3],
-                [vars.color.fg]: tinted.fg[1],
-                [vars.color.muted.bg]: tinted.bg[4],
-                [vars.color.muted.fg]: tinted.fg[3],
-                [vars.button.boxShadow]:
-                  `inset 0 0 0 ${vars.button.border.width} ${vars.color.border}`,
-              },
+            // ghost - disabled
+            [[`&.${modes.ghost}:disabled`, `&.${modes.ghost}[data-disabled]`].join(',')]: {
+              vars: stateVars.ghost.disabled,
             },
 
-            [`&.${modes.ghost}[data-disabled]`]: {
-              vars: {
-                ..._fromEntries(
-                  AVATAR_COLORS.map((c) => [
-                    vars.color.avatar[c].bg,
-                    vars.color.tinted.default.bg[2],
-                  ]),
-                ),
-
-                [vars.color.bg]: vars.color.tinted.default.bg[0],
-                [vars.color.border]: vars.color.tinted.default.border[0],
-                [vars.color.code.bg]: vars.color.tinted.default.bg[1],
-                [vars.color.code.fg]: vars.color.tinted.default.border[3],
-                [vars.color.fg]: vars.color.tinted.default.border[4],
-                [vars.color.muted.bg]: vars.color.tinted.default.bg[1],
-                [vars.color.muted.fg]: vars.color.tinted.default.border[3],
-              },
+            // bleed - enabled
+            [`&.${modes.bleed}:not([data-disabled])`]: {
+              vars: stateVars.bleed.enabled,
             },
 
-            // bleed
-
-            [`&.${modes.bleed}`]: {
-              vars: {
-                [vars.color.bg]: tinted.bg[0],
-                [vars.color.border]: tinted.border[1],
-                [vars.color.fg]: tinted.fg[2],
-                [vars.color.muted.bg]: tinted.bg[1],
-                [vars.color.muted.fg]: tinted.fg[4],
-                [vars.button.boxShadow]: 'none',
-              },
+            // bleed - hovered
+            [[
+              // `&.${modes.bleed}:not([data-disabled]):hover`,
+              `&.${modes.bleed}:not([data-disabled])[data-hovered]`,
+            ].join(',')]: {
+              vars: stateVars.bleed.hovered,
             },
 
-            [`&.${modes.bleed}:not([data-disabled]):hover`]: {
-              vars: {
-                [vars.color.bg]: tinted.bg[1],
-                [vars.color.border]: tinted.border[2],
-                [vars.color.fg]: tinted.fg[1],
-                [vars.color.muted.bg]: tinted.bg[2],
-                [vars.color.muted.fg]: tinted.fg[3],
-              },
+            // bleed - pressed
+            // bleed - selected
+            [[
+              `&.${modes.bleed}:not([data-disabled]):active`,
+              `&.${modes.bleed}:not([data-disabled])[aria-pressed="true"]`,
+              `&.${modes.bleed}:not([data-disabled])[data-pressed]`,
+              `&.${modes.bleed}:not([data-disabled])[data-selected]`,
+            ].join(',')]: {
+              vars: stateVars.bleed.pressed,
             },
 
-            [`&.${modes.bleed}:not([data-disabled]):active`]: {
-              vars: {
-                [vars.color.bg]: tinted.bg[2],
-                [vars.color.border]: tinted.border[3],
-                [vars.color.fg]: tinted.fg[1],
-                [vars.color.muted.bg]: tinted.bg[3],
-                [vars.color.muted.fg]: tinted.fg[3],
-              },
-            },
-
-            [`&.${modes.bleed}:not([data-disabled])[data-selected]`]: {
-              vars: {
-                [vars.color.bg]: tinted.bg[2],
-                [vars.color.border]: tinted.border[3],
-                [vars.color.fg]: tinted.fg[1],
-                [vars.color.muted.bg]: tinted.bg[3],
-                [vars.color.muted.fg]: tinted.fg[3],
-              },
-            },
-
-            [`&.${modes.bleed}[data-disabled]`]: {
-              vars: {
-                ..._fromEntries(
-                  AVATAR_COLORS.map((c) => [
-                    vars.color.avatar[c].bg,
-                    vars.color.tinted.default.bg[2],
-                  ]),
-                ),
-
-                [vars.color.bg]: vars.color.tinted.default.bg[0],
-                [vars.color.border]: vars.color.tinted.default.border[0],
-                [vars.color.code.bg]: vars.color.tinted.default.bg[1],
-                [vars.color.code.fg]: vars.color.tinted.default.border[3],
-                [vars.color.fg]: vars.color.tinted.default.border[4],
-                [vars.color.muted.bg]: vars.color.tinted.default.bg[1],
-                [vars.color.muted.fg]: vars.color.tinted.default.border[3],
-              },
+            // bleed - disabled
+            [[`&.${modes.bleed}:disabled`, `&.${modes.bleed}[data-disabled]`].join(',')]: {
+              vars: stateVars.bleed.disabled,
             },
           },
         }),

--- a/src/css/primitives/card/card.css.ts
+++ b/src/css/primitives/card/card.css.ts
@@ -15,14 +15,8 @@ import {_style} from '../../_style.css'
 import {layers} from '../../layers.css'
 import {vars} from '../../vars.css'
 
-export const root: string = _style(layers.primitives, {
-  backgroundColor: vars.color.bg,
-  color: vars.color.fg,
-
-  transition:
-    'background-color 100ms ease-in-out, border-color 100ms, box-shadow 100ms ease-in-out, color 100ms ease-in-out',
-
-  vars: {
+const stateVars = {
+  enabled: {
     [vars.color.bg]: vars.color.tinted.default.bg[0],
     [vars.color.border]: vars.color.tinted.default.border[1],
     [vars.color.fg]: vars.color.tinted.default.fg[0],
@@ -31,7 +25,93 @@ export const root: string = _style(layers.primitives, {
     [vars.color.muted.fg]: vars.color.tinted.default.fg[4],
   },
 
-  selectors: {
+  hovered: {
+    [vars.color.bg]: vars.color.tinted.default.bg[1],
+    [vars.color.border]: vars.color.tinted.default.border[3],
+    [vars.color.fg]: vars.color.tinted.default.fg[1],
+    [vars.color.code.bg]: vars.color.tinted.default.bg[2],
+    [vars.color.code.fg]: vars.color.tinted.default.fg[4],
+    [vars.color.muted.bg]: vars.color.tinted.default.bg[2],
+    [vars.color.muted.fg]: vars.color.tinted.default.fg[4],
+  },
+
+  pressed: {
+    [vars.color.bg]: vars.color.tinted.default.bg[2],
+    [vars.color.border]: vars.color.tinted.default.border[4],
+    [vars.color.fg]: vars.color.tinted.default.fg[0],
+    [vars.color.code.bg]: vars.color.tinted.default.bg[3],
+    [vars.color.code.fg]: vars.color.tinted.default.fg[4],
+    [vars.color.muted.bg]: vars.color.tinted.default.bg[3],
+    [vars.color.muted.fg]: vars.color.tinted.default.fg[4],
+  },
+
+  selected: {
+    [vars.color.bg]: vars.color.solid.primary.bg[0],
+    [vars.color.border]: vars.color.solid.primary.border[1],
+    [vars.color.fg]: vars.color.solid.primary.fg[0],
+    [vars.color.code.bg]: vars.color.solid.primary.bg[1],
+    [vars.color.code.fg]: vars.color.solid.primary.fg[3],
+    [vars.color.muted.bg]: vars.color.solid.primary.bg[1],
+    [vars.color.muted.fg]: vars.color.solid.primary.fg[3],
+  },
+
+  disabled: {
+    [vars.color.bg]: vars.color.tinted.default.bg[0],
+    [vars.color.border]: vars.color.tinted.default.border[1],
+    [vars.color.fg]: vars.color.tinted.default.border[3],
+    [vars.color.code.bg]: vars.color.tinted.default.bg[0],
+    [vars.color.code.fg]: vars.color.tinted.default.border[2],
+    [vars.color.muted.bg]: vars.color.tinted.default.bg[1],
+    [vars.color.muted.fg]: vars.color.tinted.default.border[2],
+  },
+}
+
+export const root: string = _style(layers.primitives, {
+  'backgroundColor': vars.color.bg,
+  'color': vars.color.fg,
+
+  'transition':
+    'background-color 100ms ease-in-out, border-color 100ms, box-shadow 100ms ease-in-out, color 100ms ease-in-out',
+
+  'vars': stateVars.enabled,
+
+  '@media': {
+    '(hover: hover)': {
+      selectors: {
+        [[
+          'a.&',
+          ':not(:active)',
+          ':not(:focus)',
+          ':not(:disabled)',
+          ':not([aria-pressed="true"])',
+          ':not([data-pressed])',
+          ':not([data-focused])',
+          ':not([data-selected])',
+          ':not([data-disabled])',
+          ':hover',
+        ].join('')]: {
+          vars: stateVars.hovered,
+        },
+
+        [[
+          'button.&',
+          ':not(:active)',
+          ':not(:focus)',
+          ':not(:disabled)',
+          ':not([aria-pressed="true"])',
+          ':not([data-pressed])',
+          ':not([data-focused])',
+          ':not([data-selected])',
+          ':not([data-disabled])',
+          ':hover',
+        ].join('')]: {
+          vars: stateVars.hovered,
+        },
+      },
+    },
+  },
+
+  'selectors': {
     'a.&': {
       outline: 'none',
       textDecoration: 'none',
@@ -49,89 +129,65 @@ export const root: string = _style(layers.primitives, {
         `repeating-conic-gradient(${vars.color.bg} 0% 25%, ${vars.color.muted.bg} 0% 50%)` as string,
     },
 
-    'a.&:not([data-disabled]):hover, button.&:not([data-disabled]):hover': {
-      vars: {
-        [vars.color.bg]: vars.color.tinted.default.bg[1],
-        [vars.color.border]: vars.color.tinted.default.border[3],
-        [vars.color.fg]: vars.color.tinted.default.fg[1],
-        [vars.color.code.bg]: vars.color.tinted.default.bg[2],
-        [vars.color.code.fg]: vars.color.tinted.default.fg[4],
-        [vars.color.muted.bg]: vars.color.tinted.default.bg[2],
-        [vars.color.muted.fg]: vars.color.tinted.default.fg[4],
-      },
+    // hovered
+    [[
+      //
+      'a.&:not([data-disabled])[data-hovered]',
+      'button.&:not([data-disabled])[data-hovered]',
+    ].join(',')]: {
+      vars: stateVars.hovered,
     },
 
-    'a&:not([data-disabled]):active, button&:not([data-disabled]):active': {
-      vars: {
-        [vars.color.bg]: vars.color.tinted.default.bg[2],
-        [vars.color.border]: vars.color.tinted.default.border[4],
-        [vars.color.fg]: vars.color.tinted.default.fg[0],
-        [vars.color.code.bg]: vars.color.tinted.default.bg[3],
-        [vars.color.code.fg]: vars.color.tinted.default.fg[4],
-        [vars.color.muted.bg]: vars.color.tinted.default.bg[3],
-        [vars.color.muted.fg]: vars.color.tinted.default.fg[4],
-      },
+    // pressed
+    [[
+      'a.&:not([data-disabled]):active',
+      'button.&:not([data-disabled]):active',
+      'a.&:not([data-disabled])[aria-pressed="true"]',
+      'button.&:not([data-disabled])[aria-pressed="true"]',
+      'a.&:not([data-disabled])[data-pressed]',
+      'button.&:not([data-disabled])[data-pressed]',
+    ].join(',')]: {
+      vars: stateVars.pressed,
     },
 
-    // toggle button
-    'a&:not([data-disabled])[aria-pressed="true"], button&:not([data-disabled])[aria-pressed="true"]':
-      {
-        vars: {
-          [vars.color.bg]: vars.color.tinted.default.bg[2],
-          [vars.color.border]: vars.color.tinted.default.border[4],
-          [vars.color.fg]: vars.color.tinted.default.fg[0],
-          [vars.color.code.bg]: vars.color.tinted.default.bg[3],
-          [vars.color.code.fg]: vars.color.tinted.default.fg[4],
-          [vars.color.muted.bg]: vars.color.tinted.default.bg[3],
-          [vars.color.muted.fg]: vars.color.tinted.default.fg[4],
-        },
-      },
-
-    'a&:not([data-disabled])[data-pressed], button&:not([data-disabled])[data-pressed]': {
-      vars: {
-        [vars.color.bg]: vars.color.tinted.default.bg[2],
-        [vars.color.border]: vars.color.tinted.default.border[4],
-        [vars.color.fg]: vars.color.tinted.default.fg[0],
-        [vars.color.code.bg]: vars.color.tinted.default.bg[3],
-        [vars.color.code.fg]: vars.color.tinted.default.fg[4],
-        [vars.color.muted.bg]: vars.color.tinted.default.bg[3],
-        [vars.color.muted.fg]: vars.color.tinted.default.fg[4],
-      },
+    // selected
+    [[
+      //
+      'a.&:not([data-disabled])[data-selected]',
+      'button.&:not([data-disabled])[data-selected]',
+    ].join(',')]: {
+      vars: stateVars.selected,
     },
 
-    'a&:not([data-disabled])[data-selected], button&:not([data-disabled])[data-selected]': {
-      vars: {
-        [vars.color.bg]: vars.color.solid.primary.bg[0],
-        [vars.color.border]: vars.color.solid.primary.border[1],
-        [vars.color.fg]: vars.color.solid.primary.fg[0],
-        [vars.color.code.bg]: vars.color.solid.primary.bg[1],
-        [vars.color.code.fg]: vars.color.solid.primary.fg[3],
-        [vars.color.muted.bg]: vars.color.solid.primary.bg[1],
-        [vars.color.muted.fg]: vars.color.solid.primary.fg[3],
-      },
+    // disabled
+    [[
+      //
+      'a.&:disabled',
+      'a.&[data-disabled]',
+      'button.&:disabled',
+      'button.&[data-disabled]',
+    ].join(',')]: {
+      vars: stateVars.disabled,
     },
 
-    'a&[data-disabled], button&[data-disabled]': {
-      vars: {
-        [vars.color.bg]: vars.color.tinted.default.bg[0],
-        [vars.color.border]: vars.color.tinted.default.border[1],
-        [vars.color.fg]: vars.color.tinted.default.border[3],
-        [vars.color.code.bg]: vars.color.tinted.default.bg[0],
-        [vars.color.code.fg]: vars.color.tinted.default.border[2],
-        [vars.color.muted.bg]: vars.color.tinted.default.bg[1],
-        [vars.color.muted.fg]: vars.color.tinted.default.border[2],
-      },
-    },
-
-    'a&[data-focus-ring]:focus, button&[data-focus-ring]:focus': {
+    // focus ring
+    [[
+      //
+      'a.&[data-focus-ring]:focus',
+      'button.&[data-focus-ring]:focus',
+    ].join(',')]: {
       outline: `${vars.card.focusRing.width} solid ${vars.color.focusRing}`,
       outlineOffset: vars.card.focusRing.offset,
     },
 
-    'a&[data-focus-ring]:focus:not(:focus-visible), button&[data-focus-ring]:focus:not(:focus-visible)':
-      {
-        outline: 'none',
-      },
+    // focus ring - not focus visible
+    [[
+      //
+      'a.&[data-focus-ring]:focus:not(:focus-visible)',
+      'button.&[data-focus-ring]:focus:not(:focus-visible)',
+    ].join(',')]: {
+      outline: 'none',
+    },
   },
 })
 

--- a/src/css/primitives/selectable/selectable.css.ts
+++ b/src/css/primitives/selectable/selectable.css.ts
@@ -35,67 +35,102 @@ export const tones: Record<ElementTone, string> = {
       const focused = vars.color.solid.primary
       const disabled = vars.color.tinted.default
 
+      const stateVars = {
+        enabled: {
+          [vars.color.bg]: tinted.bg[0],
+          [vars.color.border]: tinted.border[1],
+          [vars.color.fg]: tinted.fg[2],
+          [vars.color.muted.bg]: tinted.bg[1],
+          [vars.color.muted.fg]: tinted.fg[3],
+        },
+
+        hovered: {
+          [vars.color.bg]: tinted.bg[1],
+          [vars.color.border]: tinted.border[2],
+          [vars.color.fg]: tinted.fg[1],
+          [vars.color.muted.bg]: tinted.bg[2],
+          [vars.color.muted.fg]: tinted.fg[4],
+        },
+
+        pressed: {
+          [vars.color.bg]: tinted.bg[2],
+          [vars.color.border]: tinted.border[4],
+          [vars.color.fg]: tinted.fg[0],
+          [vars.color.muted.bg]: tinted.bg[3],
+          [vars.color.muted.fg]: tinted.fg[4],
+        },
+
+        focused: {
+          [vars.color.bg]: focused.bg[0],
+          [vars.color.border]: focused.border[1],
+          [vars.color.fg]: focused.fg[0],
+          [vars.color.muted.bg]: focused.bg[1],
+          [vars.color.muted.fg]: focused.fg[3],
+        },
+
+        disabled: {
+          [vars.color.bg]: disabled.bg[0],
+          [vars.color.border]: disabled.border[1],
+          [vars.color.fg]: disabled.border[4],
+          [vars.color.muted.bg]: disabled.bg[1],
+          [vars.color.muted.fg]: disabled.border[4],
+        },
+      } as const
+
       return [
         t,
         _style(layers.primitives, {
-          'vars': {
-            [vars.color.bg]: tinted.bg[0],
-            [vars.color.border]: tinted.border[1],
-            [vars.color.fg]: tinted.fg[2],
-            [vars.color.muted.bg]: tinted.bg[1],
-            [vars.color.muted.fg]: tinted.fg[3],
-          },
+          'vars': stateVars.enabled,
 
           '@media': {
             '(hover: hover)': {
               selectors: {
-                '&:not([data-pressed]):not([data-selected]):not([data-focused]):not([data-disabled]):not(:active):not(:focus):hover':
-                  {
-                    vars: {
-                      [vars.color.bg]: tinted.bg[1],
-                      [vars.color.border]: tinted.border[2],
-                      [vars.color.fg]: tinted.fg[1],
-                      [vars.color.muted.bg]: tinted.bg[2],
-                      [vars.color.muted.fg]: tinted.fg[4],
-                    },
-                  },
+                [[
+                  '&',
+                  ':not(:active)',
+                  ':not(:focus)',
+                  ':not(:disabled)',
+                  ':not([aria-pressed="true"])',
+                  ':not([data-pressed])',
+                  ':not([data-focused])',
+                  ':not([data-selected])',
+                  ':not([data-disabled])',
+                  ':hover',
+                ].join('')]: {
+                  vars: stateVars.hovered,
+                },
               },
             },
           },
 
           'selectors': {
-            // selected
-            '&:not([data-disabled]):active, &:not([data-disabled])[aria-pressed="true"], &:not([data-disabled])[data-selected]':
-              {
-                vars: {
-                  [vars.color.bg]: tinted.bg[2],
-                  [vars.color.border]: tinted.border[4],
-                  [vars.color.fg]: tinted.fg[0],
-                  [vars.color.muted.bg]: tinted.bg[3],
-                  [vars.color.muted.fg]: tinted.fg[4],
-                },
-              },
+            // hovered
+            [['&:not([data-disabled])[data-hovered]'].join(',')]: {
+              vars: stateVars.hovered,
+            },
+
+            // pressed
+            [[
+              '&:not([data-disabled]):active',
+              '&:not([data-disabled])[aria-pressed="true"]',
+              '&:not([data-disabled])[data-pressed]',
+            ].join(',')]: {
+              vars: stateVars.pressed,
+            },
 
             // focused
-            '&:not([data-disabled]):focus, &:not([data-disabled])[data-focused]': {
-              vars: {
-                [vars.color.bg]: focused.bg[0],
-                [vars.color.border]: focused.border[1],
-                [vars.color.fg]: focused.fg[0],
-                [vars.color.muted.bg]: focused.bg[1],
-                [vars.color.muted.fg]: focused.fg[3],
-              },
+            // selected
+            [[
+              '&:not([data-disabled]):focus',
+              '&:not([data-disabled])[data-focused]',
+              '&:not([data-disabled])[data-selected]',
+            ].join(',')]: {
+              vars: stateVars.focused,
             },
 
             // disabled
-            '&[data-disabled]': {
-              vars: {
-                [vars.color.bg]: disabled.bg[0],
-                [vars.color.border]: disabled.border[1],
-                [vars.color.fg]: disabled.border[4],
-                [vars.color.muted.bg]: disabled.bg[1],
-                [vars.color.muted.fg]: disabled.border[4],
-              },
+            [['&:disabled', '&[data-disabled]'].join(',')]: {
+              vars: stateVars.disabled,
             },
           },
         }),


### PR DESCRIPTION
<!-- ### Description -->

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This fixes an issue reported by @robinpyon:

- It should still be possible to pass `data-hovered=""`,  `data-pressed=""`,  `data-selected=""` props to the `Button`, `Card`, and `Selectable` (powers `MenuItem`) components.

<!-- ### What to review -->

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

<!-- ### Testing -->

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
