### PR TITLE
perf: lazy load motion/react in Toast, Popover and Tooltip

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,22 +41,16 @@ export default ts.config(
         '@typescript-eslint/no-restricted-imports': [
           'error',
           {
-            name: 'motion/react',
-            allowTypeImports: true,
-            message:
-              'Do not import motion at runtime. It must only be imported from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
-          },
-          {
-            name: 'motion-dom',
-            allowTypeImports: true,
-            message:
-              'Do not import motion at runtime. It must only be imported from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
-          },
-          {
-            name: 'framer-motion',
-            allowTypeImports: true,
-            message:
-              'Do not import motion at runtime. It must only be imported from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+            // Patterns also cover subpaths and alternate entrypoints (e.g. `motion/mini`,
+            // `motion/react/dist/...`, `framer-motion/dom`) so they cannot bypass the guard.
+            patterns: [
+              {
+                group: ['motion', 'motion/*', 'motion-dom', 'motion-dom/*', 'framer-motion', 'framer-motion/*'],
+                allowTypeImports: true,
+                message:
+                  'Do not import motion at runtime. It must only be imported from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+              },
+            ],
           },
         ],
         'import/no-unresolved': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,27 @@ export default ts.config(
       rules: {
         // '@typescript-eslint/no-unused-vars': 'off',
         '@typescript-eslint/no-explicit-any': 'off', // todo: warn
+        '@typescript-eslint/no-restricted-imports': [
+          'error',
+          {
+            name: 'motion/react',
+            allowTypeImports: true,
+            message:
+              'Do not import motion at runtime. It must only be imported from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+          },
+          {
+            name: 'motion-dom',
+            allowTypeImports: true,
+            message:
+              'Do not import motion at runtime. It must only be imported from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+          },
+          {
+            name: 'framer-motion',
+            allowTypeImports: true,
+            message:
+              'Do not import motion at runtime. It must only be imported from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+          },
+        ],
         'import/no-unresolved': 'off',
         'no-console': 'error',
         'no-restricted-imports': [
@@ -223,6 +244,21 @@ export default ts.config(
         ],
 
         'boundaries/no-private': 'off',
+      },
+    },
+
+    // Allow runtime motion imports only in the lazy-loaded chunk modules.
+    // These files are reached exclusively via React.lazy(), so importing motion
+    // here does not leak it into the static module graph.
+    {
+      files: [
+        'src/core/primitives/popover/popoverCardAnimated.tsx',
+        'src/core/primitives/tooltip/tooltipCardAnimated.tsx',
+        'src/core/components/toast/toastCard.tsx',
+        'src/core/components/toast/toastList.tsx',
+      ],
+      rules: {
+        '@typescript-eslint/no-restricted-imports': 'off',
       },
     },
 

--- a/src/core/components/toast/toast.test.tsx
+++ b/src/core/components/toast/toast.test.tsx
@@ -1,11 +1,45 @@
 /** @jest-environment jsdom */
 
+import '../../../../test/mocks/resizeObserver.mock'
+import '../../../../test/mocks/matchMedia.mock'
+
+import {fireEvent, screen} from '@testing-library/react'
+
 import {render} from '../../../../test'
 import {ToastContext} from './toastContext'
+import {ToastProvider} from './toastProvider'
 import {ToastContextValue} from './types'
 import {useToast} from './useToast'
 
 describe('components/toast', () => {
+  describe('ToastProvider', () => {
+    it('should render a pushed toast (the toast stack is lazy loaded on first push)', async () => {
+      function PushButton() {
+        const {push} = useToast()
+
+        return (
+          <button onClick={() => push({title: 'Toast title', status: 'info'})} type="button">
+            push
+          </button>
+        )
+      }
+
+      render(
+        <ToastProvider>
+          <PushButton />
+        </ToastProvider>,
+      )
+
+      // Validate no toast is rendered before pushing
+      expect(screen.queryByText('Toast title')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByText('push'))
+
+      // Validate the pushed toast is rendered
+      await screen.findByText('Toast title')
+    })
+  })
+
   describe('useToast', () => {
     it('should get context value', async () => {
       const log = jest.fn()

--- a/src/core/components/toast/toast.tsx
+++ b/src/core/components/toast/toast.tsx
@@ -1,17 +1,4 @@
-import {CloseIcon} from '@sanity/icons'
-import {motion, type Variant, type Variants} from 'motion/react'
-
-import {usePrefersReducedMotion} from '../../hooks/usePrefersReducedMotion'
-import {Box, Button, Flex, Stack, Text} from '../../primitives'
-import {
-  BUTTON_TONE,
-  LoadingBar,
-  LoadingBarMask,
-  LoadingBarProgress,
-  STATUS_CARD_TONE,
-  StyledToast,
-  TextBox,
-} from './styles'
+import {lazy, Suspense} from 'react'
 
 /**
  * @public
@@ -27,21 +14,17 @@ export interface ToastProps {
   updatedAt?: number
 }
 
-const ROLES = {
-  error: 'alert',
-  warning: 'alert',
-  success: 'alert',
-  info: 'alert',
-} as const
-
-// Support pattern used by Sanity Studio, that works around the lack of `duration: Infinity` support in older @sanity/ui versions
-// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
-const LONG_ENOUGH_BUT_NOT_TOO_LONG = 1000 * 60 * 60 * 24 * 24
+const ToastCard = lazy(() =>
+  import('./toastCard').then((toastCardModule) => ({default: toastCardModule.ToastCard})),
+)
 
 /**
  * The `Toast` component gives feedback to users when an action has taken place.
  *
  * Toasts can be closed with a close button, or auto-dismiss after a certain timeout.
+ *
+ * The animated implementation (and the `motion` library it depends on) is loaded lazily on the
+ * first render, so the toast may appear a frame later than it otherwise would.
  *
  * @public
  */
@@ -59,140 +42,11 @@ export function Toast(
       | 'onDrag'
     >,
 ): React.JSX.Element {
-  const {
-    closable,
-    description,
-    duration,
-    onClose,
-    radius = 3,
-    title,
-    status,
-    updatedAt,
-    ...restProps
-  } = props
-  const cardTone = status ? STATUS_CARD_TONE[status] : 'default'
-  const buttonTone = status ? BUTTON_TONE[status] : 'default'
-  const role = status ? ROLES[status] : 'status'
-
-  const prefersReducedMotion = usePrefersReducedMotion()
-
-  const visualDuration: number = prefersReducedMotion ? 0 : 0.26
-  const transition = visualDuration
-    ? {type: 'spring' as const, visualDuration, bounce: 0.25}
-    : {duration: 0}
-
-  const hasDuration = duration && isFinite(duration) && duration < LONG_ENOUGH_BUT_NOT_TOO_LONG
-  const initial: ContainerVariants[] = ['hidden', 'initial']
-  const animate: ContainerVariants[] = ['visible', 'slideIn']
-  const exit: ContainerVariants[] = ['hidden', 'slideOut']
-
   return (
-    <MotionToast
-      data-ui="Toast"
-      role={role}
-      {...restProps}
-      data-has-duration={hasDuration ? '' : undefined}
-      custom={visualDuration}
-      radius={radius}
-      shadow={2}
-      tone={cardTone}
-      forwardedAs="li"
-      layout="position"
-      variants={container}
-      initial={initial}
-      animate={animate}
-      exit={exit}
-      transition={transition}
-    >
-      <MotionFlex align="flex-start" variants={content} transition={transition}>
-        <TextBox flex={1} padding={3}>
-          <Stack space={3}>
-            {title && (
-              <Text size={1} weight="medium">
-                {title}
-              </Text>
-            )}
-            {description && (
-              <MotionText muted size={1} variants={content} transition={transition}>
-                {description}
-              </MotionText>
-            )}
-          </Stack>
-        </TextBox>
-
-        {closable && (
-          <Box padding={1}>
-            <Button
-              as="button"
-              icon={CloseIcon}
-              mode="bleed"
-              padding={2}
-              tone={buttonTone}
-              onClick={onClose}
-              style={{verticalAlign: 'top'}}
-            />
-          </Box>
-        )}
-      </MotionFlex>
-      {hasDuration && (
-        <MotionLoadingBar variants={content} transition={transition}>
-          <LoadingBarMask tone={cardTone} radius={radius} />
-          <MotionLoadingBarProgress
-            key={`progress-${updatedAt}`}
-            tone={cardTone}
-            initial={{scaleX: 0}}
-            animate={{scaleX: 1}}
-            transition={{delay: visualDuration, duration: duration / 1_000, ease: 'linear'}}
-            onAnimationComplete={onClose}
-          />
-        </MotionLoadingBar>
-      )}
-    </MotionToast>
+    <Suspense fallback={null}>
+      <ToastCard {...props} />
+    </Suspense>
   )
 }
 
 Toast.displayName = 'Toast'
-
-const container = {
-  initial: {y: 32, scale: 0.5, zIndex: 1},
-  hidden: {opacity: 0},
-  visible: (visualDuration: number) => {
-    if (!visualDuration) return {opacity: 1}
-
-    return {
-      opacity: 1,
-      transition: {
-        when: 'beforeChildren',
-        staggerChildren: visualDuration / 3,
-        duration: visualDuration / 3,
-      },
-    }
-  },
-  slideIn: {
-    y: 0,
-    scale: 1,
-  },
-  slideOut: {
-    zIndex: 0,
-    scale: 0.75,
-  },
-} satisfies Variants
-type ContainerVariants = keyof typeof container
-
-const content = {
-  initial: {
-    willChange: 'transform',
-  },
-  hidden: {
-    opacity: 0,
-  },
-  visible: {
-    opacity: 1,
-  },
-} satisfies Partial<Record<ContainerVariants, Variant>>
-
-const MotionToast = motion.create(StyledToast)
-const MotionFlex = motion.create(Flex)
-const MotionText = motion.create(Text)
-const MotionLoadingBar = motion.create(LoadingBar)
-const MotionLoadingBarProgress = motion.create(LoadingBarProgress)

--- a/src/core/components/toast/toastCard.tsx
+++ b/src/core/components/toast/toastCard.tsx
@@ -26,8 +26,10 @@ const ROLES = {
 const LONG_ENOUGH_BUT_NOT_TOO_LONG = 1000 * 60 * 60 * 24 * 24
 
 /**
- * Animated `Toast` implementation, kept in a separate module so that `motion/react` is only
- * loaded when a toast is actually rendered.
+ * Animated `Toast` implementation. This module carries the `motion/react` dependency; isolating it
+ * here lets consumers defer that cost. The deferral is enforced by the consumers, not here:
+ * `toast.tsx` loads this module via `React.lazy`, and `toastProvider.tsx` gates the toast stack
+ * behind its `hasPushed` latch so nothing imports it until a toast is pushed.
  *
  * @internal
  */

--- a/src/core/components/toast/toastCard.tsx
+++ b/src/core/components/toast/toastCard.tsx
@@ -1,0 +1,184 @@
+import {CloseIcon} from '@sanity/icons'
+import {motion, type Variant, type Variants} from 'motion/react'
+
+import {usePrefersReducedMotion} from '../../hooks/usePrefersReducedMotion'
+import {Box, Button, Flex, Stack, Text} from '../../primitives'
+import {
+  BUTTON_TONE,
+  LoadingBar,
+  LoadingBarMask,
+  LoadingBarProgress,
+  STATUS_CARD_TONE,
+  StyledToast,
+  TextBox,
+} from './styles'
+import type {ToastProps} from './toast'
+
+const ROLES = {
+  error: 'alert',
+  warning: 'alert',
+  success: 'alert',
+  info: 'alert',
+} as const
+
+// Support pattern used by Sanity Studio, that works around the lack of `duration: Infinity` support in older @sanity/ui versions
+// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+const LONG_ENOUGH_BUT_NOT_TOO_LONG = 1000 * 60 * 60 * 24 * 24
+
+/**
+ * Animated `Toast` implementation, kept in a separate module so that `motion/react` is only
+ * loaded when a toast is actually rendered.
+ *
+ * @internal
+ */
+export function ToastCard(
+  props: ToastProps &
+    Omit<
+      React.HTMLProps<HTMLDivElement>,
+      | 'as'
+      | 'height'
+      | 'ref'
+      | 'title'
+      | 'onAnimationStart'
+      | 'onDragStart'
+      | 'onDragEnd'
+      | 'onDrag'
+    >,
+): React.JSX.Element {
+  const {
+    closable,
+    description,
+    duration,
+    onClose,
+    radius = 3,
+    title,
+    status,
+    updatedAt,
+    ...restProps
+  } = props
+  const cardTone = status ? STATUS_CARD_TONE[status] : 'default'
+  const buttonTone = status ? BUTTON_TONE[status] : 'default'
+  const role = status ? ROLES[status] : 'status'
+
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const visualDuration: number = prefersReducedMotion ? 0 : 0.26
+  const transition = visualDuration
+    ? {type: 'spring' as const, visualDuration, bounce: 0.25}
+    : {duration: 0}
+
+  const hasDuration = duration && isFinite(duration) && duration < LONG_ENOUGH_BUT_NOT_TOO_LONG
+  const initial: ContainerVariants[] = ['hidden', 'initial']
+  const animate: ContainerVariants[] = ['visible', 'slideIn']
+  const exit: ContainerVariants[] = ['hidden', 'slideOut']
+
+  return (
+    <MotionToast
+      data-ui="Toast"
+      role={role}
+      {...restProps}
+      data-has-duration={hasDuration ? '' : undefined}
+      custom={visualDuration}
+      radius={radius}
+      shadow={2}
+      tone={cardTone}
+      forwardedAs="li"
+      layout="position"
+      variants={container}
+      initial={initial}
+      animate={animate}
+      exit={exit}
+      transition={transition}
+    >
+      <MotionFlex align="flex-start" variants={content} transition={transition}>
+        <TextBox flex={1} padding={3}>
+          <Stack space={3}>
+            {title && (
+              <Text size={1} weight="medium">
+                {title}
+              </Text>
+            )}
+            {description && (
+              <MotionText muted size={1} variants={content} transition={transition}>
+                {description}
+              </MotionText>
+            )}
+          </Stack>
+        </TextBox>
+
+        {closable && (
+          <Box padding={1}>
+            <Button
+              as="button"
+              icon={CloseIcon}
+              mode="bleed"
+              padding={2}
+              tone={buttonTone}
+              onClick={onClose}
+              style={{verticalAlign: 'top'}}
+            />
+          </Box>
+        )}
+      </MotionFlex>
+      {hasDuration && (
+        <MotionLoadingBar variants={content} transition={transition}>
+          <LoadingBarMask tone={cardTone} radius={radius} />
+          <MotionLoadingBarProgress
+            key={`progress-${updatedAt}`}
+            tone={cardTone}
+            initial={{scaleX: 0}}
+            animate={{scaleX: 1}}
+            transition={{delay: visualDuration, duration: duration / 1_000, ease: 'linear'}}
+            onAnimationComplete={onClose}
+          />
+        </MotionLoadingBar>
+      )}
+    </MotionToast>
+  )
+}
+
+ToastCard.displayName = 'ToastCard'
+
+const container = {
+  initial: {y: 32, scale: 0.5, zIndex: 1},
+  hidden: {opacity: 0},
+  visible: (visualDuration: number) => {
+    if (!visualDuration) return {opacity: 1}
+
+    return {
+      opacity: 1,
+      transition: {
+        when: 'beforeChildren',
+        staggerChildren: visualDuration / 3,
+        duration: visualDuration / 3,
+      },
+    }
+  },
+  slideIn: {
+    y: 0,
+    scale: 1,
+  },
+  slideOut: {
+    zIndex: 0,
+    scale: 0.75,
+  },
+} satisfies Variants
+type ContainerVariants = keyof typeof container
+
+const content = {
+  initial: {
+    willChange: 'transform',
+  },
+  hidden: {
+    opacity: 0,
+  },
+  visible: {
+    opacity: 1,
+  },
+} satisfies Partial<Record<ContainerVariants, Variant>>
+
+const MotionToast = /* @__PURE__ */ motion.create(StyledToast)
+const MotionFlex = /* @__PURE__ */ motion.create(Flex)
+const MotionText = /* @__PURE__ */ motion.create(Text)
+const MotionLoadingBar = /* @__PURE__ */ motion.create(LoadingBar)
+const MotionLoadingBarProgress = /* @__PURE__ */ motion.create(LoadingBarProgress)

--- a/src/core/components/toast/toastList.tsx
+++ b/src/core/components/toast/toastList.tsx
@@ -1,0 +1,43 @@
+import {AnimatePresence} from 'motion/react'
+
+import {ToastCard} from './toastCard'
+import type {ToastParams} from './types'
+
+/**
+ * @internal
+ */
+export type ToastState = {
+  dismiss: () => void
+  id: string
+  updatedAt: number
+  params: ToastParams
+}[]
+
+/**
+ * Renders the animated toast stack. Kept in a separate module so that `motion/react` is only
+ * loaded once the first toast is pushed.
+ *
+ * @internal
+ */
+export function ToastList(props: {toasts: ToastState}): React.JSX.Element {
+  const {toasts} = props
+
+  return (
+    <AnimatePresence initial={false} mode="popLayout">
+      {toasts.map(({dismiss, id, params, updatedAt}) => (
+        <ToastCard
+          key={id}
+          closable={params.closable}
+          description={params.description}
+          onClose={dismiss}
+          status={params.status}
+          title={params.title}
+          duration={params.duration}
+          updatedAt={updatedAt}
+        />
+      ))}
+    </AnimatePresence>
+  )
+}
+
+ToastList.displayName = 'ToastList'

--- a/src/core/components/toast/toastProvider.tsx
+++ b/src/core/components/toast/toastProvider.tsx
@@ -1,20 +1,16 @@
-import {AnimatePresence} from 'motion/react'
-import {startTransition, useMemo, useState} from 'react'
+import {lazy, startTransition, Suspense, useMemo, useState} from 'react'
 
 import {useMounted} from '../../hooks/useMounted'
 import {LayerProvider} from '../../utils'
-import {Toast} from './toast'
 import {ToastContext} from './toastContext'
 import {ToastLayer, type ToastLayerProps} from './toastLayer'
+import type {ToastState} from './toastList'
 import {generateToastId} from './toastState'
 import {ToastContextValue, ToastParams} from './types'
 
-type ToastState = {
-  dismiss: () => void
-  id: string
-  updatedAt: number
-  params: ToastParams
-}[]
+const ToastList = lazy(() =>
+  import('./toastList').then((toastListModule) => ({default: toastListModule.ToastList})),
+)
 
 /**
  * @public
@@ -30,12 +26,17 @@ export interface ToastProviderProps extends Omit<ToastLayerProps, 'children'> {
 export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
   const {children, padding, paddingX, paddingY, gap, zOffset = 1} = props
   const [state, setState] = useState<ToastState>([])
+  // Latches to `true` on the first push, and deliberately never resets, so that the lazily
+  // loaded toast list stays mounted and can run exit animations for the last dismissed toast.
+  const [hasPushed, setHasPushed] = useState(false)
   const mounted = useMounted()
 
   const value: ToastContextValue = useMemo(() => {
     const push = (params: ToastParams) => {
       const id = params.id || generateToastId()
       const duration = params.duration || 5000
+
+      setHasPushed(true)
 
       startTransition(() => {
         setState((prevState): ToastState => {
@@ -89,20 +90,11 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
       {mounted && (
         <LayerProvider zOffset={zOffset}>
           <ToastLayer padding={padding} paddingX={paddingX} paddingY={paddingY} gap={gap}>
-            <AnimatePresence initial={false} mode="popLayout">
-              {state.map(({dismiss, id, params, updatedAt}) => (
-                <Toast
-                  key={id}
-                  closable={params.closable}
-                  description={params.description}
-                  onClose={dismiss}
-                  status={params.status}
-                  title={params.title}
-                  duration={params.duration}
-                  updatedAt={updatedAt}
-                />
-              ))}
-            </AnimatePresence>
+            {hasPushed && (
+              <Suspense fallback={null}>
+                <ToastList toasts={state} />
+              </Suspense>
+            )}
           </ToastLayer>
         </LayerProvider>
       )}

--- a/src/core/components/toast/toastProvider.tsx
+++ b/src/core/components/toast/toastProvider.tsx
@@ -36,20 +36,28 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
       const id = params.id || generateToastId()
       const duration = params.duration || 5000
 
+      /**
+       * Backwards compatibility for `sanity` patterns workaround a lack of programatically dismissible toasts.
+       * It uses a super short duration that closes the toast immediately in previous versions of `@sanity/ui`.
+       * We interpret this as a request to dismiss the toast immediately, and remove it from the state right away.
+       * Even once we support programatic dismissal we'll need to keep this for backwards compatibility with v2 and v1.
+       */
+      const isImmediateDismiss = duration === 0.01
+
+      if (isImmediateDismiss) {
+        startTransition(() => {
+          setState((prevState) => prevState.filter((toast) => toast.id !== id))
+        })
+
+        return id
+      }
+
+      // Latch only when a toast is genuinely added, so a programmatic dismiss does not
+      // eagerly mount the lazy motion-bearing toast list and defeat the deferred-load goal.
       setHasPushed(true)
 
       startTransition(() => {
         setState((prevState): ToastState => {
-          /**
-           * Backwards compatibility for `sanity` patterns workaround a lack of programatically dismissible toasts.
-           * It uses a super short duration that closes the toast immediately in previous versions of `@sanity/ui`.
-           * We interpret this as a request to dismiss the toast immediately, and remove it from the state right away.
-           * Even once we support programatic dismissal we'll need to keep this for backwards compatibility with v2 and v1.
-           */
-          if (duration === 0.01) {
-            return prevState.filter((toast) => toast.id !== id)
-          }
-
           /**
            * Creates a function to dismiss this specific toast.
            * This function will be passed to the Toast component

--- a/src/core/primitives/popover/popover.test.tsx
+++ b/src/core/primitives/popover/popover.test.tsx
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+
+import '../../../../test/mocks/resizeObserver.mock'
+import '../../../../test/mocks/matchMedia.mock'
+
+import {screen} from '@testing-library/react'
+
+import {render} from '../../../../test'
+import {Button, Text} from '../../primitives'
+import {Popover} from './popover'
+
+describe('Popover', () => {
+  it('should render the content when open (the popover card is lazy loaded on first open)', async () => {
+    render(
+      <Popover content={<Text size={1}>{'Popover content'}</Text>} open>
+        <Button mode="bleed" text="Reference" />
+      </Popover>,
+    )
+
+    // Validate popover content is rendered
+    await screen.findByText('Popover content')
+  })
+
+  it('should not render the content when closed', () => {
+    render(
+      <Popover content={<Text size={1}>{'Popover content'}</Text>}>
+        <Button mode="bleed" text="Reference" />
+      </Popover>,
+    )
+
+    expect(screen.queryByText('Popover content')).not.toBeInTheDocument()
+  })
+
+  it('should render the content when open and animated', async () => {
+    render(
+      <Popover animate content={<Text size={1}>{'Animated popover content'}</Text>} open>
+        <Button mode="bleed" text="Reference" />
+      </Popover>,
+    )
+
+    // Validate popover content is rendered
+    await screen.findByText('Animated popover content')
+  })
+})

--- a/src/core/primitives/popover/popover.test.tsx
+++ b/src/core/primitives/popover/popover.test.tsx
@@ -10,15 +10,16 @@ import {Button, Text} from '../../primitives'
 import {Popover} from './popover'
 
 describe('Popover', () => {
-  it('should render the content when open (the popover card is lazy loaded on first open)', async () => {
+  it('should render the content synchronously when open and not animated', () => {
     render(
       <Popover content={<Text size={1}>{'Popover content'}</Text>} open>
         <Button mode="bleed" text="Reference" />
       </Popover>,
     )
 
-    // Validate popover content is rendered
-    await screen.findByText('Popover content')
+    // Non-animated popovers must mount their content in the same commit that opens them, so
+    // listeners attached by the content (e.g. click-outside handling in `Menu`) work immediately.
+    screen.getByText('Popover content')
   })
 
   it('should not render the content when closed', () => {

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -41,17 +41,23 @@ import {
 } from './constants'
 import {size} from './floating-ui/size'
 import {calcCurrentWidth, calcMaxWidth} from './helpers'
+import {PopoverCard} from './popoverCard'
 import {PopoverUpdateCallback, PopoverWidth} from './types'
 
-// `popoverCard.tsx` is the only module in the popover graph that depends on `motion/react`.
-// Loading it (and `AnimatePresence`) lazily keeps the motion library out of the static module
-// graph, so it is only evaluated once a popover actually opens.
-const PopoverCard = lazy(() =>
-  import('./popoverCard').then((popoverCardModule) => ({default: popoverCardModule.PopoverCard})),
+// `popoverCardAnimated.tsx` is the only module in the popover graph that depends on
+// `motion/react`. Loading it (and `AnimatePresence`) lazily keeps the motion library out of the
+// static module graph, so it is only evaluated once an animated popover actually opens.
+// Non-animated popovers render the static `PopoverCard` synchronously, so popover content (and
+// any listeners it attaches, e.g. click-outside handling in `Menu`) mounts in the same commit
+// that opens the popover.
+const PopoverCardAnimated = lazy(() =>
+  import('./popoverCardAnimated').then((popoverCardModule) => ({
+    default: popoverCardModule.PopoverCardAnimated,
+  })),
 )
 
 const AnimatePresence = lazy(() =>
-  import('./popoverCard').then((popoverCardModule) => ({
+  import('./popoverCardAnimated').then((popoverCardModule) => ({
     default: popoverCardModule.AnimatePresence,
   })),
 )
@@ -341,39 +347,43 @@ export const Popover = forwardRef(function Popover(
     return childProp || <></>
   }
 
+  const CardComponent = animate ? PopoverCardAnimated : PopoverCard
+
+  const card = (
+    <CardComponent
+      {...restProps}
+      __unstable_margins={margins}
+      animate={animate}
+      arrow={arrowProp}
+      arrowRef={setArrow}
+      arrowX={arrowX}
+      arrowY={arrowY}
+      hidden={referenceHidden}
+      overflow={overflow}
+      padding={padding}
+      placement={placement}
+      radius={radius}
+      ref={setFloating}
+      scheme={scheme}
+      shadow={shadow}
+      originX={originX}
+      originY={originY}
+      strategy={strategy}
+      tone={tone}
+      width={matchReferenceWidth ? referenceWidth : width}
+      x={x}
+      y={y}
+    >
+      {content}
+    </CardComponent>
+  )
+
   const popover = (
     <LayerProvider zOffset={zOffset}>
       {/* Optional transparent blocking overlay at the top-most z-index layer. Must be positioned before the below popover card. */}
       {modal && <ViewportOverlay />}
 
-      <Suspense fallback={null}>
-        <PopoverCard
-          {...restProps}
-          __unstable_margins={margins}
-          animate={animate}
-          arrow={arrowProp}
-          arrowRef={setArrow}
-          arrowX={arrowX}
-          arrowY={arrowY}
-          hidden={referenceHidden}
-          overflow={overflow}
-          padding={padding}
-          placement={placement}
-          radius={radius}
-          ref={setFloating}
-          scheme={scheme}
-          shadow={shadow}
-          originX={originX}
-          originY={originY}
-          strategy={strategy}
-          tone={tone}
-          width={matchReferenceWidth ? referenceWidth : width}
-          x={x}
-          y={y}
-        >
-          {content}
-        </PopoverCard>
-      </Suspense>
+      {animate ? <Suspense fallback={null}>{card}</Suspense> : card}
     </LayerProvider>
   )
 

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -383,7 +383,7 @@ export const Popover = forwardRef(function Popover(
       {/* Optional transparent blocking overlay at the top-most z-index layer. Must be positioned before the below popover card. */}
       {modal && <ViewportOverlay />}
 
-      {animate ? <Suspense fallback={null}>{card}</Suspense> : card}
+      {card}
     </LayerProvider>
   )
 

--- a/src/core/primitives/popover/popover.tsx
+++ b/src/core/primitives/popover/popover.tsx
@@ -11,11 +11,12 @@ import {
   useFloating,
 } from '@floating-ui/react-dom'
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'
-import {AnimatePresence} from 'motion/react'
 import {
   cloneElement,
   forwardRef,
+  lazy,
   type Ref,
+  Suspense,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -40,8 +41,20 @@ import {
 } from './constants'
 import {size} from './floating-ui/size'
 import {calcCurrentWidth, calcMaxWidth} from './helpers'
-import {PopoverCard} from './popoverCard'
 import {PopoverUpdateCallback, PopoverWidth} from './types'
+
+// `popoverCard.tsx` is the only module in the popover graph that depends on `motion/react`.
+// Loading it (and `AnimatePresence`) lazily keeps the motion library out of the static module
+// graph, so it is only evaluated once a popover actually opens.
+const PopoverCard = lazy(() =>
+  import('./popoverCard').then((popoverCardModule) => ({default: popoverCardModule.PopoverCard})),
+)
+
+const AnimatePresence = lazy(() =>
+  import('./popoverCard').then((popoverCardModule) => ({
+    default: popoverCardModule.AnimatePresence,
+  })),
+)
 
 /** @public */
 export interface PopoverProps
@@ -185,6 +198,15 @@ export const Popover = forwardRef(function Popover(
   const zOffsetProp = _zOffsetProp ?? layer.popover.zOffset
   const prefersReducedMotion = usePrefersReducedMotion()
   const animate = prefersReducedMotion ? false : _animate
+
+  // Latches to `true` the first time an animated popover opens, and deliberately never resets,
+  // so that `AnimatePresence` only loads once needed but stays mounted to run exit animations.
+  const [hasOpenedAnimated, setHasOpenedAnimated] = useState(Boolean(animate && open))
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (animate && open) setHasOpenedAnimated(true)
+  }, [animate, open])
   const boundarySize = useElementSize(boundaryElement)?.border
   const padding = _getArrayProp(paddingProp)
   const radius = _getArrayProp(radiusProp)
@@ -324,32 +346,34 @@ export const Popover = forwardRef(function Popover(
       {/* Optional transparent blocking overlay at the top-most z-index layer. Must be positioned before the below popover card. */}
       {modal && <ViewportOverlay />}
 
-      <PopoverCard
-        {...restProps}
-        __unstable_margins={margins}
-        animate={animate}
-        arrow={arrowProp}
-        arrowRef={setArrow}
-        arrowX={arrowX}
-        arrowY={arrowY}
-        hidden={referenceHidden}
-        overflow={overflow}
-        padding={padding}
-        placement={placement}
-        radius={radius}
-        ref={setFloating}
-        scheme={scheme}
-        shadow={shadow}
-        originX={originX}
-        originY={originY}
-        strategy={strategy}
-        tone={tone}
-        width={matchReferenceWidth ? referenceWidth : width}
-        x={x}
-        y={y}
-      >
-        {content}
-      </PopoverCard>
+      <Suspense fallback={null}>
+        <PopoverCard
+          {...restProps}
+          __unstable_margins={margins}
+          animate={animate}
+          arrow={arrowProp}
+          arrowRef={setArrow}
+          arrowX={arrowX}
+          arrowY={arrowY}
+          hidden={referenceHidden}
+          overflow={overflow}
+          padding={padding}
+          placement={placement}
+          radius={radius}
+          ref={setFloating}
+          scheme={scheme}
+          shadow={shadow}
+          originX={originX}
+          originY={originY}
+          strategy={strategy}
+          tone={tone}
+          width={matchReferenceWidth ? referenceWidth : width}
+          x={x}
+          y={y}
+        >
+          {content}
+        </PopoverCard>
+      </Suspense>
     </LayerProvider>
   )
 
@@ -364,7 +388,13 @@ export const Popover = forwardRef(function Popover(
   return (
     <>
       {/* the popover */}
-      {animate ? <AnimatePresence>{children}</AnimatePresence> : children}
+      {animate
+        ? hasOpenedAnimated && (
+            <Suspense fallback={null}>
+              <AnimatePresence>{children}</AnimatePresence>
+            </Suspense>
+          )
+        : children}
 
       {/* the referred element */}
       {child}

--- a/src/core/primitives/popover/popoverCard.tsx
+++ b/src/core/primitives/popover/popoverCard.tsx
@@ -1,10 +1,8 @@
 import {Strategy} from '@floating-ui/react-dom'
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'
-import {motion, type MotionProps} from 'motion/react'
 import React, {CSSProperties, forwardRef, useMemo} from 'react'
 import {styled} from 'styled-components'
 
-import {POPOVER_MOTION_PROPS} from '../../constants'
 import {BoxOverflow, CardTone, Placement, PopoverMargins, Radius} from '../../types'
 import {Arrow, useLayer} from '../../utils'
 import {Card, CardProps} from '../card'
@@ -15,50 +13,56 @@ import {
   DEFAULT_POPOVER_ARROW_WIDTH,
   DEFAULT_POPOVER_MARGINS,
 } from './constants'
+import {popoverCardStyle, popoverWrapperStyle} from './popoverCardStyles'
 
-// Re-exported so `popover.tsx` can lazily load `AnimatePresence` from the same chunk as this
-// module, avoiding both a static `motion/react` import and a second chunk request.
-export {AnimatePresence} from 'motion/react'
-
-const MotionCard = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Card))`
-  &:not([hidden]) {
-    display: flex;
-  }
-  flex-direction: column;
-  width: max-content;
-  min-width: min-content;
-  will-change: transform;
+const StyledCard = /* @__PURE__ */ styled(Card)`
+  ${popoverCardStyle}
 `
 
-const MotionFlex = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Flex))`
-  will-change: opacity;
+const StyledFlex = /* @__PURE__ */ styled(Flex)`
+  ${popoverWrapperStyle}
 `
 
 /**
  * @internal
  */
-export const PopoverCard = forwardRef(function PopoverCard(
-  props: {
-    /** @beta*/
-    __unstable_margins?: PopoverMargins
-    animate?: boolean
-    arrow: boolean
-    arrowRef: React.Ref<HTMLDivElement>
-    arrowX?: number
-    arrowY?: number
-    originX?: number
-    originY?: number
-    overflow?: BoxOverflow
-    padding?: number | number[]
-    placement: Placement
-    radius?: Radius | Radius[]
-    scheme?: ThemeColorSchemeKey
-    shadow?: number | number[]
-    strategy: Strategy
-    tone: CardTone
-    width: number | undefined
-    x: number | null
-    y: number | null
+export interface PopoverCardProps {
+  /** @beta*/
+  __unstable_margins?: PopoverMargins
+  animate?: boolean
+  arrow: boolean
+  arrowRef: React.Ref<HTMLDivElement>
+  arrowX?: number
+  arrowY?: number
+  originX?: number
+  originY?: number
+  overflow?: BoxOverflow
+  padding?: number | number[]
+  placement: Placement
+  radius?: Radius | Radius[]
+  scheme?: ThemeColorSchemeKey
+  shadow?: number | number[]
+  strategy: Strategy
+  tone: CardTone
+  width: number | undefined
+  x: number | null
+  y: number | null
+}
+
+/**
+ * Layout shared by the static `PopoverCard` and the motion-wrapped card in
+ * `popoverCardAnimated.tsx`. The root and wrapper components (and their extra props) are
+ * injected, so the motion variant can pass `motion/react` components without this module
+ * depending on them.
+ *
+ * @internal
+ */
+export const PopoverCardLayout = forwardRef(function PopoverCardLayout(
+  props: PopoverCardProps & {
+    cardComponent?: React.ElementType
+    cardProps?: Record<string, unknown>
+    flexComponent?: React.ElementType
+    flexProps?: Record<string, unknown>
   } & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
@@ -69,7 +73,11 @@ export const PopoverCard = forwardRef(function PopoverCard(
     arrowRef,
     arrowX,
     arrowY,
+    cardComponent: CardComponent = StyledCard,
+    cardProps,
     children,
+    flexComponent: FlexComponent = StyledFlex,
+    flexProps,
     padding,
     placement,
     originX,
@@ -125,9 +133,10 @@ export const PopoverCard = forwardRef(function PopoverCard(
   )
 
   return (
-    <MotionCard
+    <CardComponent
       data-ui="Popover"
-      {...(restProps as CardProps & MotionProps)}
+      {...(restProps as CardProps)}
+      {...cardProps}
       data-placement={placement}
       radius={radius}
       ref={ref}
@@ -136,24 +145,18 @@ export const PopoverCard = forwardRef(function PopoverCard(
       sizing="border"
       style={rootStyle}
       tone={tone}
-      variants={POPOVER_MOTION_PROPS.card}
-      transition={POPOVER_MOTION_PROPS.transition}
-      initial={animate ? ['hidden', 'initial'] : undefined}
-      animate={animate ? ['visible', 'scaleIn'] : undefined}
-      exit={animate ? ['hidden', 'scaleOut'] : undefined}
     >
-      <MotionFlex
+      <FlexComponent
         data-ui="Popover__wrapper"
+        {...flexProps}
         direction="column"
         flex={1}
         overflow={overflow}
-        variants={POPOVER_MOTION_PROPS.children}
-        transition={POPOVER_MOTION_PROPS.transition}
       >
         <Flex direction="column" flex={1} padding={padding}>
           {children}
         </Flex>
-      </MotionFlex>
+      </FlexComponent>
 
       {arrow && (
         <Arrow
@@ -164,7 +167,22 @@ export const PopoverCard = forwardRef(function PopoverCard(
           radius={DEFAULT_POPOVER_ARROW_RADIUS}
         />
       )}
-    </MotionCard>
+    </CardComponent>
   )
+})
+PopoverCardLayout.displayName = 'ForwardRef(PopoverCardLayout)'
+
+/**
+ * Static, motion-free popover card. Rendered synchronously when the popover is not animated, so
+ * popover content (and any listeners it attaches, e.g. click-outside handling in `Menu`) mounts
+ * in the same commit that opens the popover.
+ *
+ * @internal
+ */
+export const PopoverCard = forwardRef(function PopoverCard(
+  props: PopoverCardProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  return <PopoverCardLayout {...props} ref={ref} />
 })
 PopoverCard.displayName = 'ForwardRef(PopoverCard)'

--- a/src/core/primitives/popover/popoverCard.tsx
+++ b/src/core/primitives/popover/popoverCard.tsx
@@ -16,7 +16,11 @@ import {
   DEFAULT_POPOVER_MARGINS,
 } from './constants'
 
-const MotionCard = styled(motion.create(Card))`
+// Re-exported so `popover.tsx` can lazily load `AnimatePresence` from the same chunk as this
+// module, avoiding both a static `motion/react` import and a second chunk request.
+export {AnimatePresence} from 'motion/react'
+
+const MotionCard = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Card))`
   &:not([hidden]) {
     display: flex;
   }
@@ -26,7 +30,7 @@ const MotionCard = styled(motion.create(Card))`
   will-change: transform;
 `
 
-const MotionFlex = styled(motion.create(Flex))`
+const MotionFlex = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Flex))`
   will-change: opacity;
 `
 

--- a/src/core/primitives/popover/popoverCardAnimated.tsx
+++ b/src/core/primitives/popover/popoverCardAnimated.tsx
@@ -1,0 +1,65 @@
+import {motion} from 'motion/react'
+import React, {forwardRef, useMemo} from 'react'
+import {styled} from 'styled-components'
+
+import {POPOVER_MOTION_PROPS} from '../../constants'
+import {Card} from '../card'
+import {Flex} from '../flex'
+import {PopoverCardLayout, type PopoverCardProps} from './popoverCard'
+import {popoverCardStyle, popoverWrapperStyle} from './popoverCardStyles'
+
+// Re-exported so `popover.tsx` can lazily load `AnimatePresence` from the same chunk as this
+// module, avoiding both a static `motion/react` import and a second chunk request.
+export {AnimatePresence} from 'motion/react'
+
+const MotionCard = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Card))`
+  ${popoverCardStyle}
+`
+
+const MotionFlex = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Flex))`
+  ${popoverWrapperStyle}
+`
+
+/**
+ * Motion-wrapped popover card, kept in its own lazily loaded chunk so `motion/react` is only
+ * evaluated once an animated popover opens.
+ *
+ * @internal
+ */
+export const PopoverCardAnimated = forwardRef(function PopoverCardAnimated(
+  props: PopoverCardProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {animate} = props
+
+  const cardProps = useMemo(
+    () => ({
+      variants: POPOVER_MOTION_PROPS.card,
+      transition: POPOVER_MOTION_PROPS.transition,
+      initial: animate ? ['hidden', 'initial'] : undefined,
+      animate: animate ? ['visible', 'scaleIn'] : undefined,
+      exit: animate ? ['hidden', 'scaleOut'] : undefined,
+    }),
+    [animate],
+  )
+
+  const flexProps = useMemo(
+    () => ({
+      variants: POPOVER_MOTION_PROPS.children,
+      transition: POPOVER_MOTION_PROPS.transition,
+    }),
+    [],
+  )
+
+  return (
+    <PopoverCardLayout
+      {...props}
+      cardComponent={MotionCard}
+      cardProps={cardProps}
+      flexComponent={MotionFlex}
+      flexProps={flexProps}
+      ref={ref}
+    />
+  )
+})
+PopoverCardAnimated.displayName = 'ForwardRef(PopoverCardAnimated)'

--- a/src/core/primitives/popover/popoverCardStyles.ts
+++ b/src/core/primitives/popover/popoverCardStyles.ts
@@ -1,0 +1,22 @@
+import {css} from 'styled-components'
+
+/**
+ * Shared between the static root in `popoverCard.tsx` and the motion-wrapped root in
+ * `popoverCardAnimated.tsx`, so both render identically.
+ *
+ * @internal
+ */
+export const popoverCardStyle = css`
+  &:not([hidden]) {
+    display: flex;
+  }
+  flex-direction: column;
+  width: max-content;
+  min-width: min-content;
+  will-change: transform;
+`
+
+/** @internal */
+export const popoverWrapperStyle = css`
+  will-change: opacity;
+`

--- a/src/core/primitives/tooltip/tooltip.test.tsx
+++ b/src/core/primitives/tooltip/tooltip.test.tsx
@@ -21,7 +21,7 @@ afterEach(() => {
 
 describe('Tooltip', () => {
   describe('Using same delay for open and close', () => {
-    it('should hide and show the tooltip content when hovered, with no delay', async () => {
+    it('should hide and show the tooltip content when hovered, with no delay', () => {
       render(
         <Tooltip content={<Text size={1}>{'Tooltip content'}</Text>} placement={'top'}>
           <Button mode="bleed" text="Hover me" />
@@ -35,8 +35,8 @@ describe('Tooltip', () => {
 
       fireEvent.mouseEnter(button)
 
-      // Validate tooltip content is rendered (the tooltip card module is lazy loaded on first use)
-      await screen.findByText('Tooltip content')
+      // Validate tooltip content is rendered synchronously (non-animated tooltips do not lazy load)
+      screen.getByText('Tooltip content')
 
       fireEvent.mouseOut(button)
       // Validate tooltip content is not rendered anymore

--- a/src/core/primitives/tooltip/tooltip.test.tsx
+++ b/src/core/primitives/tooltip/tooltip.test.tsx
@@ -21,7 +21,7 @@ afterEach(() => {
 
 describe('Tooltip', () => {
   describe('Using same delay for open and close', () => {
-    it('should hide and show the tooltip content when hovered, with no delay', () => {
+    it('should hide and show the tooltip content when hovered, with no delay', async () => {
       render(
         <Tooltip content={<Text size={1}>{'Tooltip content'}</Text>} placement={'top'}>
           <Button mode="bleed" text="Hover me" />
@@ -35,8 +35,8 @@ describe('Tooltip', () => {
 
       fireEvent.mouseEnter(button)
 
-      // Validate tooltip content is rendered
-      screen.getByText('Tooltip content')
+      // Validate tooltip content is rendered (the tooltip card module is lazy loaded on first use)
+      await screen.findByText('Tooltip content')
 
       fireEvent.mouseOut(button)
       // Validate tooltip content is not rendered anymore

--- a/src/core/primitives/tooltip/tooltip.tsx
+++ b/src/core/primitives/tooltip/tooltip.tsx
@@ -9,10 +9,11 @@ import {
   useFloating,
 } from '@floating-ui/react-dom'
 import type {ThemeColorSchemeKey} from '@sanity/ui/theme'
-import {AnimatePresence} from 'motion/react'
 import {
   cloneElement,
   forwardRef,
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useId,
@@ -39,8 +40,20 @@ import {
   DEFAULT_TOOLTIP_DISTANCE,
   DEFAULT_TOOLTIP_PADDING,
 } from './constants'
-import {TooltipCard} from './tooltipCard'
 import {useTooltipDelayGroup} from './tooltipDelayGroup'
+
+// `tooltipCard.tsx` is the only module in the tooltip graph that depends on `motion/react`.
+// Loading it (and `AnimatePresence`) lazily keeps the motion library out of the static module
+// graph, so it is only evaluated once a tooltip actually shows.
+const TooltipCard = lazy(() =>
+  import('./tooltipCard').then((tooltipCardModule) => ({default: tooltipCardModule.TooltipCard})),
+)
+
+const AnimatePresence = lazy(() =>
+  import('./tooltipCard').then((tooltipCardModule) => ({
+    default: tooltipCardModule.AnimatePresence,
+  })),
+)
 
 /**
  * @public
@@ -121,6 +134,10 @@ export const Tooltip = forwardRef(function Tooltip(
   const prefersReducedMotion = usePrefersReducedMotion()
   const animate = prefersReducedMotion ? false : _animate
   const fallbackPlacements = _getArrayProp(fallbackPlacementsProp)
+
+  // Latches to `true` the first time an animated tooltip shows, and deliberately never resets,
+  // so that `AnimatePresence` only loads once needed but stays mounted to run exit animations.
+  const [hasShownAnimated, setHasShownAnimated] = useState(false)
   const ref = useRef<HTMLDivElement | null>(null)
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
   const arrowRef = useRef<HTMLDivElement | null>(null)
@@ -160,6 +177,11 @@ export const Tooltip = forwardRef(function Tooltip(
   const delayGroupContext = useTooltipDelayGroup()
   const {setIsGroupActive, setOpenTooltipId} = delayGroupContext || {}
   const showTooltip = isOpen || delayGroupContext?.openTooltipId === tooltipId
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (animate && showTooltip) setHasShownAnimated(true)
+  }, [animate, showTooltip])
 
   const isInsideGroup = delayGroupContext !== null
   const openDelayProp = typeof delay === 'number' ? delay : delay?.open || 0
@@ -349,24 +371,26 @@ export const Tooltip = forwardRef(function Tooltip(
       }}
       zOffset={zOffset}
     >
-      <TooltipCard
-        {...restProps}
-        animate={animate}
-        arrow={arrowProp}
-        arrowRef={setArrow}
-        arrowX={arrowX}
-        arrowY={arrowY}
-        originX={originX}
-        originY={originY}
-        padding={padding}
-        placement={placement}
-        radius={radius}
-        ref={setFloating}
-        scheme={scheme}
-        shadow={shadow}
-      >
-        {content}
-      </TooltipCard>
+      <Suspense fallback={null}>
+        <TooltipCard
+          {...restProps}
+          animate={animate}
+          arrow={arrowProp}
+          arrowRef={setArrow}
+          arrowX={arrowX}
+          arrowY={arrowY}
+          originX={originX}
+          originY={originY}
+          padding={padding}
+          placement={placement}
+          radius={radius}
+          ref={setFloating}
+          scheme={scheme}
+          shadow={shadow}
+        >
+          {content}
+        </TooltipCard>
+      </Suspense>
     </StyledTooltip>
   )
 
@@ -383,7 +407,13 @@ export const Tooltip = forwardRef(function Tooltip(
   return (
     <>
       {/* the tooltip */}
-      {animate ? <AnimatePresence>{children}</AnimatePresence> : children}
+      {animate
+        ? hasShownAnimated && (
+            <Suspense fallback={null}>
+              <AnimatePresence>{children}</AnimatePresence>
+            </Suspense>
+          )
+        : children}
 
       {/* the referred element */}
       {child}

--- a/src/core/primitives/tooltip/tooltip.tsx
+++ b/src/core/primitives/tooltip/tooltip.tsx
@@ -142,6 +142,7 @@ export const Tooltip = forwardRef(function Tooltip(
 
   // Latches to `true` the first time an animated tooltip shows, and deliberately never resets,
   // so that `AnimatePresence` only loads once needed but stays mounted to run exit animations.
+  // Unlike popover, seeds `false`: a tooltip is hover/focus-driven, so it is never open at mount.
   const [hasShownAnimated, setHasShownAnimated] = useState(false)
   const ref = useRef<HTMLDivElement | null>(null)
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
@@ -399,7 +400,7 @@ export const Tooltip = forwardRef(function Tooltip(
       }}
       zOffset={zOffset}
     >
-      {animate ? <Suspense fallback={null}>{card}</Suspense> : card}
+      {card}
     </StyledTooltip>
   )
 

--- a/src/core/primitives/tooltip/tooltip.tsx
+++ b/src/core/primitives/tooltip/tooltip.tsx
@@ -40,17 +40,22 @@ import {
   DEFAULT_TOOLTIP_DISTANCE,
   DEFAULT_TOOLTIP_PADDING,
 } from './constants'
+import {TooltipCard} from './tooltipCard'
 import {useTooltipDelayGroup} from './tooltipDelayGroup'
 
-// `tooltipCard.tsx` is the only module in the tooltip graph that depends on `motion/react`.
-// Loading it (and `AnimatePresence`) lazily keeps the motion library out of the static module
-// graph, so it is only evaluated once a tooltip actually shows.
-const TooltipCard = lazy(() =>
-  import('./tooltipCard').then((tooltipCardModule) => ({default: tooltipCardModule.TooltipCard})),
+// `tooltipCardAnimated.tsx` is the only module in the tooltip graph that depends on
+// `motion/react`. Loading it (and `AnimatePresence`) lazily keeps the motion library out of the
+// static module graph, so it is only evaluated once an animated tooltip actually shows.
+// Non-animated tooltips render the static `TooltipCard` synchronously, so tooltip content mounts
+// in the same commit that shows the tooltip.
+const TooltipCardAnimated = lazy(() =>
+  import('./tooltipCardAnimated').then((tooltipCardModule) => ({
+    default: tooltipCardModule.TooltipCardAnimated,
+  })),
 )
 
 const AnimatePresence = lazy(() =>
-  import('./tooltipCard').then((tooltipCardModule) => ({
+  import('./tooltipCardAnimated').then((tooltipCardModule) => ({
     default: tooltipCardModule.AnimatePresence,
   })),
 )
@@ -360,6 +365,29 @@ export const Tooltip = forwardRef(function Tooltip(
 
   if (disabled) return child
 
+  const CardComponent = animate ? TooltipCardAnimated : TooltipCard
+
+  const card = (
+    <CardComponent
+      {...restProps}
+      animate={animate}
+      arrow={arrowProp}
+      arrowRef={setArrow}
+      arrowX={arrowX}
+      arrowY={arrowY}
+      originX={originX}
+      originY={originY}
+      padding={padding}
+      placement={placement}
+      radius={radius}
+      ref={setFloating}
+      scheme={scheme}
+      shadow={shadow}
+    >
+      {content}
+    </CardComponent>
+  )
+
   const tooltip = (
     <StyledTooltip
       data-ui="Tooltip"
@@ -371,26 +399,7 @@ export const Tooltip = forwardRef(function Tooltip(
       }}
       zOffset={zOffset}
     >
-      <Suspense fallback={null}>
-        <TooltipCard
-          {...restProps}
-          animate={animate}
-          arrow={arrowProp}
-          arrowRef={setArrow}
-          arrowX={arrowX}
-          arrowY={arrowY}
-          originX={originX}
-          originY={originY}
-          padding={padding}
-          placement={placement}
-          radius={radius}
-          ref={setFloating}
-          scheme={scheme}
-          shadow={shadow}
-        >
-          {content}
-        </TooltipCard>
-      </Suspense>
+      {animate ? <Suspense fallback={null}>{card}</Suspense> : card}
     </StyledTooltip>
   )
 

--- a/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/src/core/primitives/tooltip/tooltipCard.tsx
@@ -13,7 +13,11 @@ import {
   DEFAULT_TOOLTIP_ARROW_WIDTH,
 } from './constants'
 
-const MotionCard = styled(motion.create(Card))`
+// Re-exported so `tooltip.tsx` can lazily load `AnimatePresence` from the same chunk as this
+// module, avoiding both a static `motion/react` import and a second chunk request.
+export {AnimatePresence} from 'motion/react'
+
+const MotionCard = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Card))`
   will-change: transform;
 `
 

--- a/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/src/core/primitives/tooltip/tooltipCard.tsx
@@ -1,9 +1,7 @@
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'
-import {motion, type MotionProps} from 'motion/react'
 import React, {CSSProperties, forwardRef, useMemo} from 'react'
 import {styled} from 'styled-components'
 
-import {POPOVER_MOTION_PROPS} from '../../constants'
 import {Placement, Radius} from '../../types'
 import {Arrow} from '../../utils'
 import {Card, CardProps} from '../card'
@@ -12,32 +10,41 @@ import {
   DEFAULT_TOOLTIP_ARROW_RADIUS,
   DEFAULT_TOOLTIP_ARROW_WIDTH,
 } from './constants'
+import {tooltipCardStyle} from './tooltipCardStyles'
 
-// Re-exported so `tooltip.tsx` can lazily load `AnimatePresence` from the same chunk as this
-// module, avoiding both a static `motion/react` import and a second chunk request.
-export {AnimatePresence} from 'motion/react'
-
-const MotionCard = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Card))`
-  will-change: transform;
+const StyledCard = /* @__PURE__ */ styled(Card)`
+  ${tooltipCardStyle}
 `
 
 /**
  * @internal
  */
-export const TooltipCard = forwardRef(function TooltipCard(
-  props: {
-    animate?: boolean
-    arrow: boolean
-    arrowRef: React.Ref<HTMLDivElement>
-    arrowX?: number
-    arrowY?: number
-    originX?: number
-    originY?: number
-    padding?: number | number[]
-    placement?: Placement
-    radius?: Radius | Radius[]
-    scheme?: ThemeColorSchemeKey
-    shadow?: number | number[]
+export interface TooltipCardProps {
+  animate?: boolean
+  arrow: boolean
+  arrowRef: React.Ref<HTMLDivElement>
+  arrowX?: number
+  arrowY?: number
+  originX?: number
+  originY?: number
+  padding?: number | number[]
+  placement?: Placement
+  radius?: Radius | Radius[]
+  scheme?: ThemeColorSchemeKey
+  shadow?: number | number[]
+}
+
+/**
+ * Layout shared by the static `TooltipCard` and the motion-wrapped card in
+ * `tooltipCardAnimated.tsx`. The root component (and its extra props) is injected, so the motion
+ * variant can pass a `motion/react` component without this module depending on it.
+ *
+ * @internal
+ */
+export const TooltipCardLayout = forwardRef(function TooltipCardLayout(
+  props: TooltipCardProps & {
+    cardComponent?: React.ElementType
+    cardProps?: Record<string, unknown>
   } & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
@@ -47,6 +54,8 @@ export const TooltipCard = forwardRef(function TooltipCard(
     arrowRef,
     arrowX,
     arrowY,
+    cardComponent: CardComponent = StyledCard,
+    cardProps,
     children,
     originX,
     originY,
@@ -80,9 +89,10 @@ export const TooltipCard = forwardRef(function TooltipCard(
   )
 
   return (
-    <MotionCard
+    <CardComponent
       data-ui="Tooltip__card"
-      {...(restProps as CardProps & MotionProps)}
+      {...(restProps as CardProps)}
+      {...cardProps}
       data-placement={placement}
       padding={padding}
       radius={radius}
@@ -90,11 +100,6 @@ export const TooltipCard = forwardRef(function TooltipCard(
       scheme={scheme}
       shadow={shadow}
       style={rootStyle}
-      variants={POPOVER_MOTION_PROPS.card}
-      transition={POPOVER_MOTION_PROPS.transition}
-      initial={animate ? ['hidden', 'initial'] : undefined}
-      animate={animate ? ['visible', 'scaleIn'] : undefined}
-      exit={animate ? ['hidden', 'scaleOut'] : undefined}
     >
       {children}
 
@@ -107,7 +112,21 @@ export const TooltipCard = forwardRef(function TooltipCard(
           radius={DEFAULT_TOOLTIP_ARROW_RADIUS}
         />
       )}
-    </MotionCard>
+    </CardComponent>
   )
+})
+TooltipCardLayout.displayName = 'ForwardRef(TooltipCardLayout)'
+
+/**
+ * Static, motion-free tooltip card. Rendered synchronously when the tooltip is not animated, so
+ * tooltip content mounts in the same commit that shows the tooltip.
+ *
+ * @internal
+ */
+export const TooltipCard = forwardRef(function TooltipCard(
+  props: TooltipCardProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  return <TooltipCardLayout {...props} ref={ref} />
 })
 TooltipCard.displayName = 'ForwardRef(TooltipCard)'

--- a/src/core/primitives/tooltip/tooltipCardAnimated.tsx
+++ b/src/core/primitives/tooltip/tooltipCardAnimated.tsx
@@ -1,0 +1,43 @@
+import {motion} from 'motion/react'
+import React, {forwardRef, useMemo} from 'react'
+import {styled} from 'styled-components'
+
+import {POPOVER_MOTION_PROPS} from '../../constants'
+import {Card} from '../card'
+import {TooltipCardLayout, type TooltipCardProps} from './tooltipCard'
+import {tooltipCardStyle} from './tooltipCardStyles'
+
+// Re-exported so `tooltip.tsx` can lazily load `AnimatePresence` from the same chunk as this
+// module, avoiding both a static `motion/react` import and a second chunk request.
+export {AnimatePresence} from 'motion/react'
+
+const MotionCard = /* @__PURE__ */ styled(/* @__PURE__ */ motion.create(Card))`
+  ${tooltipCardStyle}
+`
+
+/**
+ * Motion-wrapped tooltip card, kept in its own lazily loaded chunk so `motion/react` is only
+ * evaluated once an animated tooltip shows.
+ *
+ * @internal
+ */
+export const TooltipCardAnimated = forwardRef(function TooltipCardAnimated(
+  props: TooltipCardProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'width'>,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {animate} = props
+
+  const cardProps = useMemo(
+    () => ({
+      variants: POPOVER_MOTION_PROPS.card,
+      transition: POPOVER_MOTION_PROPS.transition,
+      initial: animate ? ['hidden', 'initial'] : undefined,
+      animate: animate ? ['visible', 'scaleIn'] : undefined,
+      exit: animate ? ['hidden', 'scaleOut'] : undefined,
+    }),
+    [animate],
+  )
+
+  return <TooltipCardLayout {...props} cardComponent={MotionCard} cardProps={cardProps} ref={ref} />
+})
+TooltipCardAnimated.displayName = 'ForwardRef(TooltipCardAnimated)'

--- a/src/core/primitives/tooltip/tooltipCardStyles.ts
+++ b/src/core/primitives/tooltip/tooltipCardStyles.ts
@@ -1,0 +1,11 @@
+import {css} from 'styled-components'
+
+/**
+ * Shared between the static root in `tooltipCard.tsx` and the motion-wrapped root in
+ * `tooltipCardAnimated.tsx`, so both render identically.
+ *
+ * @internal
+ */
+export const tooltipCardStyle = css`
+  will-change: transform;
+`


### PR DESCRIPTION
### Description

@sanity/ui pulls `motion/react` (framer-motion) into its static module graph: Toast, Popover and Tooltip import `motion`/`AnimatePresence` and build motion components at module scope. So every consumer of any @sanity/ui primitive evaluates the whole framer-motion/motion-dom graph at module-eval time, even when it never renders an animated component - wasted main-thread work on the startup path.

This PR keeps `motion/react` out of the static graph and lazy-loads it on first actual use (first toast pushed, first `animate` popover opened, first `animate` tooltip shown). The non-animated default renders a static, motion-free card synchronously, so content (and any listeners it attaches, e.g. `Menu`/`MenuButton` click-outside handling) mounts in the same commit, exactly as before. A never-resetting latch keeps the lazy component mounted after first use so exit animations keep working. The toast latch only flips on a genuine push - a programmatic dismiss (`duration === 0.01`) no longer loads the chunk.

### Why we're confident motion is actually deferred

- Built entries (`dist/index.mjs` / `index.js`) contain zero static `motion/react` imports (they had one before). Motion appears only in four chunks - `popoverCardAnimated`, `tooltipCardAnimated`, `toastCard`, `toastList` - each reached purely via dynamic `import()`, which is the lazy load. A consumer that never animates never fetches or evaluates motion.
- An ESLint guard forbids runtime imports of `motion/react`/`motion-dom`/`framer-motion` (including subpaths and alternate entrypoints such as `motion/react/dist/...`, `motion/mini`, `framer-motion/dom`) anywhere except those four chunk modules, so a future static import fails lint instead of silently re-introducing the cost.
- New tests assert the non-animated path mounts synchronously and the lazy paths resolve on first animated use.
- Static package bytes drop 352,263 -> 348,295; the expensive motion-dom/framer-motion evaluation is fully deferred.

### Why we're confident there's no regression

- Public `dist/index.d.ts` is byte-identical to a same-toolchain `main` build except 3 added doc-comment lines: no added or removed exports, no prop/ref/signature changes. This change is import-graph-only, not an API change.
- Full unit suite green (43 suites / 129 tests), plus `tsc` and lint.
- Full cypress suite green locally (22 tests / 8 specs), including the `MenuButton` open/close-on-outside-click flow - the behaviour that depends on synchronous popover content mounting, and the regression this PR specifically fixes.
- An independent adversarial review (a blind reviewer with no knowledge of the rationale, followed by informed triage) surfaced and resolved the real items, including the toast dismiss eager-load and a subpath gap in the lint guard.

### Caveats

- The first-ever toast render, and the first-ever `animate` popover/tooltip render, resolve one microtask plus one same-bundle chunk fetch later than before; subsequent renders are synchronous. Non-animated popovers/tooltips are unaffected.
- `renderToString` of an initially-open `animate` Popover/Tooltip emits the Suspense fallback instead of the card markup (toasts were already client-only via `useMounted`). Non-animated popovers/tooltips SSR exactly as before. Narrow SSR edge case, flagged for reviewer judgment.


### How this fits

Part of the sanity studio startup performance effort. The studio's login screen renders @sanity/ui pre-auth, so this package's static motion import puts ~456KB of motion/motion-dom into every studio's eager bundle. Important: this fix pays off only TOGETHER with the studio-side work to defer the post-auth UI (in progress in sanity-io/sanity) - verified on a real studio build that this PR alone changes nothing there, because packages/sanity's own post-auth code re-imports motion/react; once that code is deferred, this PR is what keeps motion out for good. Same fix on the v4 line: #2207. The red e2e checks are a shared-workflow infra issue, fixed by https://github.com/sanity-io/sanity/pull/13084.
