### PR TITLE
chore: accept iconRight prop for tabs

### DIFF
--- a/src/core/components/tab/tab.tsx
+++ b/src/core/components/tab/tab.tsx
@@ -14,6 +14,7 @@ export interface TabProps {
   'aria-controls': string
   'id': string
   'icon'?: React.ElementType | React.ReactNode
+  'iconRight'?: React.ElementType | React.ReactNode
   'focused'?: boolean
   'fontSize'?: number | number[]
   'label'?: React.ReactNode

--- a/stories/components/Tab.stories.tsx
+++ b/stories/components/Tab.stories.tsx
@@ -66,3 +66,12 @@ export const WithIcon: Story = {
     return <Tab {...props} />
   },
 }
+
+export const WithIconRight: Story = {
+  args: {
+    iconRight: SearchIcon,
+  },
+  render: (props) => {
+    return <Tab {...props} />
+  },
+}


### PR DESCRIPTION
### Description
Tabs are a button, buttons have icon right. This change only exposes the prop to allow it's use
We need it to add a validation warning icon to the tabs used in the studio to render the groups.

<img width="1003" height="157" alt="Screenshot 2026-01-28 at 10 44 28" src="https://github.com/user-attachments/assets/cdd9ccae-a583-48ec-aea9-045acb8298e6" />

See this issue: https://github.com/sanity-io/sanity/issues/11263

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
