### PR TITLE
feat: add deprecation warning to box grid item props

### DIFF
--- a/src/core/primitives/box/box.test.tsx
+++ b/src/core/primitives/box/box.test.tsx
@@ -1,0 +1,134 @@
+/** @jest-environment jsdom */
+
+import {type ComponentProps} from 'react'
+
+import {render} from '../../../../test'
+import {responsiveGridItemStyle} from '../../styles/internal'
+import {Box} from './box'
+
+jest.mock('../../styles/internal', () => {
+  const actual = jest.requireActual('../../styles/internal')
+
+  return {
+    ...actual,
+    responsiveGridItemStyle: jest.fn(actual.responsiveGridItemStyle),
+  }
+})
+
+describe('<Box />', () => {
+  const mockedResponsiveGridItemStyle = jest.mocked(responsiveGridItemStyle)
+
+  beforeEach(() => {
+    mockedResponsiveGridItemStyle.mockClear()
+  })
+
+  it('uses column when gridColumn is not provided', () => {
+    render(<Box column={3} />)
+
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$column: [3]}))
+  })
+
+  it('uses gridColumn when provided', () => {
+    render(<Box gridColumn={4} />)
+
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$column: [4]}))
+  })
+
+  it('prefers gridColumn over column when both are provided', () => {
+    render(<Box column={3} gridColumn={5} />)
+
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$column: [5]}))
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(expect.objectContaining({$column: [3]}))
+  })
+
+  it('supports responsive arrays with gridColumn', () => {
+    const gridColumn: ComponentProps<typeof Box>['gridColumn'] = [2, 'full']
+
+    render(<Box gridColumn={gridColumn} />)
+
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$column: [2, 'full']}),
+    )
+  })
+
+  it('uses columnStart when gridColumnStart is not provided', () => {
+    render(<Box columnStart={2} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$columnStart: [2]}),
+    )
+  })
+
+  it('prefers gridColumnStart over columnStart when both are provided', () => {
+    render(<Box columnStart={2} gridColumnStart={4} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$columnStart: [4]}),
+    )
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$columnStart: [2]}),
+    )
+  })
+
+  it('uses columnEnd when gridColumnEnd is not provided', () => {
+    render(<Box columnEnd={3} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$columnEnd: [3]}),
+    )
+  })
+
+  it('prefers gridColumnEnd over columnEnd when both are provided', () => {
+    render(<Box columnEnd={3} gridColumnEnd={5} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$columnEnd: [5]}),
+    )
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$columnEnd: [3]}),
+    )
+  })
+
+  it('uses row when gridRow is not provided', () => {
+    render(<Box row={1} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$row: [1]}))
+  })
+
+  it('prefers gridRow over row when both are provided', () => {
+    render(<Box row={1} gridRow={2} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(expect.objectContaining({$row: [2]}))
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$row: [1]}),
+    )
+  })
+
+  it('uses rowStart when gridRowStart is not provided', () => {
+    render(<Box rowStart={2} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$rowStart: [2]}),
+    )
+  })
+
+  it('prefers gridRowStart over rowStart when both are provided', () => {
+    render(<Box rowStart={2} gridRowStart={4} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$rowStart: [4]}),
+    )
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$rowStart: [2]}),
+    )
+  })
+
+  it('uses rowEnd when gridRowEnd is not provided', () => {
+    render(<Box rowEnd={3} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$rowEnd: [3]}),
+    )
+  })
+
+  it('prefers gridRowEnd over rowEnd when both are provided', () => {
+    render(<Box rowEnd={3} gridRowEnd={5} />)
+    expect(mockedResponsiveGridItemStyle).toHaveBeenCalledWith(
+      expect.objectContaining({$rowEnd: [5]}),
+    )
+    expect(mockedResponsiveGridItemStyle).not.toHaveBeenCalledWith(
+      expect.objectContaining({$rowEnd: [3]}),
+    )
+  })
+})

