### PR TITLE
fix(useDelayedState): cancel timeouts on unmount

### DIFF
--- a/src/core/hooks/useDelayed.test.ts
+++ b/src/core/hooks/useDelayed.test.ts
@@ -47,6 +47,26 @@ describe('useDelayedState', () => {
     expect(result.current[0]).toBe(true)
   })
 
+  it('should clear pending timeout on unmount', () => {
+    jest.useFakeTimers()
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+    const {result, unmount} = renderHook(() => useDelayedState(false))
+    const [, setState] = result.current
+
+    act(() => {
+      setState(true, 1000)
+    })
+
+    clearTimeoutSpy.mockClear()
+
+    // Unmount while the delayed update is still pending
+    unmount()
+
+    // clearTimeout should have been called during cleanup
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+    clearTimeoutSpy.mockRestore()
+  })
+
   it('should cancel update if the set state was called with a new state', () => {
     const {result} = renderHook(() => useDelayedState(false))
     const [, setState] = result.current

--- a/src/core/hooks/useDelayedState.ts
+++ b/src/core/hooks/useDelayedState.ts
@@ -1,4 +1,4 @@
-import {SetStateAction, useCallback, useRef, useState} from 'react'
+import {SetStateAction, useCallback, useEffect, useRef, useState} from 'react'
 
 /**
  * @beta
@@ -22,6 +22,14 @@ export function useDelayedState<S>(
 
     if (!delay) return action()
     delayedAction.current = setTimeout(action, delay)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (delayedAction.current) {
+        clearTimeout(delayedAction.current)
+      }
+    }
   }, [])
 
   return [state, onStateChange]


### PR DESCRIPTION
### Description

We're seeing random tests fail in the studio unit tests with errors like:

```
ReferenceError: window is not defined
 ❯ resolveUpdatePriority node_modules/.pnpm/react-dom@19.2.4_react@19.2.4/node_modules/react-dom/cjs/react-dom-client.development.js:1308:7
 ❯ requestUpdateLane node_modules/.pnpm/react-dom@19.2.4_react@19.2.4/node_modules/react-dom/cjs/react-dom-client.development.js:16345:11
 ❯ dispatchSetState node_modules/.pnpm/react-dom@19.2.4_react@19.2.4/node_modules/react-dom/cjs/react-dom-client.development.js:9126:14
 ❯ Timeout.action [as _onTimeout] node_modules/.pnpm/@sanity+ui@3.1.13_@emotion+is-prop-valid@1.4.0_@sanity+styled-components@6.1.24_react-d_5a06a13ba0fc77dadcaacef74351e620/node_modules/@sanity/ui/dist/_chunks-es/_visual-editing.mjs:4716:7
 ❯ listOnTimeout node:internal/timers:605:17
 ❯ processTimers node:internal/timers:541:7

This error originated in "packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
```

Line 4716 of the `_visual-editing.mjs` file referenced in the stack trace is inside of `useDelayedState`. I believe what happens is that the test completes, JSDOM is tore down, and then later the timeout fires, leading react to `dispatchSetState` -> `resolveUpdatePriority` which accesses `window` directly.

By cancelling the timeouts on unmount, we avoid this scenario. The hook is only used in Tooltip related components. The pending timer would have been one of:

  - A delayed open (`setIsOpen(true, openDelay)`) - but the component is already gone, so opening it is meaningless.
  - A delayed close (`setIsOpen(false, closeDelay)`) - the component is already unmounted, so it's already "closed".
  - A delayed group state change (`setIsGroupActive`/`setOpenTooltipId`) - the group provider is unmounting, so all tooltips in the group are being torn down too.

So this _should_ be safe.

### What to review

Any consequences I haven't though of?

### Testing

Added a test that failed before this change, but it basically just ensures the timeouts are cleared on unmount.