### PR TITLE
fix(toast): support `duration: Infinity`

### DIFF
--- a/src/core/components/toast/ToastProvider.tsx
+++ b/src/core/components/toast/ToastProvider.tsx
@@ -60,7 +60,7 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
             })
           }
 
-          const timeoutId = setTimeout(dismiss, duration)
+          const timeoutId = duration === Infinity ? undefined : setTimeout(dismiss, duration)
 
           /**
            * Create updated state by:


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fix implementation so that `pushToast({duration: Inifinity})` renders a toast which doesn't auto-dismiss.
