### PR TITLE
fix(button): revert adding explicity inline-size

### DIFF
--- a/src/css/primitives/button/button.css.ts
+++ b/src/css/primitives/button/button.css.ts
@@ -23,7 +23,6 @@ export const root: string = _style(layers.primitives, {
   verticalAlign: 'top',
   backgroundColor: vars.color.bg,
   color: vars.color.fg,
-  inlineSize: 'max-content',
 
   selectors: {
     '&::-moz-focus-inner': {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The `inlineSize` prop was added in https://github.com/sanity-io/ui/commit/e3ba3cb4d1958a84aa6edbdffeb7dfef9e9287a0, but breaks a ton of buttons in Dashboard, because adding `width="fill"` to buttons no longer works.

Refs https://github.com/sanity-io/ada/pull/1965

https://sanity-io.slack.com/archives/C08SH30FJQL/p1761558755847009
