### PR TITLE
fix: match storybook output to Vercel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "pkg:check": "pkg --strict",
     "prepare": "husky install",
     "release": "semantic-release",
-    "storybook:build": "storybook build",
+    "storybook:build": "storybook build -o storybook/storybook-static",
     "storybook:dev": "storybook dev -p 6006",
     "test": "jest",
     "test:browser": "start-server-and-test 'run-s workshop:build workshop:start' http://localhost:1337 'run-s cypress:run'",


### PR DESCRIPTION
## Summary
- The Vercel project `sanity-ui-storybook` expects output at `storybook/storybook-static` (matching the v4 monorepo layout)
- On v3 branches, `storybook build` outputs to `storybook-static/` at the repo root, causing all deployments to fail with "No Output Directory found"
- Updates the build script to use `storybook build -o storybook/storybook-static` so the output lands where Vercel expects it

## Test plan
- [x] Verify the Vercel preview deployment for this PR succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)