--- a/src/core/primitives/box/box.tsx
+++ b/src/core/primitives/box/box.tsx
@@ -63,9 +63,12 @@ export const Box = forwardRef(function Box(
 ) {
   const {
     as: asProp = 'div',
-    column,
-    columnStart,
-    columnEnd,
+    gridColumn,
+    column: deprecated_column,
+    gridColumnStart,
+    columnStart: deprecated_columnStart,
+    gridColumnEnd,
+    columnEnd: deprecated_columnEnd,
     display = 'block',
     flex,
     height,
@@ -84,12 +87,21 @@ export const Box = forwardRef(function Box(
     paddingRight,
     paddingBottom,
     paddingLeft,
-    row,
-    rowStart,
-    rowEnd,
+    gridRow,
+    row: deprecated_row,
+    gridRowStart,
+    rowStart: deprecated_rowStart,
+    gridRowEnd,
+    rowEnd: deprecated_rowEnd,
     sizing,
     ...restProps
   } = props
+  const column = gridColumn === undefined ? deprecated_column : gridColumn
+  const columnStart = gridColumnStart === undefined ? deprecated_columnStart : gridColumnStart
+  const columnEnd = gridColumnEnd === undefined ? deprecated_columnEnd : gridColumnEnd
+  const row = gridRow === undefined ? deprecated_row : gridRow
+  const rowStart = gridRowStart === undefined ? deprecated_rowStart : gridRowStart
+  const rowEnd = gridRowEnd === undefined ? deprecated_rowEnd : gridRowEnd
 
   return (
     <StyledBox

--- a/src/core/primitives/types.ts
+++ b/src/core/primitives/types.ts
@@ -86,11 +86,35 @@ export interface ResponsiveGridProps {
  * @public
  */
 export interface ResponsiveGridItemProps {
+  gridColumn?: GridItemColumn | GridItemColumn[]
+  /**
+   * @deprecated Use `gridColumn` instead. `column` will be removed in v4.
+   */
   column?: GridItemColumn | GridItemColumn[]
+  gridColumnStart?: GridItemColumnStart | GridItemColumnStart[]
+  /**
+   * @deprecated Use `gridColumnStart` instead. `columnStart` will be removed in v4.
+   */
   columnStart?: GridItemColumnStart | GridItemColumnStart[]
+  gridColumnEnd?: GridItemColumnEnd | GridItemColumnEnd[]
+  /**
+   * @deprecated Use `gridColumnEnd` instead. `columnEnd` will be removed in v4.
+   */
   columnEnd?: GridItemColumnEnd | GridItemColumnEnd[]
+  gridRow?: GridItemRow | GridItemRow[]
+  /**
+   * @deprecated Use `gridRow` instead. `row` will be removed in v4.
+   */
   row?: GridItemRow | GridItemRow[]
+  gridRowStart?: GridItemRowStart | GridItemRowStart[]
+  /**
+   * @deprecated Use `gridRowStart` instead. `rowStart` will be removed in v4.
+   */
   rowStart?: GridItemRowStart | GridItemRowStart[]
+  gridRowEnd?: GridItemRowEnd | GridItemRowEnd[]
+  /**
+   * @deprecated Use `gridRowEnd` instead. `rowEnd` will be removed in v4.
+   */
   rowEnd?: GridItemRowEnd | GridItemRowEnd[]
 }
 

--- a/stories/primitives/Box.stories.tsx
+++ b/stories/primitives/Box.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react'
 
-import {Box, Text} from '../../src/core/primitives'
+import {Box, Grid, Text} from '../../src/core/primitives'
 import {getSpaceControls} from '../controls'
 
 const meta: Meta<typeof Box> = {
@@ -26,5 +26,39 @@ type Story = StoryObj<typeof Box>
 export const Default: Story = {
   render: (props) => {
     return <Box {...props} />
+  },
+}
+
+export const AsGridItem: Story = {
+  args: {
+    gridColumn: 2,
+    children: <Text>Cell B</Text>,
+  },
+  argTypes: {
+    gridColumn: {control: {type: 'number', min: 1, max: 12}},
+    column: {control: {type: 'number', min: 1, max: 12}},
+    gridColumnStart: {control: {type: 'number', min: 1, max: 12}},
+    columnStart: {control: {type: 'number', min: 1, max: 12}},
+    gridColumnEnd: {control: {type: 'number', min: 1, max: 12}},
+    columnEnd: {control: {type: 'number', min: 1, max: 12}},
+    gridRow: {control: {type: 'number', min: 1, max: 12}},
+    row: {control: {type: 'number', min: 1, max: 12}},
+    gridRowStart: {control: {type: 'number', min: 1, max: 12}},
+    rowStart: {control: {type: 'number', min: 1, max: 12}},
+    gridRowEnd: {control: {type: 'number', min: 1, max: 12}},
+    rowEnd: {control: {type: 'number', min: 1, max: 12}},
+  },
+  render: (props) => {
+    return (
+      <Grid gap={2} gridTemplateColumns={4}>
+        <Box padding={3} style={{border: '1px dashed #999'}}>
+          <Text>Cell A</Text>
+        </Box>
+        <Box {...props} />
+        <Box padding={3} style={{border: '1px dashed #999'}}>
+          <Text>Cell C</Text>
+        </Box>
+      </Grid>
+    )
   },
 }


### PR DESCRIPTION
### Description
Deprecates box grid item props `column` for `gridColumn` and equivalents. 

```ts
export interface ResponsiveGridItemProps {
  gridColumn?: GridItemColumn | GridItemColumn[]
  /**
   * @deprecated Use `gridColumn` instead. `column` will be removed in v4.
   */
  column?: GridItemColumn | GridItemColumn[]
  gridColumnStart?: GridItemColumnStart | GridItemColumnStart[]
  /**
   * @deprecated Use `gridColumnStart` instead. `columnStart` will be removed in v4.
   */
  columnStart?: GridItemColumnStart | GridItemColumnStart[]
  gridColumnEnd?: GridItemColumnEnd | GridItemColumnEnd[]
  /**
   * @deprecated Use `gridColumnEnd` instead. `columnEnd` will be removed in v4.
   */
  columnEnd?: GridItemColumnEnd | GridItemColumnEnd[]
  gridRow?: GridItemRow | GridItemRow[]
  /**
   * @deprecated Use `gridRow` instead. `row` will be removed in v4.
   */
  row?: GridItemRow | GridItemRow[]
  gridRowStart?: GridItemRowStart | GridItemRowStart[]
  /**
   * @deprecated Use `gridRowStart` instead. `rowStart` will be removed in v4.
   */
  rowStart?: GridItemRowStart | GridItemRowStart[]
  gridRowEnd?: GridItemRowEnd | GridItemRowEnd[]
  /**
   * @deprecated Use `gridRowEnd` instead. `rowEnd` will be removed in v4.
   */
  rowEnd?: GridItemRowEnd | GridItemRowEnd[]
}
```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
