### PR TITLE
perf: lazy load motion/react in Toast, Popover and Tooltip

### DIFF
--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -156,22 +156,28 @@ export default defineConfig(import.meta.dirname, [
       '@typescript-eslint/no-restricted-imports': [
         'error',
         {
-          name: 'motion/react',
-          allowTypeImports: true,
-          message:
-            'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
-        },
-        {
-          name: 'motion-dom',
-          allowTypeImports: true,
-          message:
-            'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
-        },
-        {
-          name: 'framer-motion',
-          allowTypeImports: true,
-          message:
-            'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+          patterns: [
+            {
+              // Matches `motion`, `motion/react`, `motion/mini`, `motion/react-client`,
+              // `motion/react/dist/...` and every other subpath/entrypoint.
+              regex: '^motion(/.*)?$',
+              allowTypeImports: true,
+              message:
+                'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+            },
+            {
+              regex: '^motion-dom(/.*)?$',
+              allowTypeImports: true,
+              message:
+                'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+            },
+            {
+              regex: '^framer-motion(/.*)?$',
+              allowTypeImports: true,
+              message:
+                'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+            },
+          ],
         },
       ],
     },

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -145,4 +145,46 @@ export default defineConfig(import.meta.dirname, [
       'boundaries/no-private': 'off',
     },
   },
+
+  // Keep `motion/react` (framer-motion / motion-dom) out of the static module graph. Runtime
+  // imports are blocked everywhere; type-only imports are allowed (they erase at build). The lazy
+  // chunk modules below are the only places motion may be imported at runtime, reached only via
+  // `React.lazy(() => import(...))`.
+  {
+    files: ['**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          name: 'motion/react',
+          allowTypeImports: true,
+          message:
+            'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+        },
+        {
+          name: 'motion-dom',
+          allowTypeImports: true,
+          message:
+            'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+        },
+        {
+          name: 'framer-motion',
+          allowTypeImports: true,
+          message:
+            'Do not import motion at runtime. Import it only from the lazy-loaded chunk modules so it stays out of the static module graph. Type-only imports are allowed.',
+        },
+      ],
+    },
+  },
+
+  // Whitelist the lazy chunk files (reached only via React.lazy()).
+  {
+    files: [
+      'src/primitives/popover/PopoverLayerAnimated.tsx',
+      'src/primitives/tooltip/TooltipLayerAnimated.tsx',
+      'src/components/toast/ToastCard.tsx',
+      'src/components/toast/ToastList.tsx',
+    ],
+    rules: {'@typescript-eslint/no-restricted-imports': 'off'},
+  },
 ])

--- a/packages/ui/src/components/toast/Toast.tsx
+++ b/packages/ui/src/components/toast/Toast.tsx
@@ -1,16 +1,7 @@
-import {CloseIcon} from '@sanity/icons'
-import {type RadiusStyleProps, toast} from '@sanity/ui-css'
-import {motion, type Variant, type Variants} from 'motion/react'
-import {type ReactNode} from 'react'
+import {type RadiusStyleProps} from '@sanity/ui-css'
+import {lazy, type ReactNode, Suspense} from 'react'
 
 import type {ComponentType, Props} from '../../core/types'
-import {usePrefersReducedMotion} from '../../hooks/usePrefersReducedMotion'
-import {Box} from '../../primitives/box/Box'
-import {Button} from '../../primitives/button/Button'
-import {Card} from '../../primitives/card/Card'
-import {Flex} from '../../primitives/flex/Flex'
-import {Stack} from '../../primitives/stack/Stack'
-import {Text} from '../../primitives/text/Text'
 
 /** @internal */
 export const DEFAULT_TOAST_ELEMENT = 'li'
@@ -31,161 +22,26 @@ export type ToastElementType = 'li' | ComponentType
 /** @internal */
 export type ToastProps<E extends ToastElementType = ToastElementType> = Props<ToastOwnProps, E>
 
-// Support pattern used by Sanity Studio, that works around the lack of `duration: Infinity` support in older @sanity/ui versions
-// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
-const LONG_ENOUGH_BUT_NOT_TOO_LONG = 1000 * 60 * 60 * 24 * 24
-
-const ROLES = {
-  error: 'alert',
-  warning: 'alert',
-  success: 'alert',
-  info: 'alert',
-} as const
-
-const STATUS_CARD_TONE = {
-  error: 'critical',
-  warning: 'caution',
-  success: 'positive',
-  info: 'neutral',
-} as const
-
-const BUTTON_TONE = {
-  error: 'critical',
-  warning: 'caution',
-  success: 'positive',
-  info: 'neutral',
-} as const
+const ToastCard = lazy(() =>
+  import('./ToastCard').then((toastCardModule) => ({default: toastCardModule.ToastCard})),
+)
 
 /**
  * The `Toast` component gives feedback to users when an action has taken place.
  *
  * Toasts can be closed with a close button, or auto-dismiss when the duration expires.
  *
+ * The animated implementation (and the `motion` library it depends on) is loaded lazily on the
+ * first render, so the toast may appear a frame later than it otherwise would.
+ *
  * @internal
  */
 export function Toast<E extends ToastElementType = typeof DEFAULT_TOAST_ELEMENT>(
   props: ToastProps<E>,
 ): React.JSX.Element {
-  const {
-    as = DEFAULT_TOAST_ELEMENT,
-    closable,
-    description,
-    duration,
-    onClose,
-    radius = 3,
-    title,
-    status,
-    ...rest
-  } = props as ToastProps<typeof DEFAULT_TOAST_ELEMENT>
-
-  const cardTone = status ? STATUS_CARD_TONE[status] : 'default'
-  const buttonTone = status ? BUTTON_TONE[status] : 'default'
-  const role = status ? ROLES[status] : 'status'
-
-  const prefersReducedMotion = usePrefersReducedMotion()
-
-  const visualDuration: number = prefersReducedMotion ? 0 : 0.26
-  const transition = visualDuration
-    ? {type: 'spring' as const, visualDuration, bounce: 0.25}
-    : {duration: 0}
-
-  const hasDuration = duration && isFinite(duration) && duration < LONG_ENOUGH_BUT_NOT_TOO_LONG
-  const initial: ContainerVariants[] = ['hidden', 'initial']
-  const animate: ContainerVariants[] = ['visible', 'slideIn']
-  const exit: ContainerVariants[] = ['hidden', 'slideOut']
-
   return (
-    <MotionCard
-      as={as}
-      className={toast()}
-      data-ui="Toast"
-      role={role}
-      {...rest}
-      animate={animate}
-      custom={visualDuration}
-      data-has-duration={hasDuration ? '' : undefined}
-      exit={exit}
-      initial={initial}
-      layout="position"
-      position="relative"
-      radius={radius}
-      shadow={2}
-      tone={cardTone}
-      transition={transition}
-      variants={container}
-    >
-      <MotionFlex align="flex-start" transition={transition} variants={content}>
-        <Flex flex={1} overflowX="auto" padding={3}>
-          <Stack gap={3}>
-            {title && (
-              <Text size={1} weight="medium">
-                {title}
-              </Text>
-            )}
-            {description && (
-              <MotionText muted size={1} transition={transition} variants={content}>
-                {description}
-              </MotionText>
-            )}
-          </Stack>
-        </Flex>
-
-        {closable && (
-          <Box padding={1}>
-            <Button
-              as="button"
-              icon={CloseIcon}
-              mode="bleed"
-              padding={2}
-              style={{verticalAlign: 'top'}}
-              tone={buttonTone}
-              onClick={onClose}
-            />
-          </Box>
-        )}
-      </MotionFlex>
-    </MotionCard>
+    <Suspense fallback={null}>
+      <ToastCard {...(props as ToastProps<typeof DEFAULT_TOAST_ELEMENT>)} />
+    </Suspense>
   )
 }
-
-const container = {
-  initial: {y: 32, scale: 0.5, zIndex: 1},
-  hidden: {opacity: 0},
-  visible: (visualDuration: number) => {
-    if (!visualDuration) return {opacity: 1}
-
-    return {
-      opacity: 1,
-      transition: {
-        when: 'beforeChildren',
-        staggerChildren: visualDuration / 3,
-        duration: visualDuration / 3,
-      },
-    }
-  },
-  slideIn: {
-    y: 0,
-    scale: 1,
-  },
-  slideOut: {
-    zIndex: 0,
-    scale: 0.75,
-  },
-} satisfies Variants
-type ContainerVariants = keyof typeof container
-
-const content = {
-  initial: {
-    willChange: 'transform',
-  },
-  hidden: {
-    opacity: 0,
-  },
-  visible: {
-    opacity: 1,
-  },
-} satisfies Partial<Record<ContainerVariants, Variant>>
-
-const MotionCard = motion.create(Card)
-const MotionFlex = motion.create(Flex)
-const MotionText = motion.create(Text)

--- a/packages/ui/src/components/toast/ToastCard.tsx
+++ b/packages/ui/src/components/toast/ToastCard.tsx
@@ -1,0 +1,177 @@
+import {CloseIcon} from '@sanity/icons'
+import {toast} from '@sanity/ui-css'
+import {motion, type Variant, type Variants} from 'motion/react'
+
+import {usePrefersReducedMotion} from '../../hooks/usePrefersReducedMotion'
+import {Box} from '../../primitives/box/Box'
+import {Button} from '../../primitives/button/Button'
+import {Card} from '../../primitives/card/Card'
+import {Flex} from '../../primitives/flex/Flex'
+import {Stack} from '../../primitives/stack/Stack'
+import {Text} from '../../primitives/text/Text'
+import {
+  DEFAULT_TOAST_ELEMENT,
+  type ToastElementType,
+  type ToastProps,
+} from './Toast'
+
+// Support pattern used by Sanity Studio, that works around the lack of `duration: Infinity` support in older @sanity/ui versions
+// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+const LONG_ENOUGH_BUT_NOT_TOO_LONG = 1000 * 60 * 60 * 24 * 24
+
+const ROLES = {
+  error: 'alert',
+  warning: 'alert',
+  success: 'alert',
+  info: 'alert',
+} as const
+
+const STATUS_CARD_TONE = {
+  error: 'critical',
+  warning: 'caution',
+  success: 'positive',
+  info: 'neutral',
+} as const
+
+const BUTTON_TONE = {
+  error: 'critical',
+  warning: 'caution',
+  success: 'positive',
+  info: 'neutral',
+} as const
+
+/**
+ * Animated `Toast` implementation. This module carries the `motion/react` dependency; isolating it
+ * here lets consumers defer that cost. `Toast.tsx` loads this module via `React.lazy`, so nothing
+ * imports it until a toast is rendered.
+ *
+ * @internal
+ */
+export function ToastCard<E extends ToastElementType = typeof DEFAULT_TOAST_ELEMENT>(
+  props: ToastProps<E>,
+): React.JSX.Element {
+  const {
+    as = DEFAULT_TOAST_ELEMENT,
+    closable,
+    description,
+    duration,
+    onClose,
+    radius = 3,
+    title,
+    status,
+    ...rest
+  } = props as ToastProps<typeof DEFAULT_TOAST_ELEMENT>
+
+  const cardTone = status ? STATUS_CARD_TONE[status] : 'default'
+  const buttonTone = status ? BUTTON_TONE[status] : 'default'
+  const role = status ? ROLES[status] : 'status'
+
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const visualDuration: number = prefersReducedMotion ? 0 : 0.26
+  const transition = visualDuration
+    ? {type: 'spring' as const, visualDuration, bounce: 0.25}
+    : {duration: 0}
+
+  const hasDuration = duration && isFinite(duration) && duration < LONG_ENOUGH_BUT_NOT_TOO_LONG
+  const initial: ContainerVariants[] = ['hidden', 'initial']
+  const animate: ContainerVariants[] = ['visible', 'slideIn']
+  const exit: ContainerVariants[] = ['hidden', 'slideOut']
+
+  return (
+    <MotionCard
+      as={as}
+      className={toast()}
+      data-ui="Toast"
+      role={role}
+      {...rest}
+      animate={animate}
+      custom={visualDuration}
+      data-has-duration={hasDuration ? '' : undefined}
+      exit={exit}
+      initial={initial}
+      layout="position"
+      position="relative"
+      radius={radius}
+      shadow={2}
+      tone={cardTone}
+      transition={transition}
+      variants={container}
+    >
+      <MotionFlex align="flex-start" transition={transition} variants={content}>
+        <Flex flex={1} overflowX="auto" padding={3}>
+          <Stack gap={3}>
+            {title && (
+              <Text size={1} weight="medium">
+                {title}
+              </Text>
+            )}
+            {description && (
+              <MotionText muted size={1} transition={transition} variants={content}>
+                {description}
+              </MotionText>
+            )}
+          </Stack>
+        </Flex>
+
+        {closable && (
+          <Box padding={1}>
+            <Button
+              as="button"
+              icon={CloseIcon}
+              mode="bleed"
+              padding={2}
+              style={{verticalAlign: 'top'}}
+              tone={buttonTone}
+              onClick={onClose}
+            />
+          </Box>
+        )}
+      </MotionFlex>
+    </MotionCard>
+  )
+}
+
+ToastCard.displayName = 'ToastCard'
+
+const container = {
+  initial: {y: 32, scale: 0.5, zIndex: 1},
+  hidden: {opacity: 0},
+  visible: (visualDuration: number) => {
+    if (!visualDuration) return {opacity: 1}
+
+    return {
+      opacity: 1,
+      transition: {
+        when: 'beforeChildren',
+        staggerChildren: visualDuration / 3,
+        duration: visualDuration / 3,
+      },
+    }
+  },
+  slideIn: {
+    y: 0,
+    scale: 1,
+  },
+  slideOut: {
+    zIndex: 0,
+    scale: 0.75,
+  },
+} satisfies Variants
+type ContainerVariants = keyof typeof container
+
+const content = {
+  initial: {
+    willChange: 'transform',
+  },
+  hidden: {
+    opacity: 0,
+  },
+  visible: {
+    opacity: 1,
+  },
+} satisfies Partial<Record<ContainerVariants, Variant>>
+
+const MotionCard = motion.create(Card)
+const MotionFlex = motion.create(Flex)
+const MotionText = motion.create(Text)

--- a/packages/ui/src/components/toast/ToastList.tsx
+++ b/packages/ui/src/components/toast/ToastList.tsx
@@ -1,0 +1,39 @@
+import {AnimatePresence} from 'motion/react'
+
+import {ToastCard} from './ToastCard'
+import type {ToastParams} from './types'
+
+/** @internal */
+export type ToastState = {
+  dismiss: () => void
+  id: string
+  params: ToastParams
+}[]
+
+/**
+ * Renders the animated toast stack. Kept in a separate module so that `motion/react` is only
+ * loaded once the first toast is pushed.
+ *
+ * @internal
+ */
+export function ToastList(props: {toasts: ToastState}): React.JSX.Element {
+  const {toasts} = props
+
+  return (
+    <AnimatePresence initial={false} mode="popLayout">
+      {toasts.map(({dismiss, id, params}) => (
+        <ToastCard
+          key={id}
+          closable={params.closable}
+          description={params.description}
+          duration={params.duration}
+          status={params.status}
+          title={params.title}
+          onClose={dismiss}
+        />
+      ))}
+    </AnimatePresence>
+  )
+}
+
+ToastList.displayName = 'ToastList'

--- a/packages/ui/src/components/toast/ToastProvider.test.tsx
+++ b/packages/ui/src/components/toast/ToastProvider.test.tsx
@@ -1,0 +1,75 @@
+import {act, screen} from '@testing-library/react'
+import {useEffect} from 'react'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {render} from '$test/utils'
+
+import {ToastProvider} from './ToastProvider'
+import {useToast} from './useToast'
+
+// Records whether the motion-bearing toast list chunk has been evaluated. `ToastProvider` lazily
+// imports it via `React.lazy(() => import('./ToastList'))`, so the factory only runs once the
+// `hasPushed` latch mounts the list. A programmatic dismiss (duration 0.01) must never reach it.
+const {toastListChunkState} = vi.hoisted(() => ({toastListChunkState: {evaluated: false}}))
+
+vi.mock('./ToastList', async (importOriginal) => {
+  toastListChunkState.evaluated = true
+  return importOriginal<typeof import('./ToastList')>()
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  if (vi.isFakeTimers()) {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  }
+})
+
+function PushOnMount({duration, title}: {duration?: number; title: string}) {
+  const {push} = useToast()
+
+  useEffect(() => {
+    push({duration, title})
+  }, [duration, push, title])
+
+  return null
+}
+
+describe('ToastProvider', () => {
+  it('does not load the motion-bearing toast list chunk for a programmatic dismiss (duration 0.01)', async () => {
+    // Guard: only meaningful before any genuine push in this file has mounted the list.
+    expect(toastListChunkState.evaluated).toBe(false)
+
+    render(
+      <ToastProvider>
+        <PushOnMount duration={0.01} title="Dismiss ping" />
+      </ToastProvider>,
+    )
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    // A dismiss/ping renders nothing and must keep the motion chunk out of the graph.
+    expect(toastListChunkState.evaluated).toBe(false)
+    expect(screen.queryByText('Dismiss ping')).not.toBeInTheDocument()
+  })
+
+  it('loads the toast list chunk and renders the toast when one is genuinely pushed', async () => {
+    // Real timers so React Testing Library's `findBy*` polling can advance while the lazy chunk
+    // resolves. An `Infinity` duration keeps the toast from auto-dismissing during the test.
+    vi.useRealTimers()
+
+    render(
+      <ToastProvider>
+        <PushOnMount duration={Infinity} title="Real toast" />
+      </ToastProvider>,
+    )
+
+    expect(await screen.findByText('Real toast')).toBeInTheDocument()
+    expect(toastListChunkState.evaluated).toBe(true)
+  })
+})

--- a/packages/ui/src/components/toast/ToastProvider.tsx
+++ b/packages/ui/src/components/toast/ToastProvider.tsx
@@ -35,8 +35,6 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
       const id = params.id ?? generateToastId()
       const duration = params.duration ?? 5000
 
-      setHasPushed(true)
-
       // If the `id` is reused, clear the previous timeout
       const existingTimeoutId = timeoutIdsRef.current[id]
       if (existingTimeoutId) {
@@ -44,18 +42,27 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
         timeoutIdsRef.current[id] = undefined
       }
 
+      /**
+       * Backwards compatibility for `sanity` patterns workaround a lack of programatically dismissible toasts.
+       * It uses a super short duration that closes the toast immediately in previous versions of `@sanity/ui`.
+       * We interpret this as a request to dismiss the toast immediately, and remove it from the state right away.
+       * Even once we support programatic dismissal we'll need to keep this for backwards compatibility with v2 and v1.
+       */
+      if (duration === 0.01) {
+        startTransition(() => {
+          setState((prevState) => prevState.filter((toast) => toast.id !== id))
+        })
+
+        return id
+      }
+
+      // A toast is genuinely being added, so latch the lazily loaded toast list to mount. This
+      // stays after the dismiss/ping short-circuit above so that a programmatic dismiss never
+      // eagerly loads the motion-bearing chunk.
+      setHasPushed(true)
+
       startTransition(() => {
         setState((prevState): ToastState => {
-          /**
-           * Backwards compatibility for `sanity` patterns workaround a lack of programatically dismissible toasts.
-           * It uses a super short duration that closes the toast immediately in previous versions of `@sanity/ui`.
-           * We interpret this as a request to dismiss the toast immediately, and remove it from the state right away.
-           * Even once we support programatic dismissal we'll need to keep this for backwards compatibility with v2 and v1.
-           */
-          if (duration === 0.01) {
-            return prevState.filter((toast) => toast.id !== id)
-          }
-
           /**
            * Creates a function to dismiss this specific toast.
            * This function will be passed to the Toast component

--- a/packages/ui/src/components/toast/ToastProvider.tsx
+++ b/packages/ui/src/components/toast/ToastProvider.tsx
@@ -1,20 +1,17 @@
 import type {ResponsiveProp} from '@sanity/ui-css'
-import {AnimatePresence} from 'motion/react'
-import {startTransition, useMemo, useRef, useState} from 'react'
+import {lazy, startTransition, Suspense, useMemo, useRef, useState} from 'react'
 
 import {useMounted} from '../../hooks/useMounted'
 import {LayerProvider} from '../../primitives/layer/LayerProvider'
-import {Toast} from './Toast'
 import {ToastContext} from './ToastContext'
 import {ToastLayer, type ToastLayerProps} from './ToastLayer'
+import type {ToastState} from './ToastList'
 import {generateToastId} from './toastState'
 import type {ToastContextValue, ToastParams} from './types'
 
-type ToastState = {
-  dismiss: () => void
-  id: string
-  params: ToastParams
-}[]
+const ToastList = lazy(() =>
+  import('./ToastList').then((toastListModule) => ({default: toastListModule.ToastList})),
+)
 
 /** @public */
 export interface ToastProviderProps extends Omit<ToastLayerProps, 'children'> {
@@ -26,6 +23,9 @@ export interface ToastProviderProps extends Omit<ToastLayerProps, 'children'> {
 export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
   const {children, padding, paddingX, paddingY, gap, zOffset = 1} = props
   const [state, setState] = useState<ToastState>([])
+  // Latches to `true` on the first push, and deliberately never resets, so that the lazily loaded
+  // toast list stays mounted and can run exit animations for the last dismissed toast.
+  const [hasPushed, setHasPushed] = useState(false)
   const mounted = useMounted()
 
   const timeoutIdsRef = useRef<Record<string, NodeJS.Timeout | undefined>>({})
@@ -34,6 +34,8 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
     const push = (params: ToastParams) => {
       const id = params.id ?? generateToastId()
       const duration = params.duration ?? 5000
+
+      setHasPushed(true)
 
       // If the `id` is reused, clear the previous timeout
       const existingTimeoutId = timeoutIdsRef.current[id]
@@ -106,19 +108,11 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
       {mounted && (
         <LayerProvider zOffset={zOffset}>
           <ToastLayer gap={gap} padding={padding} paddingX={paddingX} paddingY={paddingY}>
-            <AnimatePresence initial={false} mode="popLayout">
-              {state.map(({dismiss, id, params}) => (
-                <Toast
-                  key={id}
-                  closable={params.closable}
-                  description={params.description}
-                  duration={params.duration}
-                  status={params.status}
-                  title={params.title}
-                  onClose={dismiss}
-                />
-              ))}
-            </AnimatePresence>
+            {hasPushed && (
+              <Suspense fallback={null}>
+                <ToastList toasts={state} />
+              </Suspense>
+            )}
           </ToastLayer>
         </LayerProvider>
       )}

--- a/packages/ui/src/primitives/popover/Popover.test.tsx
+++ b/packages/ui/src/primitives/popover/Popover.test.tsx
@@ -1,0 +1,62 @@
+import {screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {render} from '$test/utils'
+
+import {Button} from '../button/Button'
+import {Popover} from './Popover'
+
+// Records whether the motion-bearing animated layer chunk has been evaluated. The lazy import in
+// `Popover.tsx` resolves to this mocked module, so the factory only runs once the animated path is
+// actually reached. The non-animated path must never trigger it, which is the lazy-load invariant.
+const {animatedChunkState} = vi.hoisted(() => ({animatedChunkState: {evaluated: false}}))
+
+vi.mock('./PopoverLayerAnimated', async (importOriginal) => {
+  animatedChunkState.evaluated = true
+  return importOriginal<typeof import('./PopoverLayerAnimated')>()
+})
+
+describe('Popover', () => {
+  describe('Non-animated path', () => {
+    it('renders content synchronously when open without animate', () => {
+      render(
+        <Popover content={<span>Static content</span>} open placement="top">
+          <Button mode="bleed" text="Reference" />
+        </Popover>,
+      )
+
+      // No awaiting: the static layer mounts in the same commit that opens the popover.
+      expect(screen.getByText('Static content')).toBeInTheDocument()
+    })
+
+    it('does not evaluate the motion-bearing animated chunk on a static render', () => {
+      // Guard: this assertion is only meaningful before any animated render in this file has run.
+      expect(animatedChunkState.evaluated).toBe(false)
+
+      render(
+        <Popover content={<span>Static content</span>} open placement="top">
+          <Button mode="bleed" text="Reference" />
+        </Popover>,
+      )
+
+      expect(screen.getByText('Static content')).toBeInTheDocument()
+      // The motion chunk stays out of the static render path.
+      expect(animatedChunkState.evaluated).toBe(false)
+    })
+  })
+
+  describe('Animated path', () => {
+    it('renders content when open with animate', async () => {
+      render(
+        <Popover animate content={<span>Animated content</span>} open placement="top">
+          <Button mode="bleed" text="Reference" />
+        </Popover>,
+      )
+
+      // The animated layer is lazily loaded, so content arrives asynchronously.
+      expect(await screen.findByText('Animated content')).toBeInTheDocument()
+      // Reaching the animated path is what loads the motion-bearing chunk.
+      expect(animatedChunkState.evaluated).toBe(true)
+    })
+  })
+})

--- a/packages/ui/src/primitives/popover/Popover.tsx
+++ b/packages/ui/src/primitives/popover/Popover.tsx
@@ -1,17 +1,20 @@
 import {autoUpdate, type RootBoundary, useFloating} from '@floating-ui/react-dom'
 import {type MaxWidth, popover as popoverCss, type ResponsiveProp} from '@sanity/ui-css'
-import {AnimatePresence} from 'motion/react'
 import {
   cloneElement,
   type ForwardedRef,
+  lazy,
   type ReactElement,
   type ReactNode,
   type Ref,
+  Suspense,
   use,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 
 import {Z_OFFSETS} from '../../core/constants'
@@ -26,9 +29,28 @@ import {
   DEFAULT_POPOVER_DISTANCE,
   DEFAULT_POPOVER_MARGINS,
 } from './constants'
-import {PopoverLayer, type PopoverLayerOwnProps, type PopoverLayerProps} from './PopoverLayer'
+import type {PopoverLayerOwnProps, PopoverLayerProps} from './PopoverLayer'
+import {PopoverLayerStatic} from './PopoverLayerStatic'
 import type {PopoverMargins, PopoverUpdateCallback} from './types'
 import {useMiddleware} from './useMiddleware'
+
+// `PopoverLayerAnimated.tsx` is the only module in the popover graph that depends on
+// `motion/react`. Loading it (and `AnimatePresence`) lazily keeps the motion library out of the
+// static module graph, so it is only evaluated once an animated popover actually opens.
+// Non-animated popovers render the static `PopoverLayerStatic` synchronously, so popover content
+// (and any listeners it attaches, e.g. click-outside handling in `Menu`) mounts in the same commit
+// that opens the popover.
+const PopoverLayerAnimated = lazy(() =>
+  import('./PopoverLayerAnimated').then((popoverLayerModule) => ({
+    default: popoverLayerModule.PopoverLayerAnimated,
+  })),
+)
+
+const AnimatePresence = lazy(() =>
+  import('./PopoverLayerAnimated').then((popoverLayerModule) => ({
+    default: popoverLayerModule.AnimatePresence,
+  })),
+)
 
 /** @public */
 export type PopoverOwnProps = Omit<PopoverLayerOwnProps, 'maxWidth'> & {
@@ -174,6 +196,15 @@ export function Popover(props: PopoverProps): React.JSX.Element {
   const prefersReducedMotion = usePrefersReducedMotion()
   const animate = prefersReducedMotion ? false : _animate
 
+  // Latches to `true` the first time an animated popover opens, and deliberately never resets,
+  // so that `AnimatePresence` only loads once needed but stays mounted to run exit animations.
+  const [hasOpenedAnimated, setHasOpenedAnimated] = useState(Boolean(animate && open))
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (animate && open) setHasOpenedAnimated(true)
+  }, [animate, open])
+
   const ref = useRef<HTMLDivElement | null>(null)
 
   const rootBoundary: RootBoundary = 'viewport'
@@ -242,13 +273,15 @@ export function Popover(props: PopoverProps): React.JSX.Element {
     return childProp || <></>
   }
 
+  const LayerComponent = animate ? PopoverLayerAnimated : PopoverLayerStatic
+
   const node = (
     <>
       {/* Optional transparent blocking overlay at the top-most z-index layer. Must be positioned
       before the below popover card. */}
       {modal && <ViewportOverlay />}
 
-      <PopoverLayer
+      <LayerComponent
         {...rest}
         ref={setFloating}
         animate={animate}
@@ -267,7 +300,7 @@ export function Popover(props: PopoverProps): React.JSX.Element {
         zOffset={zOffset}
       >
         {content}
-      </PopoverLayer>
+      </LayerComponent>
     </>
   )
 
@@ -282,7 +315,13 @@ export function Popover(props: PopoverProps): React.JSX.Element {
   return (
     <>
       {/* the popover */}
-      {animate ? <AnimatePresence>{children}</AnimatePresence> : children}
+      {animate
+        ? hasOpenedAnimated && (
+            <Suspense fallback={null}>
+              <AnimatePresence>{children}</AnimatePresence>
+            </Suspense>
+          )
+        : children}
 
       {/* the referred element */}
       {child}

--- a/packages/ui/src/primitives/popover/PopoverLayer.tsx
+++ b/packages/ui/src/primitives/popover/PopoverLayer.tsx
@@ -1,12 +1,8 @@
 import type {Strategy} from '@floating-ui/react-dom'
-import {popover_card} from '@sanity/ui-css'
-import {type HTMLMotionProps, motion} from 'motion/react'
-import {useMemo} from 'react'
+import type {HTMLMotionProps} from 'motion/react'
 
-import {POPOVER_MOTION_PROPS} from '../../core/constants'
 import type {Assign} from '../../core/types'
-import {Flex} from '../flex/Flex'
-import {Layer, type LayerOwnProps} from '../layer/Layer'
+import type {LayerOwnProps} from '../layer/Layer'
 
 /** @internal */
 export interface PopoverLayerOwnProps extends LayerOwnProps {
@@ -28,74 +24,3 @@ export interface PopoverLayerOwnProps extends LayerOwnProps {
 
 /** @public */
 export type PopoverLayerProps = Assign<HTMLMotionProps<'div'>, PopoverLayerOwnProps>
-
-/** @internal */
-export function PopoverLayer(props: PopoverLayerProps): React.JSX.Element {
-  const {
-    animate = false,
-    children,
-    maxWidth,
-    padding,
-    originX,
-    originY,
-    overflow,
-    radius,
-    referenceWidth,
-    shadow,
-    strategy,
-    style,
-    tone = 'inherit',
-    x,
-    y,
-    ...rest
-  } = props
-
-  const rootStyle = useMemo(
-    () => ({
-      left: x,
-      originX,
-      originY,
-      top: y,
-      width: referenceWidth,
-      willChange: animate ? 'transform' : undefined,
-      ...style,
-    }),
-    [animate, originX, originY, referenceWidth, style, x, y],
-  )
-
-  return (
-    <Layer
-      className={popover_card()}
-      data-ui="Popover"
-      {...rest}
-      animate={animate ? ['visible', 'scaleIn'] : undefined}
-      as={motion.div}
-      display="flex"
-      exit={animate ? ['hidden', 'scaleOut'] : undefined}
-      flexDirection="column"
-      initial={animate ? ['hidden', 'initial'] : undefined}
-      position={strategy}
-      radius={radius}
-      shadow={shadow}
-      sizing="border"
-      style={rootStyle}
-      tone={tone}
-      transition={POPOVER_MOTION_PROPS.transition}
-      variants={POPOVER_MOTION_PROPS.card}
-    >
-      <Flex
-        data-ui="Popover__wrapper"
-        direction="column"
-        flex={1}
-        maxWidth={maxWidth}
-        overflow={overflow}
-        radius={radius}
-        tabIndex={-1}
-      >
-        <Flex direction="column" flex={1} padding={padding}>
-          {children}
-        </Flex>
-      </Flex>
-    </Layer>
-  )
-}

--- a/packages/ui/src/primitives/popover/PopoverLayerAnimated.tsx
+++ b/packages/ui/src/primitives/popover/PopoverLayerAnimated.tsx
@@ -1,0 +1,88 @@
+import {popover_card} from '@sanity/ui-css'
+import {motion} from 'motion/react'
+import {useMemo} from 'react'
+
+import {POPOVER_MOTION_PROPS} from '../../core/constants'
+import {Flex} from '../flex/Flex'
+import {Layer} from '../layer/Layer'
+import type {PopoverLayerProps} from './PopoverLayer'
+
+// Re-exported so `Popover.tsx` can lazily load `AnimatePresence` from the same chunk as this
+// module, avoiding both a static `motion/react` import and a second chunk request.
+export {AnimatePresence} from 'motion/react'
+
+/**
+ * Motion-wrapped popover layer, kept in its own lazily loaded chunk so `motion/react` is only
+ * evaluated once an animated popover opens.
+ *
+ * @internal
+ */
+export function PopoverLayerAnimated(props: PopoverLayerProps): React.JSX.Element {
+  const {
+    animate = false,
+    children,
+    maxWidth,
+    originX,
+    originY,
+    overflow,
+    padding,
+    radius,
+    referenceWidth,
+    shadow,
+    strategy,
+    style,
+    tone = 'inherit',
+    x,
+    y,
+    ...rest
+  } = props
+
+  const rootStyle = useMemo(
+    () => ({
+      left: x,
+      originX,
+      originY,
+      top: y,
+      width: referenceWidth,
+      willChange: animate ? 'transform' : undefined,
+      ...style,
+    }),
+    [animate, originX, originY, referenceWidth, style, x, y],
+  )
+
+  return (
+    <Layer
+      className={popover_card()}
+      data-ui="Popover"
+      {...rest}
+      animate={animate ? ['visible', 'scaleIn'] : undefined}
+      as={motion.div}
+      display="flex"
+      exit={animate ? ['hidden', 'scaleOut'] : undefined}
+      flexDirection="column"
+      initial={animate ? ['hidden', 'initial'] : undefined}
+      position={strategy}
+      radius={radius}
+      shadow={shadow}
+      sizing="border"
+      style={rootStyle}
+      tone={tone}
+      transition={POPOVER_MOTION_PROPS.transition}
+      variants={POPOVER_MOTION_PROPS.card}
+    >
+      <Flex
+        data-ui="Popover__wrapper"
+        direction="column"
+        flex={1}
+        maxWidth={maxWidth}
+        overflow={overflow}
+        radius={radius}
+        tabIndex={-1}
+      >
+        <Flex direction="column" flex={1} padding={padding}>
+          {children}
+        </Flex>
+      </Flex>
+    </Layer>
+  )
+}

--- a/packages/ui/src/primitives/popover/PopoverLayerStatic.tsx
+++ b/packages/ui/src/primitives/popover/PopoverLayerStatic.tsx
@@ -1,0 +1,79 @@
+import {popover_card} from '@sanity/ui-css'
+import {type CSSProperties, useMemo} from 'react'
+
+import {Flex} from '../flex/Flex'
+import {Layer} from '../layer/Layer'
+import type {PopoverLayerProps} from './PopoverLayer'
+
+/**
+ * Static, motion-free popover layer. Rendered synchronously when the popover is not animated, so
+ * popover content (and any listeners it attaches, e.g. click-outside handling in `Menu`) mounts in
+ * the same commit that opens the popover, without pulling `motion/react` into the static module
+ * graph.
+ *
+ * @internal
+ */
+export function PopoverLayerStatic(props: PopoverLayerProps): React.JSX.Element {
+  const {
+    animate: _animate,
+    children,
+    maxWidth,
+    onAnimationStart: _onAnimationStart,
+    onDrag: _onDrag,
+    onDragEnd: _onDragEnd,
+    onDragStart: _onDragStart,
+    originX: _originX,
+    originY: _originY,
+    overflow,
+    padding,
+    radius,
+    referenceWidth,
+    shadow,
+    strategy,
+    style,
+    tone = 'inherit',
+    x,
+    y,
+    ...rest
+  } = props
+
+  const rootStyle = useMemo(
+    (): CSSProperties => ({
+      left: x,
+      top: y,
+      width: referenceWidth,
+      ...(style as CSSProperties),
+    }),
+    [referenceWidth, style, x, y],
+  )
+
+  return (
+    <Layer
+      className={popover_card()}
+      data-ui="Popover"
+      {...rest}
+      display="flex"
+      flexDirection="column"
+      position={strategy}
+      radius={radius}
+      shadow={shadow}
+      sizing="border"
+      style={rootStyle}
+      tone={tone}
+    >
+      <Flex
+        data-ui="Popover__wrapper"
+        direction="column"
+        flex={1}
+        maxWidth={maxWidth}
+        overflow={overflow}
+        radius={radius}
+        tabIndex={-1}
+      >
+        <Flex direction="column" flex={1} padding={padding}>
+          {children}
+        </Flex>
+      </Flex>
+    </Layer>
+  )
+}

--- a/packages/ui/src/primitives/tooltip/Tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip/Tooltip.tsx
@@ -14,10 +14,11 @@ import {
   tooltip,
 } from '@sanity/ui-css'
 import type {CardTone, ColorScheme, FontTextSize} from '@sanity/ui-tokens'
-import {AnimatePresence} from 'motion/react'
 import {
   cloneElement,
+  lazy,
   startTransition,
+  Suspense,
   use,
   useCallback,
   useEffect,
@@ -50,7 +51,23 @@ import {
   DEFAULT_TOOLTIP_PADDING,
 } from './constants'
 import {TooltipDelayGroupContext} from './tooltipDelayGroup/TooltipDelayGroupContext'
-import {TooltipLayer} from './TooltipLayer'
+import {TooltipLayerStatic} from './TooltipLayerStatic'
+
+// `TooltipLayerAnimated.tsx` is the only module in the tooltip graph that depends on
+// `motion/react`. Loading it (and `AnimatePresence`) lazily keeps the motion library out of the
+// static module graph, so it is only evaluated once an animated tooltip is shown. Non-animated
+// tooltips render the static `TooltipLayerStatic` synchronously.
+const TooltipLayerAnimated = lazy(() =>
+  import('./TooltipLayerAnimated').then((tooltipLayerModule) => ({
+    default: tooltipLayerModule.TooltipLayerAnimated,
+  })),
+)
+
+const AnimatePresence = lazy(() =>
+  import('./TooltipLayerAnimated').then((tooltipLayerModule) => ({
+    default: tooltipLayerModule.AnimatePresence,
+  })),
+)
 
 /** @public */
 export const DEFAULT_TOOLTIP_ELEMENT = 'div'
@@ -209,6 +226,16 @@ export function Tooltip<E extends TooltipElementType = typeof DEFAULT_TOOLTIP_EL
   const [localVisible, setVisible] = useState(false)
 
   const visible = groupVisible || localVisible
+
+  // Latches to `true` the first time an animated tooltip is shown, and deliberately never resets,
+  // so that `AnimatePresence` only loads once needed but stays mounted to run exit animations.
+  // Seeded `false` because a tooltip is hover/focus driven and is never visible at mount.
+  const [hasShownAnimated, setHasShownAnimated] = useState(false)
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (animate && visible) setHasShownAnimated(true)
+  }, [animate, visible])
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
@@ -407,8 +434,10 @@ export function Tooltip<E extends TooltipElementType = typeof DEFAULT_TOOLTIP_EL
 
   if (disabled) return child
 
+  const LayerComponent = animate ? TooltipLayerAnimated : TooltipLayerStatic
+
   const node = (
-    <TooltipLayer
+    <LayerComponent
       data-ui="Tooltip"
       {...rest}
       ref={setFloating}
@@ -432,7 +461,7 @@ export function Tooltip<E extends TooltipElementType = typeof DEFAULT_TOOLTIP_EL
       zOffset={zOffset}
     >
       {content}
-    </TooltipLayer>
+    </LayerComponent>
   )
 
   let children = visible ? node : null
@@ -446,7 +475,13 @@ export function Tooltip<E extends TooltipElementType = typeof DEFAULT_TOOLTIP_EL
   return (
     <>
       {/* the tooltip */}
-      {animate ? <AnimatePresence>{children}</AnimatePresence> : children}
+      {animate
+        ? hasShownAnimated && (
+            <Suspense fallback={null}>
+              <AnimatePresence>{children}</AnimatePresence>
+            </Suspense>
+          )
+        : children}
 
       {/* the referred element */}
       {child}

--- a/packages/ui/src/primitives/tooltip/TooltipLayer.tsx
+++ b/packages/ui/src/primitives/tooltip/TooltipLayer.tsx
@@ -1,9 +1,5 @@
-import {motion, type MotionStyle} from 'motion/react'
-import {useMemo} from 'react'
-
-import {POPOVER_MOTION_PROPS} from '../../core/constants'
 import type {Placement} from '../../core/types'
-import {Layer, type LayerOwnProps, type LayerProps} from '../layer/Layer'
+import type {LayerOwnProps, LayerProps} from '../layer/Layer'
 
 /** @internal */
 export const DEFAULT_TOOLTIP_LAYER_ELEMENT = 'div'
@@ -18,55 +14,3 @@ export interface TooltipLayerOwnProps extends LayerOwnProps {
 
 /** @internal */
 export type TooltipLayerProps = TooltipLayerOwnProps & LayerProps<'div'>
-
-/** @internal */
-export function TooltipLayer(props: TooltipLayerProps): React.JSX.Element {
-  const {
-    animate,
-    children,
-    originX,
-    originY,
-    padding,
-    placement,
-    radius,
-    scheme,
-    shadow,
-    style,
-    tone,
-    ...rest
-  } = props
-
-  const rootStyle: MotionStyle = useMemo(
-    () => ({
-      originX,
-      originY,
-      willChange: animate ? 'transform' : undefined,
-      ...style,
-    }),
-    [animate, originX, originY, style],
-  )
-
-  return (
-    // @ts-expect-error - TODO: fix this
-    <Layer
-      data-ui="Tooltip__layer"
-      {...rest}
-      animate={animate ? ['visible', 'scaleIn'] : undefined}
-      as={motion.div}
-      data-animate={animate ? '' : undefined}
-      data-placement={placement}
-      exit={animate ? ['hidden', 'scaleOut'] : undefined}
-      initial={animate ? ['hidden', 'initial'] : undefined}
-      padding={padding}
-      radius={radius}
-      scheme={scheme}
-      shadow={shadow}
-      style={rootStyle}
-      tone={tone}
-      transition={POPOVER_MOTION_PROPS.transition}
-      variants={POPOVER_MOTION_PROPS.card}
-    >
-      {children}
-    </Layer>
-  )
-}

--- a/packages/ui/src/primitives/tooltip/TooltipLayerAnimated.tsx
+++ b/packages/ui/src/primitives/tooltip/TooltipLayerAnimated.tsx
@@ -1,0 +1,67 @@
+import {motion, type MotionStyle} from 'motion/react'
+import {useMemo} from 'react'
+
+import {POPOVER_MOTION_PROPS} from '../../core/constants'
+import {Layer} from '../layer/Layer'
+import type {TooltipLayerProps} from './TooltipLayer'
+
+// Re-exported so `Tooltip.tsx` can lazily load `AnimatePresence` from the same chunk as this
+// module, avoiding both a static `motion/react` import and a second chunk request.
+export {AnimatePresence} from 'motion/react'
+
+/**
+ * Motion-wrapped tooltip layer, kept in its own lazily loaded chunk so `motion/react` is only
+ * evaluated once an animated tooltip is shown.
+ *
+ * @internal
+ */
+export function TooltipLayerAnimated(props: TooltipLayerProps): React.JSX.Element {
+  const {
+    animate,
+    children,
+    originX,
+    originY,
+    padding,
+    placement,
+    radius,
+    scheme,
+    shadow,
+    style,
+    tone,
+    ...rest
+  } = props
+
+  const rootStyle: MotionStyle = useMemo(
+    () => ({
+      originX,
+      originY,
+      willChange: animate ? 'transform' : undefined,
+      ...style,
+    }),
+    [animate, originX, originY, style],
+  )
+
+  return (
+    // @ts-expect-error - TODO: fix this
+    <Layer
+      data-ui="Tooltip__layer"
+      {...rest}
+      animate={animate ? ['visible', 'scaleIn'] : undefined}
+      as={motion.div}
+      data-animate={animate ? '' : undefined}
+      data-placement={placement}
+      exit={animate ? ['hidden', 'scaleOut'] : undefined}
+      initial={animate ? ['hidden', 'initial'] : undefined}
+      padding={padding}
+      radius={radius}
+      scheme={scheme}
+      shadow={shadow}
+      style={rootStyle}
+      tone={tone}
+      transition={POPOVER_MOTION_PROPS.transition}
+      variants={POPOVER_MOTION_PROPS.card}
+    >
+      {children}
+    </Layer>
+  )
+}

--- a/packages/ui/src/primitives/tooltip/TooltipLayerStatic.tsx
+++ b/packages/ui/src/primitives/tooltip/TooltipLayerStatic.tsx
@@ -1,0 +1,42 @@
+import {Layer} from '../layer/Layer'
+import type {TooltipLayerProps} from './TooltipLayer'
+
+/**
+ * Static, motion-free tooltip layer. Rendered synchronously when the tooltip is not animated (e.g.
+ * under reduced motion or `animate={false}`), keeping `motion/react` out of the static module
+ * graph for that path.
+ *
+ * @internal
+ */
+export function TooltipLayerStatic(props: TooltipLayerProps): React.JSX.Element {
+  const {
+    animate: _animate,
+    children,
+    originX: _originX,
+    originY: _originY,
+    padding,
+    placement,
+    radius,
+    scheme,
+    shadow,
+    style,
+    tone,
+    ...rest
+  } = props
+
+  return (
+    <Layer
+      data-ui="Tooltip__layer"
+      {...rest}
+      data-placement={placement}
+      padding={padding}
+      radius={radius}
+      scheme={scheme}
+      shadow={shadow}
+      style={style}
+      tone={tone}
+    >
+      {children}
+    </Layer>
+  )
+}


### PR DESCRIPTION
### Description

Port of #2206 to v4. In v4, @sanity/ui still pulls `motion/react` (framer-motion) into its static module graph: `Toast.tsx` creates `motion.create(...)` wrappers at module scope, and `PopoverLayer`/`TooltipLayer` render `as={motion.div}` with a static `AnimatePresence`. So every consumer evaluates the framer-motion/motion-dom graph at import time, even rendering a static screen.

This PR keeps `motion/react` out of the static graph and lazy-loads it on first animated use. v4 differs structurally from v3 (motion lived inside the Layer components, with no existing static/animated split), so the port introduces motion-free static Layer variants plus separate animated chunks:

- Popover/Tooltip: new `PopoverLayerStatic`/`TooltipLayerStatic` (motion-free, rendered synchronously for the non-animated path) and `PopoverLayerAnimated`/`TooltipLayerAnimated` (the only modules importing `motion/react` at runtime; re-export `AnimatePresence`; loaded via `React.lazy`). A never-resetting latch keeps `AnimatePresence` mounted after first animated use so exit animations keep working.
- Toast: motion implementation moved to internal `ToastCard`; the public `Toast` is an API-identical generic `React.lazy` + `<Suspense fallback={null}>` wrapper. `ToastProvider` lazy-loads `ToastList` behind a `hasPushed` latch that only flips on a genuine push - a programmatic dismiss (`duration === 0.01`) does not load the chunk.

### Why we're confident motion is actually deferred

- `dist/index.js` had one static `motion/react` import on `origin/v4`; it now has zero (the shared `_chunks-es/index.js` is also zero). Motion appears only in four chunks - `PopoverLayerAnimated`, `TooltipLayerAnimated`, `ToastCard`, `ToastList` - each reached purely via dynamic `import()`.
- A runtime test proves the behaviour, not just the structure: a module-evaluation spy asserts the motion chunk is not evaluated on a static render or a programmatic dismiss, and is evaluated on an animated render / genuine push.
- An ESLint guard forbids runtime imports of `motion/react`/`motion-dom`/`framer-motion` (including subpaths and alternate entrypoints) anywhere except those four chunk modules.

### Why we're confident there's no regression

- Public `dist/index.d.ts` is byte-identical to the `origin/v4` baseline except 3 added doc-comment lines on `Toast`: no new public exports; `PopoverLayerProps`/`TooltipLayerProps`/`ToastProps` and the `Toast` generic signature are unchanged.
- `vitest run` 46/46 (including the new lazy-path and invariant tests), plus eslint, `tsc --build`, and `pkg:build` all pass.
- Same independent adversarial review + triage as #2206; the v4-specific items it found (toast dismiss eager-load, a subpath gap in the lint guard, missing automated coverage) are fixed in this PR.

### Intentional deviations (worth a reviewer's eye)

- Removed the `Toast.displayName = 'Toast'` assignment: the React Compiler statically attached it as a public d.ts namespace member, breaking byte-identical output. React still infers the devtools name from the function name.
- `PopoverLayerStatic` destructures out the motion drag/animation handlers (`onDrag`/`onDragStart`/`onDragEnd`/`onAnimationStart`) and casts `style` to `CSSProperties`, because the shared public `PopoverLayerProps` extends `HTMLMotionProps<'div'>` and both layers must keep that signature so the `animate ? Animated : Static` union typechecks. Behaviour-preserving (the original `as={motion.div}` consumed those props as motion handlers, never as DOM listeners).
- Kept two `react-hooks/set-state-in-effect` disables on the latch effects (legitimate latch pattern).

### Caveats

- The first-ever toast render, and the first-ever `animate` popover/tooltip render, resolve one microtask plus one same-bundle chunk fetch later; subsequent renders are synchronous. (Tooltip's `animate` defaults to `true` in v4; Popover's defaults to `false`.)
- `renderToString` of an initially-open `animate` Popover/Tooltip emits the Suspense fallback instead of card markup. Narrow SSR edge case.
- Not yet run: Playwright e2e and a visual static-vs-animated parity pass - worth doing before merge. `pkg:check` (api-extractor) fails only on a pre-existing, unrelated `@sanity/ui-tokens` module-resolution defect on `origin/v4`; confirm in CI.


### How this fits

v4 port of #2206 (see its "How this fits" for the full context) - keeps the motion eviction from being lost when v4 ships. Part of the sanity studio startup performance effort.
