### PR TITLE
feat: `space`, `columns`, `rows` and box grid item deprecation warnings

### DIFF
--- a/src/core/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/src/core/components/breadcrumbs/breadcrumbs.test.tsx
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Box} from '../../primitives'
+import {Breadcrumbs} from './breadcrumbs'
+
+jest.mock('../../primitives', () => {
+  const actual = jest.requireActual('../../primitives')
+
+  return {
+    ...actual,
+    Box: jest.fn((props: Record<string, unknown>) => (actual.Box as any).render(props, null)),
+  }
+})
+
+function renderBreadcrumbs(props: Partial<React.ComponentProps<typeof Breadcrumbs>> = {}) {
+  return render(
+    <Breadcrumbs {...props}>
+      <span>Root</span>
+      <span>Section</span>
+    </Breadcrumbs>,
+  )
+}
+
+describe('components/breadcrumbs spacing', () => {
+  const mockedBox = jest.mocked(Box)
+
+  beforeEach(() => {
+    mockedBox.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    renderBreadcrumbs({space: 2})
+    expect(mockedBox.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({paddingX: [2]}),
+    )
+
+    renderBreadcrumbs({gap: 2})
+    expect(mockedBox.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({paddingX: [2]}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    renderBreadcrumbs({gap: 3, space: 1})
+    const propsList = mockedBox.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({paddingX: [3]}))
+    expect(propsList).not.toContainEqual(expect.objectContaining({paddingX: [1]}))
+  })
+})

--- a/src/core/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/src/core/components/breadcrumbs/breadcrumbs.test.tsx
@@ -35,6 +35,7 @@ describe('components/breadcrumbs spacing', () => {
       expect.objectContaining({paddingX: [2]}),
     )
 
+    mockedBox.mockClear()
     renderBreadcrumbs({gap: 2})
     expect(mockedBox.mock.calls.map(([props]) => props)).toContainEqual(
       expect.objectContaining({paddingX: [2]}),

--- a/src/core/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/core/components/breadcrumbs/breadcrumbs.tsx
@@ -34,8 +34,8 @@ export const Breadcrumbs = forwardRef(function Breadcrumbs(
   props: BreadcrumbsProps & Omit<React.HTMLProps<HTMLOListElement>, 'as' | 'ref' | 'type'>,
   ref: React.ForwardedRef<HTMLOListElement>,
 ) {
-  const {children, gap, maxLength, separator, space: spaceRaw = 2, ...restProps} = props
-  const space = _getArrayProp(gap === undefined ? spaceRaw : gap)
+  const {children, gap, maxLength, separator, space: deprecated_space = 2, ...restProps} = props
+  const space = _getArrayProp(gap === undefined ? deprecated_space : gap)
   const [open, setOpen] = useState(false)
   const expandElementRef = useRef<HTMLButtonElement | null>(null)
   const popoverElementRef = useRef<HTMLDivElement | null>(null)

--- a/src/core/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/core/components/breadcrumbs/breadcrumbs.tsx
@@ -20,6 +20,10 @@ import {ExpandButton, StyledBreadcrumbs} from './breadcrumbs.styles'
 export interface BreadcrumbsProps {
   maxLength?: number
   separator?: React.ReactNode
+  gap?: number | number[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
 }
 
@@ -30,8 +34,8 @@ export const Breadcrumbs = forwardRef(function Breadcrumbs(
   props: BreadcrumbsProps & Omit<React.HTMLProps<HTMLOListElement>, 'as' | 'ref' | 'type'>,
   ref: React.ForwardedRef<HTMLOListElement>,
 ) {
-  const {children, maxLength, separator, space: spaceRaw = 2, ...restProps} = props
-  const space = _getArrayProp(spaceRaw)
+  const {children, gap, maxLength, separator, space: spaceRaw = 2, ...restProps} = props
+  const space = _getArrayProp(gap === undefined ? spaceRaw : gap)
   const [open, setOpen] = useState(false)
   const expandElementRef = useRef<HTMLButtonElement | null>(null)
   const popoverElementRef = useRef<HTMLDivElement | null>(null)
@@ -101,7 +105,7 @@ function useItems({
       <Popover
         constrainSize
         content={
-          <Stack as="ol" overflow="auto" padding={space} space={space}>
+          <Stack as="ol" overflow="auto" padding={space} gap={space}>
             {rawItems.slice(beforeLength - 1, len - afterLength)}
           </Stack>
         }

--- a/src/core/components/hotkeys/hotkeys.test.tsx
+++ b/src/core/components/hotkeys/hotkeys.test.tsx
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Inline} from '../../primitives'
+import {Hotkeys} from './hotkeys'
+
+jest.mock('../../primitives', () => {
+  const actual = jest.requireActual('../../primitives')
+
+  return {
+    ...actual,
+    Inline: jest.fn((props: Record<string, unknown>) => (actual.Inline as any).render(props, null)),
+  }
+})
+
+describe('components/hotkeys spacing', () => {
+  const mockedInline = jest.mocked(Inline)
+
+  beforeEach(() => {
+    mockedInline.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    render(<Hotkeys keys={['Ctrl', 'S']} space={2} />)
+    expect(mockedInline.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: [2]}),
+    )
+
+    render(<Hotkeys gap={2} keys={['Ctrl', 'S']} />)
+    expect(mockedInline.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: [2]}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    render(<Hotkeys gap={3} keys={['Ctrl', 'S']} space={1} />)
+    const propsList = mockedInline.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({gap: [3]}))
+    expect(propsList).not.toContainEqual(expect.objectContaining({gap: [1]}))
+  })
+})

--- a/src/core/components/hotkeys/hotkeys.test.tsx
+++ b/src/core/components/hotkeys/hotkeys.test.tsx
@@ -26,6 +26,7 @@ describe('components/hotkeys spacing', () => {
       expect.objectContaining({gap: [2]}),
     )
 
+    mockedInline.mockClear()
     render(<Hotkeys gap={2} keys={['Ctrl', 'S']} />)
     expect(mockedInline.mock.calls.map(([props]) => props)).toContainEqual(
       expect.objectContaining({gap: [2]}),

--- a/src/core/components/hotkeys/hotkeys.tsx
+++ b/src/core/components/hotkeys/hotkeys.tsx
@@ -44,8 +44,8 @@ export const Hotkeys = forwardRef(function Hotkeys(
   props: HotkeysProps & Omit<React.HTMLProps<HTMLElement>, 'as' | 'ref' | 'size'>,
   ref: React.Ref<HTMLElement>,
 ) {
-  const {fontSize, gap, keys, padding, radius, space: spaceProp = 0.5, ...restProps} = props
-  const spacing = _getArrayProp(gap === undefined ? spaceProp : gap)
+  const {fontSize, gap, keys, padding, radius, space: deprecated_space = 0.5, ...restProps} = props
+  const spacing = _getArrayProp(gap === undefined ? deprecated_space : gap)
 
   if (!keys || keys.length === 0) {
     return <></>

--- a/src/core/components/hotkeys/hotkeys.tsx
+++ b/src/core/components/hotkeys/hotkeys.tsx
@@ -10,8 +10,12 @@ import {Radius} from '../../types'
  */
 export interface HotkeysProps {
   fontSize?: number | number[]
+  gap?: number | number[]
   padding?: number | number[]
   radius?: Radius | Radius[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
   keys?: string[]
 }
@@ -40,8 +44,8 @@ export const Hotkeys = forwardRef(function Hotkeys(
   props: HotkeysProps & Omit<React.HTMLProps<HTMLElement>, 'as' | 'ref' | 'size'>,
   ref: React.Ref<HTMLElement>,
 ) {
-  const {fontSize, keys, padding, radius, space: spaceProp = 0.5, ...restProps} = props
-  const space = _getArrayProp(spaceProp)
+  const {fontSize, gap, keys, padding, radius, space: spaceProp = 0.5, ...restProps} = props
+  const spacing = _getArrayProp(gap === undefined ? spaceProp : gap)
 
   if (!keys || keys.length === 0) {
     return <></>
@@ -49,7 +53,7 @@ export const Hotkeys = forwardRef(function Hotkeys(
 
   return (
     <StyledHotkeys data-ui="Hotkeys" {...restProps} ref={ref}>
-      <Inline as="span" space={space}>
+      <Inline as="span" gap={spacing}>
         {keys.map((key, i) => (
           <Key fontSize={fontSize} key={i} padding={padding} radius={radius}>
             {key}

--- a/src/core/components/menu/menu.spacing.test.tsx
+++ b/src/core/components/menu/menu.spacing.test.tsx
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Stack} from '../../primitives'
+import {Menu} from './menu'
+
+jest.mock('../../primitives', () => {
+  const actual = jest.requireActual('../../primitives')
+
+  return {
+    ...actual,
+    Stack: jest.fn((props: Record<string, unknown>) => (actual.Stack as any).render(props, null)),
+  }
+})
+
+jest.mock('../../utils', () => {
+  const actual = jest.requireActual('../../utils')
+
+  return {
+    ...actual,
+    useLayer: () => ({isTopLayer: true}),
+  }
+})
+
+describe('components/menu spacing', () => {
+  const mockedStack = jest.mocked(Stack)
+
+  beforeEach(() => {
+    mockedStack.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    render(
+      <Menu space={2}>
+        <div>Item</div>
+      </Menu>,
+    )
+    expect(mockedStack.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: 2}),
+    )
+
+    render(
+      <Menu gap={2}>
+        <div>Item</div>
+      </Menu>,
+    )
+    expect(mockedStack.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: 2}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    render(
+      <Menu gap={3} space={1}>
+        <div>Item</div>
+      </Menu>,
+    )
+    const propsList = mockedStack.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({gap: 3}))
+    expect(propsList).not.toContainEqual(expect.objectContaining({gap: 1}))
+  })
+})

--- a/src/core/components/menu/menu.spacing.test.tsx
+++ b/src/core/components/menu/menu.spacing.test.tsx
@@ -39,6 +39,7 @@ describe('components/menu spacing', () => {
       expect.objectContaining({gap: 2}),
     )
 
+    mockedStack.mockClear()
     render(
       <Menu gap={2}>
         <div>Item</div>

--- a/src/core/components/menu/menu.tsx
+++ b/src/core/components/menu/menu.tsx
@@ -66,10 +66,10 @@ export const Menu = forwardRef(function Menu(
     registerElement,
     shouldFocus: _shouldFocus,
     gap,
-    space = 1,
+    space: deprecated_space = 1,
     ...restProps
   } = props
-  const spacing = gap === undefined ? space : gap
+  const spacing = gap === undefined ? deprecated_space : gap
   const shouldFocus =
     _shouldFocus ?? ((props.focusFirst && 'first') || (props.focusLast && 'last') || null)
 

--- a/src/core/components/menu/menu.tsx
+++ b/src/core/components/menu/menu.tsx
@@ -27,6 +27,10 @@ export interface MenuProps extends ResponsivePaddingProps {
   'originElement'?: HTMLElement | null
   'registerElement'?: (el: HTMLElement) => () => void
   'shouldFocus'?: 'first' | 'last' | null
+  'gap'?: number | number[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   'space'?: number | number[]
   'aria-labelledby'?: string
   'onBlurCapture'?: (event: FocusEvent) => void
@@ -61,9 +65,11 @@ export const Menu = forwardRef(function Menu(
     padding = 1,
     registerElement,
     shouldFocus: _shouldFocus,
+    gap,
     space = 1,
     ...restProps
   } = props
+  const spacing = gap === undefined ? space : gap
   const shouldFocus =
     _shouldFocus ?? ((props.focusFirst && 'first') || (props.focusLast && 'last') || null)
 
@@ -164,7 +170,7 @@ export const Menu = forwardRef(function Menu(
         role="menu"
         tabIndex={-1}
       >
-        <Stack space={space}>{children}</Stack>
+        <Stack gap={spacing}>{children}</Stack>
       </StyledMenu>
     </MenuContext.Provider>
   )

--- a/src/core/components/menu/menuGroup.spacing.test.tsx
+++ b/src/core/components/menu/menuGroup.spacing.test.tsx
@@ -1,0 +1,68 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Flex} from '../../primitives'
+import {MenuContext, MenuContextValue} from './menuContext'
+import {MenuGroup} from './menuGroup'
+import {MenuItem} from './menuItem'
+
+jest.mock('../../primitives', () => {
+  const actual = jest.requireActual('../../primitives')
+
+  return {
+    ...actual,
+    Flex: jest.fn((props: Record<string, unknown>) => (actual.Flex as any).render(props, null)),
+    Popover: jest.fn(
+      ({
+        children,
+      }: {
+        children?: React.ReactNode
+      }) => children,
+    ),
+  }
+})
+
+const menuContextValue: MenuContextValue = {
+  version: 2,
+  activeElement: null,
+  mount: () => () => undefined,
+  onItemMouseEnter: () => undefined,
+  onItemMouseLeave: () => undefined,
+}
+
+function renderMenuGroup(props: Partial<React.ComponentProps<typeof MenuGroup>> = {}) {
+  return render(
+    <MenuContext.Provider value={menuContextValue}>
+      <MenuGroup id="menu-group" text="Menu group" {...props}>
+        <MenuItem id="submenu-item" text="Submenu item" />
+      </MenuGroup>
+    </MenuContext.Provider>,
+  )
+}
+
+describe('components/menuGroup spacing', () => {
+  const mockedFlex = jest.mocked(Flex)
+
+  beforeEach(() => {
+    mockedFlex.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    renderMenuGroup({space: 2})
+    expect(mockedFlex.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: 2}),
+    )
+
+    renderMenuGroup({gap: 2})
+    expect(mockedFlex.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: 2}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    renderMenuGroup({gap: 3, space: 1})
+    const propsList = mockedFlex.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({gap: 3}))
+    expect(propsList).not.toContainEqual(expect.objectContaining({gap: 1}))
+  })
+})

--- a/src/core/components/menu/menuGroup.spacing.test.tsx
+++ b/src/core/components/menu/menuGroup.spacing.test.tsx
@@ -53,6 +53,7 @@ describe('components/menuGroup spacing', () => {
       expect.objectContaining({gap: 2}),
     )
 
+    mockedFlex.mockClear()
     renderMenuGroup({gap: 2})
     expect(mockedFlex.mock.calls.map(([props]) => props)).toContainEqual(
       expect.objectContaining({gap: 2}),

--- a/src/core/components/menu/menuGroup.tsx
+++ b/src/core/components/menu/menuGroup.tsx
@@ -31,6 +31,10 @@ export interface MenuGroupProps {
   padding?: number | number[]
   popover?: Omit<PopoverProps, 'content' | 'open'>
   radius?: Radius | Radius[]
+  gap?: number | number[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
   text: React.ReactNode
   tone?: SelectableTone
@@ -53,11 +57,13 @@ export function MenuGroup(
     padding = 3,
     popover,
     radius = 2,
+    gap,
     space = 3,
     text,
     tone = 'default',
     ...restProps
   } = props
+  const spacing = gap === undefined ? space : gap
   const menu = useMenu()
   const {scheme} = useRootTheme()
   const {
@@ -193,7 +199,7 @@ export function MenuGroup(
         tabIndex={-1}
         type={as === 'button' ? 'button' : undefined}
       >
-        <Flex gap={space} padding={padding}>
+        <Flex gap={spacing} padding={padding}>
           {IconComponent && (
             <Text size={fontSize}>
               {isValidElement(IconComponent) && IconComponent}

--- a/src/core/components/menu/menuGroup.tsx
+++ b/src/core/components/menu/menuGroup.tsx
@@ -58,12 +58,12 @@ export function MenuGroup(
     popover,
     radius = 2,
     gap,
-    space = 3,
+    space: deprecated_space = 3,
     text,
     tone = 'default',
     ...restProps
   } = props
-  const spacing = gap === undefined ? space : gap
+  const spacing = gap === undefined ? deprecated_space : gap
   const menu = useMenu()
   const {scheme} = useRootTheme()
   const {

--- a/src/core/components/menu/menuItem.spacing.test.tsx
+++ b/src/core/components/menu/menuItem.spacing.test.tsx
@@ -43,6 +43,7 @@ describe('components/menuItem spacing', () => {
       expect.objectContaining({gap: 2}),
     )
 
+    mockedFlex.mockClear()
     renderMenuItem({gap: 2})
     expect(mockedFlex.mock.calls.map(([props]) => props)).toContainEqual(
       expect.objectContaining({gap: 2}),

--- a/src/core/components/menu/menuItem.spacing.test.tsx
+++ b/src/core/components/menu/menuItem.spacing.test.tsx
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Flex} from '../../primitives'
+import {MenuContext, MenuContextValue} from './menuContext'
+import {MenuItem} from './menuItem'
+
+jest.mock('../../primitives', () => {
+  const actual = jest.requireActual('../../primitives')
+
+  return {
+    ...actual,
+    Flex: jest.fn((props: Record<string, unknown>) => (actual.Flex as any).render(props, null)),
+  }
+})
+
+const menuContextValue: MenuContextValue = {
+  version: 2,
+  activeElement: null,
+  mount: () => () => undefined,
+  onItemMouseEnter: () => undefined,
+  onItemMouseLeave: () => undefined,
+}
+
+function renderMenuItem(props: Partial<React.ComponentProps<typeof MenuItem>> = {}) {
+  return render(
+    <MenuContext.Provider value={menuContextValue}>
+      <MenuItem id="menu-item" text="Menu item" {...props} />
+    </MenuContext.Provider>,
+  )
+}
+
+describe('components/menuItem spacing', () => {
+  const mockedFlex = jest.mocked(Flex)
+
+  beforeEach(() => {
+    mockedFlex.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    renderMenuItem({space: 2})
+    expect(mockedFlex.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: 2}),
+    )
+
+    renderMenuItem({gap: 2})
+    expect(mockedFlex.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: 2}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    renderMenuItem({gap: 3, space: 1})
+    const propsList = mockedFlex.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({gap: 3}))
+    expect(propsList).not.toContainEqual(expect.objectContaining({gap: 1}))
+  })
+})

--- a/src/core/components/menu/menuItem.tsx
+++ b/src/core/components/menu/menuItem.tsx
@@ -67,12 +67,12 @@ export const MenuItem = forwardRef(function MenuItem(
     radius = 2,
     selected: selectedProp,
     gap,
-    space = 3,
+    space: deprecated_space = 3,
     text,
     tone = 'default',
     ...restProps
   } = props
-  const spacing = gap === undefined ? space : gap
+  const spacing = gap === undefined ? deprecated_space : gap
   const {scheme} = useRootTheme()
   const menu = useMenu()
   const {

--- a/src/core/components/menu/menuItem.tsx
+++ b/src/core/components/menu/menuItem.tsx
@@ -30,6 +30,10 @@ export interface MenuItemProps extends ResponsivePaddingProps, ResponsiveRadiusP
   iconRight?: React.ElementType | React.ReactNode
   pressed?: boolean
   selected?: boolean
+  gap?: number | number[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
   text?: React.ReactNode
   tone?: SelectableTone
@@ -62,11 +66,13 @@ export const MenuItem = forwardRef(function MenuItem(
     pressed,
     radius = 2,
     selected: selectedProp,
+    gap,
     space = 3,
     text,
     tone = 'default',
     ...restProps
   } = props
+  const spacing = gap === undefined ? space : gap
   const {scheme} = useRootTheme()
   const menu = useMenu()
   const {
@@ -137,7 +143,7 @@ export const MenuItem = forwardRef(function MenuItem(
       type={as === 'button' ? 'button' : undefined}
     >
       {(IconComponent || text || IconRightComponent) && (
-        <Flex as="span" gap={space} align="center" {...paddingProps}>
+        <Flex as="span" gap={spacing} align="center" {...paddingProps}>
           {IconComponent && (
             <Text size={fontSize}>
               {isValidElement(IconComponent) && IconComponent}

--- a/src/core/components/tab/tabList.test.tsx
+++ b/src/core/components/tab/tabList.test.tsx
@@ -29,7 +29,6 @@ describe('components/tabList', () => {
         <Tab aria-controls="tab-panel-a" id="tab-a" label="Tab A" />
         <Tab aria-controls="tab-panel-b" id="tab-b" label="Tab B" />
       </TabList>,
-      {strict: false},
     )
   }
 

--- a/src/core/components/tab/tabList.test.tsx
+++ b/src/core/components/tab/tabList.test.tsx
@@ -1,0 +1,48 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {inlineSpaceStyle} from '../../primitives/inline/styles'
+import {Tab} from './tab'
+import {TabList} from './tabList'
+
+jest.mock('../../primitives/inline/styles', () => {
+  const actual = jest.requireActual('../../primitives/inline/styles')
+
+  return {
+    ...actual,
+    inlineSpaceStyle: jest.fn(actual.inlineSpaceStyle),
+  }
+})
+
+describe('components/tabList', () => {
+  const mockedInlineSpaceStyle = jest.mocked(inlineSpaceStyle)
+
+  beforeEach(() => {
+    mockedInlineSpaceStyle.mockClear()
+  })
+
+  function renderTabList(
+    props: Partial<React.ComponentProps<typeof TabList>> = {},
+  ): ReturnType<typeof render> {
+    return render(
+      <TabList {...props}>
+        <Tab aria-controls="tab-panel-a" id="tab-a" label="Tab A" />
+        <Tab aria-controls="tab-panel-b" id="tab-b" label="Tab B" />
+      </TabList>,
+      {strict: false},
+    )
+  }
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    renderTabList({space: 2})
+    expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
+
+    renderTabList({gap: 2})
+    expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    renderTabList({gap: 3, space: 1})
+    expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [3]}))
+  })
+})

--- a/src/core/components/tab/tabList.test.tsx
+++ b/src/core/components/tab/tabList.test.tsx
@@ -36,6 +36,7 @@ describe('components/tabList', () => {
     renderTabList({space: 2})
     expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
 
+    mockedInlineSpaceStyle.mockClear()
     renderTabList({gap: 2})
     expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
   })

--- a/src/core/components/tab/tabList.tsx
+++ b/src/core/components/tab/tabList.tsx
@@ -4,10 +4,6 @@ import {styled} from 'styled-components'
 import {Inline, InlineProps} from '../../primitives'
 
 /**
- * Inherits layout spacing props from `InlineProps`:
- * - `gap` (preferred)
- * - `space` (deprecated, will be removed in v4)
- *
  * @public
  */
 export interface TabListProps extends Omit<InlineProps, 'as' | 'height'> {

--- a/src/core/components/tab/tabList.tsx
+++ b/src/core/components/tab/tabList.tsx
@@ -4,6 +4,10 @@ import {styled} from 'styled-components'
 import {Inline, InlineProps} from '../../primitives'
 
 /**
+ * Inherits layout spacing props from `InlineProps`:
+ * - `gap` (preferred)
+ * - `space` (deprecated, will be removed in v4)
+ *
  * @public
  */
 export interface TabListProps extends Omit<InlineProps, 'as' | 'height'> {

--- a/src/core/components/tree/tree.test.tsx
+++ b/src/core/components/tree/tree.test.tsx
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Stack} from '../../primitives'
+import {Tree} from './tree'
+import {TreeItem} from './treeItem'
+
+jest.mock('../../primitives', () => {
+  const actual = jest.requireActual('../../primitives')
+
+  return {
+    ...actual,
+    Stack: jest.fn((props: Record<string, unknown>) => (actual.Stack as any).render(props, null)),
+  }
+})
+
+describe('components/tree spacing', () => {
+  const mockedStack = jest.mocked(Stack)
+
+  beforeEach(() => {
+    mockedStack.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    render(
+      <Tree space={2}>
+        <TreeItem text="Item 1" />
+      </Tree>,
+    )
+    expect(mockedStack.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: 2}),
+    )
+
+    render(
+      <Tree gap={2}>
+        <TreeItem text="Item 1" />
+      </Tree>,
+    )
+    expect(mockedStack.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({gap: 2}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    render(
+      <Tree gap={3} space={1}>
+        <TreeItem text="Item 1" />
+      </Tree>,
+    )
+    const propsList = mockedStack.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({gap: 3}))
+    expect(propsList).not.toContainEqual(expect.objectContaining({gap: 1}))
+  })
+})

--- a/src/core/components/tree/tree.test.tsx
+++ b/src/core/components/tree/tree.test.tsx
@@ -31,6 +31,7 @@ describe('components/tree spacing', () => {
       expect.objectContaining({gap: 2}),
     )
 
+    mockedStack.mockClear()
     render(
       <Tree gap={2}>
         <TreeItem text="Item 1" />

--- a/src/core/components/tree/tree.tsx
+++ b/src/core/components/tree/tree.tsx
@@ -18,6 +18,10 @@ import {TreeContextValue, TreeState} from './types'
  * @beta
  */
 export interface TreeProps {
+  gap?: number | number[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
 }
 
@@ -30,7 +34,8 @@ export const Tree = forwardRef(function Tree(
     Omit<React.HTMLProps<HTMLDivElement>, 'align' | 'as' | 'height' | 'ref' | 'role' | 'wrap'>,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ): React.JSX.Element {
-  const {children, space = 1, onFocus, ...restProps} = props
+  const {children, gap, space = 1, onFocus, ...restProps} = props
+  const spacing = gap === undefined ? space : gap
   const ref = useRef<HTMLDivElement | null>(null)
   const [focusedElement, setFocusedElement] = useState<HTMLElement | null>(null)
   const focusedElementRef = useRef(focusedElement)
@@ -89,10 +94,11 @@ export const Tree = forwardRef(function Tree(
       registerItem,
       setExpanded,
       setFocusedElement,
-      space,
+      gap: spacing,
+      space: spacing,
       state,
     }),
-    [focusedElement, itemElements, path, registerItem, setExpanded, space, state],
+    [focusedElement, itemElements, path, registerItem, setExpanded, spacing, state],
   )
 
   const handleKeyDown = useCallback(
@@ -221,7 +227,7 @@ export const Tree = forwardRef(function Tree(
         onKeyDown={handleKeyDown}
         ref={ref}
         role="tree"
-        space={space}
+        gap={spacing}
       >
         {children}
       </Stack>

--- a/src/core/components/tree/tree.tsx
+++ b/src/core/components/tree/tree.tsx
@@ -34,8 +34,8 @@ export const Tree = forwardRef(function Tree(
     Omit<React.HTMLProps<HTMLDivElement>, 'align' | 'as' | 'height' | 'ref' | 'role' | 'wrap'>,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ): React.JSX.Element {
-  const {children, gap, space = 1, onFocus, ...restProps} = props
-  const spacing = gap === undefined ? space : gap
+  const {children, gap, space: deprecated_space = 1, onFocus, ...restProps} = props
+  const spacing = gap === undefined ? deprecated_space : gap
   const ref = useRef<HTMLDivElement | null>(null)
   const [focusedElement, setFocusedElement] = useState<HTMLElement | null>(null)
   const focusedElementRef = useRef(focusedElement)

--- a/src/core/components/tree/treeGroup.tsx
+++ b/src/core/components/tree/treeGroup.tsx
@@ -18,9 +18,9 @@ export function TreeGroup(
       data-ui="TreeGroup"
       {...restProps}
       hidden={!expanded}
-      marginTop={tree.space}
+      marginTop={tree.gap}
       role="group"
-      space={tree.space}
+      gap={tree.gap}
     >
       {children}
     </Stack>

--- a/src/core/components/tree/treeItem.test.tsx
+++ b/src/core/components/tree/treeItem.test.tsx
@@ -3,8 +3,8 @@
 import {render} from '../../../../test'
 import {Box} from '../../primitives'
 import {TreeContext} from './treeContext'
-import {TreeContextValue, TreeState} from './types'
 import {TreeItem} from './treeItem'
+import {TreeContextValue, TreeState} from './types'
 
 jest.mock('../../primitives', () => {
   const actual = jest.requireActual('../../primitives')

--- a/src/core/components/tree/treeItem.test.tsx
+++ b/src/core/components/tree/treeItem.test.tsx
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Box} from '../../primitives'
+import {TreeContext} from './treeContext'
+import {TreeContextValue, TreeState} from './types'
+import {TreeItem} from './treeItem'
+
+jest.mock('../../primitives', () => {
+  const actual = jest.requireActual('../../primitives')
+
+  return {
+    ...actual,
+    Box: jest.fn((props: Record<string, unknown>) => (actual.Box as any).render(props, null)),
+  }
+})
+
+const treeContextValue: TreeContextValue = {
+  version: 0.0,
+  focusedElement: null,
+  gap: 1,
+  level: 0,
+  path: [],
+  registerItem: () => () => undefined,
+  setExpanded: () => undefined,
+  setFocusedElement: () => undefined,
+  space: 1,
+  state: {} as TreeState,
+}
+
+function renderTreeItem(props: Partial<React.ComponentProps<typeof TreeItem>> = {}) {
+  return render(
+    <TreeContext.Provider value={treeContextValue}>
+      <TreeItem text="Item" {...props} />
+    </TreeContext.Provider>,
+  )
+}
+
+describe('components/treeItem spacing', () => {
+  const mockedBox = jest.mocked(Box)
+
+  beforeEach(() => {
+    mockedBox.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    renderTreeItem({space: 2})
+    expect(mockedBox.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({marginRight: 2}),
+    )
+
+    renderTreeItem({gap: 2})
+    expect(mockedBox.mock.calls.map(([props]) => props)).toContainEqual(
+      expect.objectContaining({marginRight: 2}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    renderTreeItem({gap: 3, space: 1})
+    const propsList = mockedBox.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({marginRight: 3}))
+    expect(propsList).not.toContainEqual(expect.objectContaining({marginRight: 1}))
+  })
+})

--- a/src/core/components/tree/treeItem.test.tsx
+++ b/src/core/components/tree/treeItem.test.tsx
@@ -49,6 +49,7 @@ describe('components/treeItem spacing', () => {
       expect.objectContaining({marginRight: 2}),
     )
 
+    mockedBox.mockClear()
     renderTreeItem({gap: 2})
     expect(mockedBox.mock.calls.map(([props]) => props)).toContainEqual(
       expect.objectContaining({marginRight: 2}),

--- a/src/core/components/tree/treeItem.tsx
+++ b/src/core/components/tree/treeItem.tsx
@@ -26,6 +26,10 @@ export interface TreeItemProps {
    */
   linkAs?: BoxProps['as']
   padding?: number | number[]
+  gap?: number | number[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
   text?: React.ReactNode
   weight?: ThemeFontWeightKey
@@ -60,11 +64,13 @@ export function TreeItem(
     onClick,
     padding = 2,
     selected = false,
+    gap,
     space = 2,
     text,
     weight,
     ...restProps
   } = props
+  const spacing = gap === undefined ? space : gap
   const [rootElement, _setRootElement] = useState<HTMLLIElement | null>(null)
   /**
    * The startTransition wrapper here is to avoid an issue when on React 18 where this error can happen:
@@ -133,7 +139,7 @@ export function TreeItem(
   const content = (
     <Flex padding={padding}>
       <Box
-        marginRight={space}
+        marginRight={spacing}
         style={{
           visibility: IconComponent || children ? 'visible' : 'hidden',
           pointerEvents: 'none',

--- a/src/core/components/tree/treeItem.tsx
+++ b/src/core/components/tree/treeItem.tsx
@@ -65,12 +65,12 @@ export function TreeItem(
     padding = 2,
     selected = false,
     gap,
-    space = 2,
+    space: deprecated_space = 2,
     text,
     weight,
     ...restProps
   } = props
-  const spacing = gap === undefined ? space : gap
+  const spacing = gap === undefined ? deprecated_space : gap
   const [rootElement, _setRootElement] = useState<HTMLLIElement | null>(null)
   /**
    * The startTransition wrapper here is to avoid an issue when on React 18 where this error can happen:

--- a/src/core/components/tree/types.ts
+++ b/src/core/components/tree/types.ts
@@ -16,6 +16,10 @@ export interface TreeContextValue {
   registerItem: (element: HTMLElement, path: string, expanded: boolean, selected: boolean) => void
   setExpanded: (path: string, expanded: boolean) => void
   setFocusedElement: (focusedElement: HTMLElement | null) => void
+  gap: number | number[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space: number | number[]
   state: TreeState
 }

--- a/src/core/primitives/box/box.test.tsx
+++ b/src/core/primitives/box/box.test.tsx
@@ -1,0 +1,134 @@
+/** @jest-environment jsdom */
+
+import {type ComponentProps} from 'react'
+
+import {render} from '../../../../test'
+import {responsiveGridItemStyle} from '../../styles/internal'
+import {Box} from './box'
+
+jest.mock('../../styles/internal', () => {
+  const actual = jest.requireActual('../../styles/internal')
+
+  return {
+    ...actual,
+    responsiveGridItemStyle: jest.fn(actual.responsiveGridItemStyle),
+  }
+})
+
+describe('<Box />', () => {
+  const mockedResponsiveGridItemStyle = jest.mocked(responsiveGridItemStyle)
+
+  beforeEach(() => {
+    mockedResponsiveGridItemStyle.mockClear()
+  })
+
+  it('uses column when gridColumn is not provided', () => {
+    render(<Box column={3} />)
+
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$column: [3]}))
+  })
+
+  it('uses gridColumn when provided', () => {
+    render(<Box gridColumn={4} />)
+
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$column: [4]}))
+  })
+
+  it('prefers gridColumn over column when both are provided', () => {
+    render(<Box column={3} gridColumn={5} />)
+
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$column: [5]}))
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(expect.objectContaining({$column: [3]}))
+  })
+
+  it('supports responsive arrays with gridColumn', () => {
+    const gridColumn: ComponentProps<typeof Box>['gridColumn'] = [2, 'full']
+
+    render(<Box gridColumn={gridColumn} />)
+
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$column: [2, 'full']}),
+    )
+  })
+
+  it('uses columnStart when gridColumnStart is not provided', () => {
+    render(<Box columnStart={2} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$columnStart: [2]}),
+    )
+  })
+
+  it('prefers gridColumnStart over columnStart when both are provided', () => {
+    render(<Box columnStart={2} gridColumnStart={4} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$columnStart: [4]}),
+    )
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$columnStart: [2]}),
+    )
+  })
+
+  it('uses columnEnd when gridColumnEnd is not provided', () => {
+    render(<Box columnEnd={3} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$columnEnd: [3]}),
+    )
+  })
+
+  it('prefers gridColumnEnd over columnEnd when both are provided', () => {
+    render(<Box columnEnd={3} gridColumnEnd={5} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$columnEnd: [5]}),
+    )
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$columnEnd: [3]}),
+    )
+  })
+
+  it('uses row when gridRow is not provided', () => {
+    render(<Box row={1} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$row: [1]}))
+  })
+
+  it('prefers gridRow over row when both are provided', () => {
+    render(<Box row={1} gridRow={2} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$row: [2]}))
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$row: [1]}),
+    )
+  })
+
+  it('uses rowStart when gridRowStart is not provided', () => {
+    render(<Box rowStart={2} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$rowStart: [2]}),
+    )
+  })
+
+  it('prefers gridRowStart over rowStart when both are provided', () => {
+    render(<Box rowStart={2} gridRowStart={4} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$rowStart: [4]}),
+    )
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$rowStart: [2]}),
+    )
+  })
+
+  it('uses rowEnd when gridRowEnd is not provided', () => {
+    render(<Box rowEnd={3} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$rowEnd: [3]}),
+    )
+  })
+
+  it('prefers gridRowEnd over rowEnd when both are provided', () => {
+    render(<Box rowEnd={3} gridRowEnd={5} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$rowEnd: [5]}),
+    )
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$rowEnd: [3]}),
+    )
+  })
+})

--- a/src/core/primitives/box/box.tsx
+++ b/src/core/primitives/box/box.tsx
@@ -63,9 +63,12 @@ export const Box = forwardRef(function Box(
 ) {
   const {
     as: asProp = 'div',
-    column,
-    columnStart,
-    columnEnd,
+    gridColumn,
+    column: deprecated_column,
+    gridColumnStart,
+    columnStart: deprecated_columnStart,
+    gridColumnEnd,
+    columnEnd: deprecated_columnEnd,
     display = 'block',
     flex,
     height,
@@ -84,12 +87,21 @@ export const Box = forwardRef(function Box(
     paddingRight,
     paddingBottom,
     paddingLeft,
-    row,
-    rowStart,
-    rowEnd,
+    gridRow,
+    row: deprecated_row,
+    gridRowStart,
+    rowStart: deprecated_rowStart,
+    gridRowEnd,
+    rowEnd: deprecated_rowEnd,
     sizing,
     ...restProps
   } = props
+  const column = gridColumn === undefined ? deprecated_column : gridColumn
+  const columnStart = gridColumnStart === undefined ? deprecated_columnStart : gridColumnStart
+  const columnEnd = gridColumnEnd === undefined ? deprecated_columnEnd : gridColumnEnd
+  const row = gridRow === undefined ? deprecated_row : gridRow
+  const rowStart = gridRowStart === undefined ? deprecated_rowStart : gridRowStart
+  const rowEnd = gridRowEnd === undefined ? deprecated_rowEnd : gridRowEnd
 
   return (
     <StyledBox

--- a/src/core/primitives/button/button.test.tsx
+++ b/src/core/primitives/button/button.test.tsx
@@ -5,9 +5,25 @@ import {screen} from '@testing-library/react'
 import {axe} from 'jest-axe'
 
 import {render} from '../../../../test'
+import {Flex} from '../flex'
 import {Button, ButtonProps} from './button'
 
+jest.mock('../flex', () => {
+  const actual = jest.requireActual('../flex')
+
+  return {
+    ...actual,
+    Flex: jest.fn((props: Record<string, unknown>) => (actual.Flex as any).render(props, null)),
+  }
+})
+
 describe('atoms/button', () => {
+  const mockedFlex = jest.mocked(Flex)
+
+  beforeEach(() => {
+    mockedFlex.mockClear()
+  })
+
   it('Axe: should have no violations', async () => {
     const lightResult = render(<Button icon={AddIcon} text="Label" tone="positive" />, {
       scheme: 'light',
@@ -40,5 +56,27 @@ describe('atoms/button', () => {
     render(<WrappedButton button={buttonProps} />)
 
     expect(screen.getByText('Button text')).toBeInTheDocument()
+  })
+
+  it('should support `space`', () => {
+    render(<Button icon={AddIcon} space={17} text="Button text" />, {strict: false})
+
+    const propsList = mockedFlex.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({gap: [17]}))
+  })
+
+  it('should support `gap`', () => {
+    render(<Button gap={18} icon={AddIcon} text="Button text" />, {strict: false})
+
+    const propsList = mockedFlex.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({gap: [18]}))
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    render(<Button gap={19} icon={AddIcon} space={20} text="Button text" />, {strict: false})
+
+    const propsList = mockedFlex.mock.calls.map(([props]) => props)
+    expect(propsList).toContainEqual(expect.objectContaining({gap: [19]}))
+    expect(propsList).not.toContainEqual(expect.objectContaining({gap: [20]}))
   })
 })

--- a/src/core/primitives/button/button.test.tsx
+++ b/src/core/primitives/button/button.test.tsx
@@ -59,21 +59,21 @@ describe('atoms/button', () => {
   })
 
   it('should support `space`', () => {
-    render(<Button icon={AddIcon} space={17} text="Button text" />, {strict: false})
+    render(<Button icon={AddIcon} space={17} text="Button text" />)
 
     const propsList = mockedFlex.mock.calls.map(([props]) => props)
     expect(propsList).toContainEqual(expect.objectContaining({gap: [17]}))
   })
 
   it('should support `gap`', () => {
-    render(<Button gap={18} icon={AddIcon} text="Button text" />, {strict: false})
+    render(<Button gap={18} icon={AddIcon} text="Button text" />)
 
     const propsList = mockedFlex.mock.calls.map(([props]) => props)
     expect(propsList).toContainEqual(expect.objectContaining({gap: [18]}))
   })
 
   it('should prefer `gap` over `space` when both are provided', () => {
-    render(<Button gap={19} icon={AddIcon} space={20} text="Button text" />, {strict: false})
+    render(<Button gap={19} icon={AddIcon} space={20} text="Button text" />)
 
     const propsList = mockedFlex.mock.calls.map(([props]) => props)
     expect(propsList).toContainEqual(expect.objectContaining({gap: [19]}))

--- a/src/core/primitives/button/button.tsx
+++ b/src/core/primitives/button/button.tsx
@@ -89,7 +89,7 @@ export const Button = forwardRef(function Button(
     radius: radiusProp = 2,
     selected,
     gap,
-    space: spaceProp = 3,
+    space: deprecated_space = 3,
     text,
     textAlign,
     textWeight,
@@ -110,7 +110,7 @@ export const Button = forwardRef(function Button(
   const paddingLeft = _getArrayProp(paddingLeftProp)
   const paddingRight = _getArrayProp(paddingRightProp)
   const radius = _getArrayProp(radiusProp)
-  const spacing = _getArrayProp(gap === undefined ? spaceProp : gap)
+  const spacing = _getArrayProp(gap === undefined ? deprecated_space : gap)
 
   const boxProps = useMemo(
     () => ({

--- a/src/core/primitives/button/button.tsx
+++ b/src/core/primitives/button/button.tsx
@@ -29,7 +29,11 @@ export interface ButtonProps extends ResponsivePaddingProps, ResponsiveRadiusPro
    */
   loading?: boolean
   selected?: boolean
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
+  gap?: number | number[]
   muted?: boolean
   text?: React.ReactNode
   textAlign?: ButtonTextAlign
@@ -84,6 +88,7 @@ export const Button = forwardRef(function Button(
     paddingRight: paddingRightProp,
     radius: radiusProp = 2,
     selected,
+    gap,
     space: spaceProp = 3,
     text,
     textAlign,
@@ -105,7 +110,7 @@ export const Button = forwardRef(function Button(
   const paddingLeft = _getArrayProp(paddingLeftProp)
   const paddingRight = _getArrayProp(paddingRightProp)
   const radius = _getArrayProp(radiusProp)
-  const space = _getArrayProp(spaceProp)
+  const spacing = _getArrayProp(gap === undefined ? spaceProp : gap)
 
   const boxProps = useMemo(
     () => ({
@@ -143,7 +148,7 @@ export const Button = forwardRef(function Button(
 
       {(IconComponent || text || IconRightComponent) && (
         <Box as="span" {...boxProps}>
-          <Flex as="span" justify={justify} gap={space}>
+          <Flex as="span" justify={justify} gap={spacing}>
             {IconComponent && (
               <Text size={fontSize}>
                 {isValidElement(IconComponent) && IconComponent}

--- a/src/core/primitives/grid/grid.test.tsx
+++ b/src/core/primitives/grid/grid.test.tsx
@@ -28,6 +28,7 @@ describe('primitives/grid', () => {
     )
     expect(mockedResponsiveGridStyle).toHaveBeenCalledWith(expect.objectContaining({$columns: [2]}))
 
+    mockedResponsiveGridStyle.mockClear()
     render(
       <Grid gridTemplateColumns={2}>
         <div>A</div>
@@ -56,6 +57,7 @@ describe('primitives/grid', () => {
     )
     expect(mockedResponsiveGridStyle).toHaveBeenCalledWith(expect.objectContaining({$rows: [2]}))
 
+    mockedResponsiveGridStyle.mockClear()
     render(
       <Grid gridTemplateRows={2}>
         <div>A</div>

--- a/src/core/primitives/grid/grid.test.tsx
+++ b/src/core/primitives/grid/grid.test.tsx
@@ -1,0 +1,76 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {responsiveGridStyle} from '../../styles/internal'
+import {Grid} from './grid'
+
+jest.mock('../../styles/internal', () => {
+  const actual = jest.requireActual('../../styles/internal')
+
+  return {
+    ...actual,
+    responsiveGridStyle: jest.fn(actual.responsiveGridStyle),
+  }
+})
+
+describe('primitives/grid', () => {
+  const mockedResponsiveGridStyle = jest.mocked(responsiveGridStyle)
+
+  beforeEach(() => {
+    mockedResponsiveGridStyle.mockClear()
+  })
+
+  it('should support `columns` and `gridTemplateColumns` with the same behavior', () => {
+    render(
+      <Grid columns={2}>
+        <div>A</div>
+      </Grid>,
+    )
+    expect(mockedResponsiveGridStyle).toHaveBeenCalledWith(expect.objectContaining({$columns: [2]}))
+
+    render(
+      <Grid gridTemplateColumns={2}>
+        <div>A</div>
+      </Grid>,
+    )
+    expect(mockedResponsiveGridStyle).toHaveBeenCalledWith(expect.objectContaining({$columns: [2]}))
+  })
+
+  it('should prefer `gridTemplateColumns` over `columns` when both are provided', () => {
+    render(
+      <Grid columns={1} gridTemplateColumns={3}>
+        <div>A</div>
+      </Grid>,
+    )
+    expect(mockedResponsiveGridStyle).toHaveBeenCalledWith(expect.objectContaining({$columns: [3]}))
+    expect(mockedResponsiveGridStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$columns: [1]}),
+    )
+  })
+
+  it('should support `rows` and `gridTemplateRows` with the same behavior', () => {
+    render(
+      <Grid rows={2}>
+        <div>A</div>
+      </Grid>,
+    )
+    expect(mockedResponsiveGridStyle).toHaveBeenCalledWith(expect.objectContaining({$rows: [2]}))
+
+    render(
+      <Grid gridTemplateRows={2}>
+        <div>A</div>
+      </Grid>,
+    )
+    expect(mockedResponsiveGridStyle).toHaveBeenCalledWith(expect.objectContaining({$rows: [2]}))
+  })
+
+  it('should prefer `gridTemplateRows` over `rows` when both are provided', () => {
+    render(
+      <Grid gridTemplateRows={3} rows={1}>
+        <div>A</div>
+      </Grid>,
+    )
+    expect(mockedResponsiveGridStyle).toHaveBeenCalledWith(expect.objectContaining({$rows: [3]}))
+    expect(mockedResponsiveGridStyle).not.toHaveBeenCalledWith(expect.objectContaining({$rows: [1]}))
+  })
+})

--- a/src/core/primitives/grid/grid.tsx
+++ b/src/core/primitives/grid/grid.tsx
@@ -22,8 +22,23 @@ export const Grid = forwardRef(function Grid(
   props: GridProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'rows'>,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const {as, autoRows, autoCols, autoFlow, columns, gap, gapX, gapY, rows, children, ...restProps} =
-    props
+  const {
+    as,
+    autoRows,
+    autoCols,
+    autoFlow,
+    columns,
+    gridTemplateColumns,
+    gap,
+    gapX,
+    gapY,
+    rows,
+    gridTemplateRows,
+    children,
+    ...restProps
+  } = props
+  const resolvedColumns = gridTemplateColumns === undefined ? columns : gridTemplateColumns
+  const resolvedRows = gridTemplateRows === undefined ? rows : gridTemplateRows
 
   return (
     <StyledGrid
@@ -33,11 +48,11 @@ export const Grid = forwardRef(function Grid(
       $autoRows={_getArrayProp(autoRows)}
       $autoCols={_getArrayProp(autoCols)}
       $autoFlow={_getArrayProp(autoFlow)}
-      $columns={_getArrayProp(columns)}
+      $columns={_getArrayProp(resolvedColumns)}
       $gap={_getArrayProp(gap)}
       $gapX={_getArrayProp(gapX)}
       $gapY={_getArrayProp(gapY)}
-      $rows={_getArrayProp(rows)}
+      $rows={_getArrayProp(resolvedRows)}
       forwardedAs={as}
       ref={ref}
     >

--- a/src/core/primitives/grid/grid.tsx
+++ b/src/core/primitives/grid/grid.tsx
@@ -37,8 +37,6 @@ export const Grid = forwardRef(function Grid(
     children,
     ...restProps
   } = props
-  const resolvedColumns = gridTemplateColumns === undefined ? columns : gridTemplateColumns
-  const resolvedRows = gridTemplateRows === undefined ? rows : gridTemplateRows
 
   return (
     <StyledGrid
@@ -48,11 +46,11 @@ export const Grid = forwardRef(function Grid(
       $autoRows={_getArrayProp(autoRows)}
       $autoCols={_getArrayProp(autoCols)}
       $autoFlow={_getArrayProp(autoFlow)}
-      $columns={_getArrayProp(resolvedColumns)}
+      $columns={_getArrayProp(gridTemplateColumns === undefined ? columns : gridTemplateColumns)}
       $gap={_getArrayProp(gap)}
       $gapX={_getArrayProp(gapX)}
       $gapY={_getArrayProp(gapY)}
-      $rows={_getArrayProp(resolvedRows)}
+      $rows={_getArrayProp(gridTemplateRows === undefined ? rows : gridTemplateRows)}
       forwardedAs={as}
       ref={ref}
     >

--- a/src/core/primitives/inline/inline.test.tsx
+++ b/src/core/primitives/inline/inline.test.tsx
@@ -26,7 +26,6 @@ describe('primitives/inline', () => {
         <span>One</span>
         <span>Two</span>
       </Inline>,
-      {strict: false},
     )
     expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
 
@@ -35,7 +34,6 @@ describe('primitives/inline', () => {
         <span>One</span>
         <span>Two</span>
       </Inline>,
-      {strict: false},
     )
     expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
   })
@@ -46,7 +44,6 @@ describe('primitives/inline', () => {
         <span>One</span>
         <span>Two</span>
       </Inline>,
-      {strict: false},
     )
     expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [3]}))
   })

--- a/src/core/primitives/inline/inline.test.tsx
+++ b/src/core/primitives/inline/inline.test.tsx
@@ -29,6 +29,7 @@ describe('primitives/inline', () => {
     )
     expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
 
+    mockedInlineSpaceStyle.mockClear()
     render(
       <Inline gap={2}>
         <span>One</span>

--- a/src/core/primitives/inline/inline.test.tsx
+++ b/src/core/primitives/inline/inline.test.tsx
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Inline} from './inline'
+import {inlineSpaceStyle} from './styles'
+
+jest.mock('./styles', () => {
+  const actual = jest.requireActual('./styles')
+
+  return {
+    ...actual,
+    inlineSpaceStyle: jest.fn(actual.inlineSpaceStyle),
+  }
+})
+
+describe('primitives/inline', () => {
+  const mockedInlineSpaceStyle = jest.mocked(inlineSpaceStyle)
+
+  beforeEach(() => {
+    mockedInlineSpaceStyle.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    render(
+      <Inline space={2}>
+        <span>One</span>
+        <span>Two</span>
+      </Inline>,
+      {strict: false},
+    )
+    expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
+
+    render(
+      <Inline gap={2}>
+        <span>One</span>
+        <span>Two</span>
+      </Inline>,
+      {strict: false},
+    )
+    expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    render(
+      <Inline gap={3} space={1}>
+        <span>One</span>
+        <span>Two</span>
+      </Inline>,
+      {strict: false},
+    )
+    expect(mockedInlineSpaceStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [3]}))
+  })
+})

--- a/src/core/primitives/inline/inline.tsx
+++ b/src/core/primitives/inline/inline.tsx
@@ -10,14 +10,13 @@ import {ResponsiveInlineSpaceStyleProps} from './types'
  * @public
  */
 export interface InlineProps extends Omit<BoxProps, 'display'> {
-
   /**
    * The spacing between children.
    * @deprecated Use `gap` instead. `space` will be removed in v4.
    */
   space?: number | number[]
-   /** The spacing between children. */
-   gap?: number | number[]
+  /** The spacing between children. */
+  gap?: number | number[]
 }
 
 const StyledInline = styled(Box)<ResponsiveInlineSpaceStyleProps>(inlineBaseStyle, inlineSpaceStyle)

--- a/src/core/primitives/inline/inline.tsx
+++ b/src/core/primitives/inline/inline.tsx
@@ -10,8 +10,14 @@ import {ResponsiveInlineSpaceStyleProps} from './types'
  * @public
  */
 export interface InlineProps extends Omit<BoxProps, 'display'> {
-  /** The spacing between children. */
+
+  /**
+   * The spacing between children.
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
+   /** The spacing between children. */
+   gap?: number | number[]
 }
 
 const StyledInline = styled(Box)<ResponsiveInlineSpaceStyleProps>(inlineBaseStyle, inlineSpaceStyle)
@@ -25,7 +31,8 @@ export const Inline = forwardRef(function Inline(
   props: InlineProps & React.HTMLProps<HTMLDivElement>,
   ref,
 ) {
-  const {as, children: childrenProp, space, ...restProps} = props
+  const {as, children: childrenProp, gap, space, ...restProps} = props
+  const spacing = gap === undefined ? space : gap
 
   const children = useMemo(
     () => Children.map(childrenProp, (child) => child && <div>{child}</div>),
@@ -36,7 +43,7 @@ export const Inline = forwardRef(function Inline(
     <StyledInline
       data-ui="Inline"
       {...restProps}
-      $space={_getArrayProp(space)}
+      $space={_getArrayProp(spacing)}
       forwardedAs={as}
       ref={ref as any}
     >

--- a/src/core/primitives/inline/inline.tsx
+++ b/src/core/primitives/inline/inline.tsx
@@ -31,8 +31,8 @@ export const Inline = forwardRef(function Inline(
   props: InlineProps & React.HTMLProps<HTMLDivElement>,
   ref,
 ) {
-  const {as, children: childrenProp, gap, space, ...restProps} = props
-  const spacing = gap === undefined ? space : gap
+  const {as, children: childrenProp, gap, space: deprecated_space, ...restProps} = props
+  const spacing = gap === undefined ? deprecated_space : gap
 
   const children = useMemo(
     () => Children.map(childrenProp, (child) => child && <div>{child}</div>),

--- a/src/core/primitives/select/select.test.tsx
+++ b/src/core/primitives/select/select.test.tsx
@@ -31,6 +31,7 @@ describe('primitives/select spacing', () => {
     )
     expect(mockedSelectInputStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
 
+    mockedSelectInputStyle.mockClear()
     render(
       <Select gap={2}>
         <option>Option A</option>

--- a/src/core/primitives/select/select.test.tsx
+++ b/src/core/primitives/select/select.test.tsx
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Select} from './select'
+import {selectStyle} from './styles'
+
+jest.mock('./styles', () => {
+  const actual = jest.requireActual('./styles')
+
+  return {
+    ...actual,
+    selectStyle: {
+      ...actual.selectStyle,
+      input: jest.fn(actual.selectStyle.input),
+    },
+  }
+})
+
+describe('primitives/select spacing', () => {
+  const mockedSelectInputStyle = jest.mocked(selectStyle.input)
+
+  beforeEach(() => {
+    mockedSelectInputStyle.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    render(
+      <Select space={2}>
+        <option>Option A</option>
+      </Select>,
+    )
+    expect(mockedSelectInputStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
+
+    render(
+      <Select gap={2}>
+        <option>Option A</option>
+      </Select>,
+    )
+    expect(mockedSelectInputStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [2]}))
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    render(
+      <Select gap={3} space={1}>
+        <option>Option A</option>
+      </Select>,
+    )
+    expect(mockedSelectInputStyle).toHaveBeenCalledWith(expect.objectContaining({$space: [3]}))
+    expect(mockedSelectInputStyle).not.toHaveBeenCalledWith(expect.objectContaining({$space: [1]}))
+  })
+})

--- a/src/core/primitives/select/select.tsx
+++ b/src/core/primitives/select/select.tsx
@@ -14,8 +14,12 @@ import {selectStyle} from './styles'
  */
 export interface SelectProps {
   fontSize?: number | number[]
+  gap?: number | number[]
   padding?: number | number[]
   radius?: Radius | Radius[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
   customValidity?: string
 }
@@ -45,12 +49,14 @@ export const Select = forwardRef(function Select(
     customValidity,
     disabled,
     fontSize = 2,
+    gap,
     padding = 3,
     radius = 2,
     readOnly,
     space = 3,
     ...restProps
   } = props
+  const spacing = gap === undefined ? space : gap
 
   const ref = useRef<HTMLSelectElement | null>(null)
 
@@ -70,7 +76,7 @@ export const Select = forwardRef(function Select(
         $fontSize={_getArrayProp(fontSize)}
         $padding={_getArrayProp(padding)}
         $radius={_getArrayProp(radius)}
-        $space={_getArrayProp(space)}
+        $space={_getArrayProp(spacing)}
         disabled={disabled || readOnly}
         ref={ref}
       >

--- a/src/core/primitives/select/select.tsx
+++ b/src/core/primitives/select/select.tsx
@@ -53,10 +53,10 @@ export const Select = forwardRef(function Select(
     padding = 3,
     radius = 2,
     readOnly,
-    space = 3,
+    space: deprecated_space = 3,
     ...restProps
   } = props
-  const spacing = gap === undefined ? space : gap
+  const spacing = gap === undefined ? deprecated_space : gap
 
   const ref = useRef<HTMLSelectElement | null>(null)
 

--- a/src/core/primitives/stack/stack.test.tsx
+++ b/src/core/primitives/stack/stack.test.tsx
@@ -30,6 +30,7 @@ describe('primitives/stack', () => {
     expect(mockedResponsiveStackSpaceStyle).toHaveBeenCalledWith(
       expect.objectContaining({$space: [2]}),
     )
+    mockedResponsiveStackSpaceStyle.mockClear()
     render(
       <Stack gap={2}>
         <span>One</span>

--- a/src/core/primitives/stack/stack.test.tsx
+++ b/src/core/primitives/stack/stack.test.tsx
@@ -25,7 +25,6 @@ describe('primitives/stack', () => {
         <span>One</span>
         <span>Two</span>
       </Stack>,
-      {strict: false},
     )
 
     expect(mockedResponsiveStackSpaceStyle).toHaveBeenCalledWith(
@@ -36,7 +35,6 @@ describe('primitives/stack', () => {
         <span>One</span>
         <span>Two</span>
       </Stack>,
-      {strict: false},
     )
 
     expect(mockedResponsiveStackSpaceStyle).toHaveBeenCalledWith(
@@ -50,7 +48,6 @@ describe('primitives/stack', () => {
         <span>One</span>
         <span>Two</span>
       </Stack>,
-      {strict: false},
     )
     expect(mockedResponsiveStackSpaceStyle).toHaveBeenCalledWith(
       expect.objectContaining({$space: [3]}),

--- a/src/core/primitives/stack/stack.test.tsx
+++ b/src/core/primitives/stack/stack.test.tsx
@@ -1,0 +1,59 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {Stack} from './stack'
+import {responsiveStackSpaceStyle} from './styles'
+
+jest.mock('./styles', () => {
+  const actual = jest.requireActual('./styles')
+
+  return {
+    ...actual,
+    responsiveStackSpaceStyle: jest.fn(actual.responsiveStackSpaceStyle),
+  }
+})
+
+describe('primitives/stack', () => {
+  const mockedResponsiveStackSpaceStyle = jest.mocked(responsiveStackSpaceStyle)
+  beforeEach(() => {
+    mockedResponsiveStackSpaceStyle.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    render(
+      <Stack space={2}>
+        <span>One</span>
+        <span>Two</span>
+      </Stack>,
+      {strict: false},
+    )
+
+    expect(mockedResponsiveStackSpaceStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$space: [2]}),
+    )
+    render(
+      <Stack gap={2}>
+        <span>One</span>
+        <span>Two</span>
+      </Stack>,
+      {strict: false},
+    )
+
+    expect(mockedResponsiveStackSpaceStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$space: [2]}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    render(
+      <Stack gap={3} space={1}>
+        <span>One</span>
+        <span>Two</span>
+      </Stack>,
+      {strict: false},
+    )
+    expect(mockedResponsiveStackSpaceStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$space: [3]}),
+    )
+  })
+})

--- a/src/core/primitives/stack/stack.tsx
+++ b/src/core/primitives/stack/stack.tsx
@@ -31,8 +31,8 @@ export const Stack = forwardRef(function Stack(
   props: StackProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'ref'>,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const {as, gap, space, ...restProps} = props
-  const spacing = gap === undefined ? space : gap
+  const {as, gap, space: deprecated_space, ...restProps} = props
+  const spacing = gap === undefined ? deprecated_space : gap
 
   return (
     <StyledStack

--- a/src/core/primitives/stack/stack.tsx
+++ b/src/core/primitives/stack/stack.tsx
@@ -10,6 +10,10 @@ import {responsiveStackSpaceStyle, ResponsiveStackSpaceStyleProps, stackBaseStyl
  */
 export interface StackProps extends BoxProps {
   as?: React.ElementType | keyof React.JSX.IntrinsicElements
+  gap?: number | number[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
 }
 
@@ -27,14 +31,15 @@ export const Stack = forwardRef(function Stack(
   props: StackProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'ref'>,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const {as, space, ...restProps} = props
+  const {as, gap, space, ...restProps} = props
+  const spacing = gap === undefined ? space : gap
 
   return (
     <StyledStack
       data-as={typeof as === 'string' ? as : undefined}
       data-ui="Stack"
       {...restProps}
-      $space={_getArrayProp(space)}
+      $space={_getArrayProp(spacing)}
       forwardedAs={as}
       ref={ref}
     />

--- a/src/core/primitives/textInput/textInput.test.tsx
+++ b/src/core/primitives/textInput/textInput.test.tsx
@@ -21,13 +21,13 @@ describe('primitives/textInput', () => {
   })
 
   it('should support `space` and `gap` with the same behavior', () => {
-    render(<TextInput icon={() => null} space={2} />, {strict: false})
+    render(<TextInput icon={() => null} space={2} />)
 
     expect(mockedResponsiveInputPaddingStyle).toHaveBeenCalledWith(
       expect.objectContaining({$space: [2]}),
     )
 
-    render(<TextInput gap={2} icon={() => null} />, {strict: false})
+    render(<TextInput gap={2} icon={() => null} />)
 
     expect(mockedResponsiveInputPaddingStyle).toHaveBeenCalledWith(
       expect.objectContaining({$space: [2]}),
@@ -35,7 +35,7 @@ describe('primitives/textInput', () => {
   })
 
   it('should prefer `gap` over `space` when both are provided', () => {
-    render(<TextInput gap={3} icon={() => null} space={1} />, {strict: false})
+    render(<TextInput gap={3} icon={() => null} space={1} />)
 
     expect(mockedResponsiveInputPaddingStyle).toHaveBeenCalledWith(
       expect.objectContaining({$space: [3]}),

--- a/src/core/primitives/textInput/textInput.test.tsx
+++ b/src/core/primitives/textInput/textInput.test.tsx
@@ -1,0 +1,47 @@
+/** @jest-environment jsdom */
+
+import {render} from '../../../../test'
+import {responsiveInputPaddingStyle} from '../../styles/internal'
+import {TextInput} from './textInput'
+
+jest.mock('../../styles/internal', () => {
+  const actual = jest.requireActual('../../styles/internal')
+
+  return {
+    ...actual,
+    responsiveInputPaddingStyle: jest.fn(actual.responsiveInputPaddingStyle),
+  }
+})
+
+describe('primitives/textInput', () => {
+  const mockedResponsiveInputPaddingStyle = jest.mocked(responsiveInputPaddingStyle)
+
+  beforeEach(() => {
+    mockedResponsiveInputPaddingStyle.mockClear()
+  })
+
+  it('should support `space` and `gap` with the same behavior', () => {
+    render(<TextInput icon={() => null} space={2} />, {strict: false})
+
+    expect(mockedResponsiveInputPaddingStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$space: [2]}),
+    )
+
+    render(<TextInput gap={2} icon={() => null} />, {strict: false})
+
+    expect(mockedResponsiveInputPaddingStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$space: [2]}),
+    )
+  })
+
+  it('should prefer `gap` over `space` when both are provided', () => {
+    render(<TextInput gap={3} icon={() => null} space={1} />, {strict: false})
+
+    expect(mockedResponsiveInputPaddingStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$space: [3]}),
+    )
+    expect(mockedResponsiveInputPaddingStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$space: [1]}),
+    )
+  })
+})

--- a/src/core/primitives/textInput/textInput.test.tsx
+++ b/src/core/primitives/textInput/textInput.test.tsx
@@ -27,6 +27,7 @@ describe('primitives/textInput', () => {
       expect.objectContaining({$space: [2]}),
     )
 
+    mockedResponsiveInputPaddingStyle.mockClear()
     render(<TextInput gap={2} icon={() => null} />)
 
     expect(mockedResponsiveInputPaddingStyle).toHaveBeenCalledWith(

--- a/src/core/primitives/textInput/textInput.tsx
+++ b/src/core/primitives/textInput/textInput.tsx
@@ -174,7 +174,7 @@ export const TextInput = forwardRef(function TextInput(
     prefix,
     radius: radiusProp = 2,
     readOnly,
-    space: spaceProp = 3,
+    space: deprecated_space = 3,
     suffix,
     customValidity,
     type = 'text',
@@ -188,7 +188,7 @@ export const TextInput = forwardRef(function TextInput(
   const fontSize = _getArrayProp(fontSizeProp)
   const padding = _getArrayProp(paddingProp)
   const radius = _getArrayProp(radiusProp)
-  const space = _getArrayProp(gap === undefined ? spaceProp : gap)
+  const space = _getArrayProp(gap === undefined ? deprecated_space : gap)
 
   // Transient properties
   const $hasClearButton = Boolean(clearButton)

--- a/src/core/primitives/textInput/textInput.tsx
+++ b/src/core/primitives/textInput/textInput.tsx
@@ -74,7 +74,11 @@ export interface TextInputProps {
   padding?: number | number[]
   prefix?: React.ReactNode
   radius?: Radius | Radius[]
+  /**
+   * @deprecated Use `gap` instead. `space` will be removed in v4.
+   */
   space?: number | number[]
+  gap?: number | number[]
   suffix?: React.ReactNode
   type?: TextInputType
   weight?: ThemeFontWeightKey
@@ -162,6 +166,7 @@ export const TextInput = forwardRef(function TextInput(
     clearButton,
     disabled = false,
     fontSize: fontSizeProp = 2,
+    gap,
     icon: IconComponent,
     iconRight: IconRightComponent,
     onClear,
@@ -183,7 +188,7 @@ export const TextInput = forwardRef(function TextInput(
   const fontSize = _getArrayProp(fontSizeProp)
   const padding = _getArrayProp(paddingProp)
   const radius = _getArrayProp(radiusProp)
-  const space = _getArrayProp(spaceProp)
+  const space = _getArrayProp(gap === undefined ? spaceProp : gap)
 
   // Transient properties
   const $hasClearButton = Boolean(clearButton)

--- a/src/core/primitives/types.ts
+++ b/src/core/primitives/types.ts
@@ -86,11 +86,35 @@ export interface ResponsiveGridProps {
  * @public
  */
 export interface ResponsiveGridItemProps {
+  gridColumn?: GridItemColumn | GridItemColumn[]
+  /**
+   * @deprecated Use `gridColumn` instead. `column` will be removed in v4.
+   */
   column?: GridItemColumn | GridItemColumn[]
+  gridColumnStart?: GridItemColumnStart | GridItemColumnStart[]
+  /**
+   * @deprecated Use `gridColumnStart` instead. `columnStart` will be removed in v4.
+   */
   columnStart?: GridItemColumnStart | GridItemColumnStart[]
+  gridColumnEnd?: GridItemColumnEnd | GridItemColumnEnd[]
+  /**
+   * @deprecated Use `gridColumnEnd` instead. `columnEnd` will be removed in v4.
+   */
   columnEnd?: GridItemColumnEnd | GridItemColumnEnd[]
+  gridRow?: GridItemRow | GridItemRow[]
+  /**
+   * @deprecated Use `gridRow` instead. `row` will be removed in v4.
+   */
   row?: GridItemRow | GridItemRow[]
+  gridRowStart?: GridItemRowStart | GridItemRowStart[]
+  /**
+   * @deprecated Use `gridRowStart` instead. `rowStart` will be removed in v4.
+   */
   rowStart?: GridItemRowStart | GridItemRowStart[]
+  gridRowEnd?: GridItemRowEnd | GridItemRowEnd[]
+  /**
+   * @deprecated Use `gridRowEnd` instead. `rowEnd` will be removed in v4.
+   */
   rowEnd?: GridItemRowEnd | GridItemRowEnd[]
 }
 

--- a/src/core/primitives/types.ts
+++ b/src/core/primitives/types.ts
@@ -66,11 +66,20 @@ export interface ResponsiveGridProps {
   autoRows?: GridAutoRows | GridAutoRows[]
   autoCols?: GridAutoCols | GridAutoCols[]
   autoFlow?: GridAutoFlow | GridAutoFlow[]
+
+  /**
+   * @deprecated Use `gridTemplateColumns` instead. `columns` will be removed in v4.
+   */
   columns?: number | number[]
+  gridTemplateColumns?: number | number[]
   gap?: number | number[]
   gapX?: number | number[]
   gapY?: number | number[]
+  /**
+   * @deprecated Use `gridTemplateRows` instead. `rows` will be removed in v4.
+   */
   rows?: number | number[]
+  gridTemplateRows?: number | number[]
 }
 
 /**

--- a/stories/components/Breadcrumbs.stories.tsx
+++ b/stories/components/Breadcrumbs.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof Breadcrumbs> = {
       <Text key="item">Item</Text>,
     ],
   },
-  argTypes: {space: getSpaceControls()},
+  argTypes: {gap: getSpaceControls(), space: getSpaceControls()},
   component: Breadcrumbs,
   tags: ['autodocs'],
 }

--- a/stories/components/Hotkeys.stories.tsx
+++ b/stories/components/Hotkeys.stories.tsx
@@ -2,11 +2,16 @@ import type {Meta, StoryObj} from '@storybook/react'
 
 import {Hotkeys} from '../../src/core/components'
 import {RADII} from '../constants'
+import {getSpaceControls} from '../controls'
 import {rowBuilder} from '../helpers/rowBuilder'
 
 const meta: Meta<typeof Hotkeys> = {
   args: {
     keys: ['Ctrl', 'Shift', 'P'],
+  },
+  argTypes: {
+    gap: getSpaceControls(),
+    space: getSpaceControls(),
   },
   component: Hotkeys,
   tags: ['autodocs'],

--- a/stories/components/Menu.stories.tsx
+++ b/stories/components/Menu.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta<typeof Menu> = {
   },
   argTypes: {
     padding: getSpaceControls(),
+    gap: getSpaceControls(),
     space: getSpaceControls(),
     disabled: {control: 'boolean'},
     paddingX: getSpaceControls(),

--- a/stories/components/MenuItem.stories.tsx
+++ b/stories/components/MenuItem.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof MenuItem> = {
     paddingLeft: getSpaceControls(),
     paddingRight: getSpaceControls(),
     paddingTop: getSpaceControls(),
+    gap: getSpaceControls(),
     space: getSpaceControls(),
   },
   component: MenuItem,

--- a/stories/components/TabList.stories.tsx
+++ b/stories/components/TabList.stories.tsx
@@ -28,6 +28,7 @@ const meta: Meta<typeof TabList> = {
     paddingTop: getSpaceControls(),
     paddingX: getSpaceControls(),
     paddingY: getSpaceControls(),
+    gap: getSpaceControls(),
     space: getSpaceControls(),
   },
   component: TabList,

--- a/stories/components/Tree.stories.tsx
+++ b/stories/components/Tree.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof Tree> = {
     ],
   },
   argTypes: {
+    gap: getSpaceControls(),
     space: getSpaceControls(),
   },
   component: Tree,

--- a/stories/primitives/Box.stories.tsx
+++ b/stories/primitives/Box.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react'
 
-import {Box, Text} from '../../src/core/primitives'
+import {Box, Grid, Text} from '../../src/core/primitives'
 import {getSpaceControls} from '../controls'
 
 const meta: Meta<typeof Box> = {
@@ -26,5 +26,39 @@ type Story = StoryObj<typeof Box>
 export const Default: Story = {
   render: (props) => {
     return <Box {...props} />
+  },
+}
+
+export const AsGridItem: Story = {
+  args: {
+    gridColumn: 2,
+    children: <Text>Cell B</Text>,
+  },
+  argTypes: {
+    gridColumn: {control: {type: 'number', min: 1, max: 12}},
+    column: {control: {type: 'number', min: 1, max: 12}},
+    gridColumnStart: {control: {type: 'number', min: 1, max: 12}},
+    columnStart: {control: {type: 'number', min: 1, max: 12}},
+    gridColumnEnd: {control: {type: 'number', min: 1, max: 12}},
+    columnEnd: {control: {type: 'number', min: 1, max: 12}},
+    gridRow: {control: {type: 'number', min: 1, max: 12}},
+    row: {control: {type: 'number', min: 1, max: 12}},
+    gridRowStart: {control: {type: 'number', min: 1, max: 12}},
+    rowStart: {control: {type: 'number', min: 1, max: 12}},
+    gridRowEnd: {control: {type: 'number', min: 1, max: 12}},
+    rowEnd: {control: {type: 'number', min: 1, max: 12}},
+  },
+  render: (props) => {
+    return (
+      <Grid gap={2} gridTemplateColumns={4}>
+        <Box padding={3} style={{border: '1px dashed #999'}}>
+          <Text>Cell A</Text>
+        </Box>
+        <Box {...props} />
+        <Box padding={3} style={{border: '1px dashed #999'}}>
+          <Text>Cell C</Text>
+        </Box>
+      </Grid>
+    )
   },
 }

--- a/stories/primitives/Button.stories.tsx
+++ b/stories/primitives/Button.stories.tsx
@@ -24,6 +24,7 @@ const meta: Meta<typeof Button> = {
     iconRight: getIconControls(),
     padding: getSpaceControls(),
     radius: getRadiusControls(),
+    gap: getSpaceControls(),
     space: getSpaceControls(),
     text: {control: 'text'},
     width: getButtonWidthControls(),
@@ -51,7 +52,7 @@ export const WithIcons: Story = {
   },
   parameters: {
     controls: {
-      include: ['icon', 'iconRight', 'mode', 'space', 'tone'],
+      include: ['icon', 'iconRight', 'mode', 'gap', 'space', 'tone'],
     },
   },
   render: (props) => <Button {...props} />,
@@ -175,7 +176,7 @@ export const MultipleStyles: Story = {
                 {/* Small button */}
                 <Button
                   {...props}
-                  space={2}
+                  gap={2}
                   padding={2}
                   tone={row}
                   mode={column}
@@ -201,7 +202,7 @@ export const MultipleStyles: Story = {
                 {/* Small button */}
                 <Button
                   {...props}
-                  space={2}
+                  gap={2}
                   padding={2}
                   tone={row}
                   mode={column}

--- a/stories/primitives/Button.stories.tsx
+++ b/stories/primitives/Button.stories.tsx
@@ -176,7 +176,7 @@ export const MultipleStyles: Story = {
                 {/* Small button */}
                 <Button
                   {...props}
-                  gap={2}
+                  space={2}
                   padding={2}
                   tone={row}
                   mode={column}
@@ -202,7 +202,7 @@ export const MultipleStyles: Story = {
                 {/* Small button */}
                 <Button
                   {...props}
-                  gap={2}
+                  space={2}
                   padding={2}
                   tone={row}
                   mode={column}

--- a/stories/primitives/Grid.stories.tsx
+++ b/stories/primitives/Grid.stories.tsx
@@ -32,6 +32,10 @@ const meta: Meta<typeof Grid> = {
     height: getHeightControls(),
     overflow: getOverflowControls(),
     gap: getSpaceControls(),
+    columns: {control: {type: 'number', min: 1, max: 12}},
+    gridTemplateColumns: {control: {type: 'number', min: 1, max: 12}},
+    rows: {control: {type: 'number', min: 1, max: 12}},
+    gridTemplateRows: {control: {type: 'number', min: 1, max: 12}},
   },
   tags: ['autodocs'],
 }

--- a/stories/primitives/Inline.stories.tsx
+++ b/stories/primitives/Inline.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta<typeof Inline> = {
     ],
   },
   argTypes: {
+    gap: getSpaceControls(),
     space: getSpaceControls(),
     padding: getSpaceControls(),
     paddingBottom: getSpaceControls(),

--- a/stories/primitives/Select.stories.tsx
+++ b/stories/primitives/Select.stories.tsx
@@ -21,6 +21,7 @@ const meta: Meta<typeof Select> = {
     fontSize: getFontSizeControls('text'),
     padding: getSpaceControls(),
     radius: getRadiusControls(),
+    gap: getSpaceControls(),
     space: getSpaceControls(),
   },
   component: Select,

--- a/stories/primitives/Stack.stories.tsx
+++ b/stories/primitives/Stack.stories.tsx
@@ -36,6 +36,7 @@ const meta: Meta<typeof Stack> = {
     marginX: getSpaceControls(),
     height: getHeightControls(),
     overflow: getOverflowControls(),
+    gap: getSpaceControls(),
     space: getSpaceControls(),
   },
   tags: ['autodocs'],

--- a/stories/primitives/TextInput.stories.tsx
+++ b/stories/primitives/TextInput.stories.tsx
@@ -21,6 +21,7 @@ const meta: Meta<typeof TextInput> = {
     icon: getIconControls(),
     iconRight: getIconControls(),
     radius: getRadiusControls(),
+    gap: getSpaceControls(),
     space: getSpaceControls(),
   },
   component: TextInput,


### PR DESCRIPTION
### Description

- Migrated spacing APIs across primitives/components to support gap while keeping space backward compatible, with clear v4 deprecation for space.
- Added migration for `Grid` template props: gridTemplateColumns/gridTemplateRows now preferred over deprecated columns/rows (with precedence to new props).

| Prop | Count in monorepo |
|--------|--------|
| space | 414 results |
| columns |  27 results |
| rows | 1 | 

This will help us have a smaller footprint one we are ready to migrate sanity monorepo to ui v4 or v5, [most of the changes in the migration PR ](https://github.com/sanity-io/sanity/pull/12394/changes) are related to this props renames. If we do that before the migration it will help us reduce the noise in the migration PR.
It will also help prepare users for the migration, by doing this change they can start updating the props for when we finally migrate the studio.


## What Changed

### Spacing migration (`space` -> `gap`, with backward compatibility)

Updated these APIs to accept both props and prefer `gap`:

- Primitives: `Inline`, `Stack`, `Button`, `TextInput`, `Select`
- Components: `TabList` (via `InlineProps`), `Menu`, `MenuItem`, `MenuGroup`, `Hotkeys`, `Breadcrumbs`, `Tree`, `TreeItem`
- Tree context contract: added `gap` while retaining deprecated `space`

All affected `space` props are now documented as deprecated (v4 removal).

### Grid migration (`columns`/`rows` -> `gridTemplateColumns`/`gridTemplateRows`)

- Added new preferred props:
  - `gridTemplateColumns`
  - `gridTemplateRows`
- Kept deprecated aliases:
  - `columns`
  - `rows`
- Implemented precedence:
  - `gridTemplateColumns ?? columns`
  - `gridTemplateRows ?? rows`
- Updated Grid story defaults/examples and added focused tests.


Deprecates box grid item props `column` for `gridColumn` and equivalents. 

```ts
export interface ResponsiveGridItemProps {
  gridColumn?: GridItemColumn | GridItemColumn[]
  /**
   * @deprecated Use `gridColumn` instead. `column` will be removed in v4.
   */
  column?: GridItemColumn | GridItemColumn[]
  gridColumnStart?: GridItemColumnStart | GridItemColumnStart[]
  /**
   * @deprecated Use `gridColumnStart` instead. `columnStart` will be removed in v4.
   */
  columnStart?: GridItemColumnStart | GridItemColumnStart[]
  gridColumnEnd?: GridItemColumnEnd | GridItemColumnEnd[]
  /**
   * @deprecated Use `gridColumnEnd` instead. `columnEnd` will be removed in v4.
   */
  columnEnd?: GridItemColumnEnd | GridItemColumnEnd[]
  gridRow?: GridItemRow | GridItemRow[]
  /**
   * @deprecated Use `gridRow` instead. `row` will be removed in v4.
   */
  row?: GridItemRow | GridItemRow[]
  gridRowStart?: GridItemRowStart | GridItemRowStart[]
  /**
   * @deprecated Use `gridRowStart` instead. `rowStart` will be removed in v4.
   */
  rowStart?: GridItemRowStart | GridItemRowStart[]
  gridRowEnd?: GridItemRowEnd | GridItemRowEnd[]
  /**
   * @deprecated Use `gridRowEnd` instead. `rowEnd` will be removed in v4.
   */
  rowEnd?: GridItemRowEnd | GridItemRowEnd[]
}
```

### Test strategy

- Added/updated focused migration tests to assert:
  1. legacy prop still works
  2. new prop works
  3. new prop takes precedence when both are provided

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is the deprecation warning ok?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
