### PR TITLE
fix: lazily compute color themes, tones, v0 colors

### DIFF
--- a/src/theme/build/lib/lazy.ts
+++ b/src/theme/build/lib/lazy.ts
@@ -1,0 +1,30 @@
+/**
+ * Defines a lazy, self-replacing property on `obj`.
+ *
+ * On first access the `factory` is called and the getter is replaced with the
+ * computed plain value — subsequent reads have zero overhead.
+ *
+ * The property is enumerable (visible in `Object.keys` / spread) in both states.
+ *
+ * @internal
+ */
+export function defineLazyProperty<T extends object, K extends keyof T>(
+  obj: T,
+  key: K,
+  factory: () => T[K],
+): void {
+  Object.defineProperty(obj, key, {
+    get() {
+      const value = factory()
+      Object.defineProperty(obj, key, {
+        value,
+        enumerable: true,
+        writable: false,
+        configurable: false,
+      })
+      return value
+    },
+    enumerable: true,
+    configurable: true,
+  })
+}

--- a/src/theme/getScopedTheme.ts
+++ b/src/theme/getScopedTheme.ts
@@ -1,3 +1,4 @@
+import {defineLazyProperty} from './build/lib/lazy'
 import {defaultThemeConfig} from './defaults/config'
 import {
   RootTheme,
@@ -29,8 +30,6 @@ export function getScopedTheme(
   const v0 = is_v2(themeProp) ? v2_v0(themeProp) : themeProp
   const v2 = is_v2(themeProp) ? themeProp : v0_v2(themeProp)
 
-  const colorScheme_v0 = v0.color[scheme] || v0.color.light
-  const color_v0 = (colorScheme_v0 as Record<string, ThemeColor>)[tone] || colorScheme_v0.default
   const layer_v0 = v0.layer || defaultThemeConfig.layer
 
   const colorScheme_v2 = v2.color[scheme] || v2.color.light
@@ -38,19 +37,27 @@ export function getScopedTheme(
   const color_v2_9 = themeColor_v0_v2_9(color_v2)
   const layer_v2 = v2.layer || defaultThemeConfig.layer
 
-  const theme: Theme = {
-    sanity: {
-      ...v0,
-      color: color_v0,
-      layer: layer_v0,
-      v2: {
-        ...v2,
-        _resolved: true,
-        color: color_v2_9,
-        layer: layer_v2,
-      },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const {color: _v0Color, ...v0Rest} = v0
+
+  const sanity = {
+    ...v0Rest,
+    layer: layer_v0,
+    v2: {
+      ...v2,
+      _resolved: true,
+      color: color_v2_9,
+      layer: layer_v2,
     },
-  }
+  } as Theme['sanity']
+
+  // Defer v0 color computation — only resolved if legacy code reads theme.sanity.color
+  defineLazyProperty(sanity, 'color', () => {
+    const colorScheme_v0 = v0.color[scheme] || v0.color.light
+    return (colorScheme_v0 as Record<string, ThemeColor>)[tone] || colorScheme_v0.default
+  })
+
+  const theme: Theme = {sanity}
 
   _setCachedTheme(themeProp, scheme, tone, theme)
 


### PR DESCRIPTION
### Description

Currently, `buildColorTheme` takes an average of 236ms to execute on my (M4 Pro) MacBook. A lot of the computation is either not needed or can be deferred until needed. This PR adds lazy evaluation in a few different parts:

1. Non-default color schemes and tones
2. v0 compatibility `color` property

This brings the up-front computation cost down to under 1ms. If we wanted to "prime" schemes/tones so it doesn't cost us at an inopportune render-time, one could do something like:

```js
import {buildTheme, getScopedTheme} from '@sanity/ui/theme'

const theme = buildTheme()

requestIdleCallback(() => {
  getScopedTheme(theme, 'light', 'default')
  getScopedTheme(theme, 'dark', 'default')
})
```

Getting the scoped theme takes about ~16ms for each one.

### What to review

Changes appear safe and don't have unwanted side effects

### Testing

No new tests. This is transparent for the end user and should be considered an implementation detail.
