### PR TITLE
ci: remove broken sanity-e2e cross-repo check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,15 +88,6 @@ jobs:
           path: cypress/videos
           if-no-files-found: ignore
 
-  sanity-e2e:
-    if: ${{ github.event_name == 'pull_request' }}
-    permissions:
-      contents: read
-      actions: write
-    name: "Run Studio End-to-end tests"
-    uses: sanity-io/sanity/.github/workflows/e2e-ui.yml@main
-    secrets: inherit
-
   release:
     permissions:
       id-token: write # to enable use of OIDC for npm provenance


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `sanity-e2e` job from the main CI workflow. This job reused `sanity-io/sanity/.github/workflows/e2e-ui.yml@main` and was failing due to the fragile cross-repo setup.

## Changes

- Deleted the `sanity-e2e` job from `.github/workflows/main.yml`
- No other jobs were affected — the release job already only depends on `lint`, `test`, and `cypress`

## Why

The Studio end-to-end check is broken and not worth fixing in this repo given the odd cross-repo dependency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f4fa35a-41c2-49f3-b228-7f5668909321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f4fa35a-41c2-49f3-b228-7f5668909321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

