### PR TITLE
ci(workflows): adopt pnpm/setup@v1 for pnpm bootstrap + caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/setup@v1
         with:
+          install: false
           cache: true
-          runtime: node@lts
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+      - run: pnpm install
       - run: pnpm ts:check
       - run: pnpm build
 
@@ -31,8 +35,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/setup@v1
         with:
+          install: false
           cache: true
-          runtime: node@lts
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+      - run: pnpm install
       - run: "pnpm lint -f gha --max-warnings 0"
 
   test:
@@ -43,17 +51,21 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        # node-version: [lts, latest]
-        node-version: [lts]
+        # node-version: [lts/*, current]
+        node-version: [lts/*]
         include:
           - platform: macos-latest
-            node-version: lts
+            node-version: lts/*
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/setup@v1
         with:
+          install: false
           cache: true
-          runtime: node@${{ matrix.node-version }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: pnpm install
       - run: pnpm build
       - run: pnpm test
 
@@ -65,7 +77,9 @@ jobs:
         with:
           install: false
           cache: true
-          runtime: node@lts
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
       - uses: cypress-io/github-action@v6
         with:
           build: pnpm workshop:build
@@ -109,8 +123,12 @@ jobs:
           persist-credentials: false
       - uses: pnpm/setup@v1
         with:
+          install: false
           cache: true
-          runtime: node@lts
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+      - run: pnpm install
       # Branches that will release new versions are defined in .releaserc.json
       - run: pnpm exec semantic-release
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/setup@v1
         with:
-          node-version: lts/*
-      - run: pnpm install
+          cache: true
+          runtime: node@lts
       - run: pnpm ts:check
       - run: pnpm build
 
@@ -30,11 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/setup@v1
         with:
-          node-version: lts/*
-      - run: pnpm install
+          cache: true
+          runtime: node@lts
       - run: "pnpm lint -f gha --max-warnings 0"
 
   test:
@@ -45,18 +43,17 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        # node-version: [lts/*, current]
-        node-version: [lts/*]
+        # node-version: [lts, latest]
+        node-version: [lts]
         include:
           - platform: macos-latest
-            node-version: lts/*
+            node-version: lts
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/setup@v1
         with:
-          node-version: ${{ matrix.node-version }}
-      - run: pnpm install
+          cache: true
+          runtime: node@${{ matrix.node-version }}
       - run: pnpm build
       - run: pnpm test
 
@@ -64,10 +61,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/setup@v1
         with:
-          node-version: lts/*
+          install: false
+          cache: true
+          runtime: node@lts
       - uses: cypress-io/github-action@v6
         with:
           build: pnpm workshop:build
@@ -109,11 +107,10 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/setup@v1
         with:
-          node-version: lts/*
-      - run: pnpm install
+          cache: true
+          runtime: node@lts
       # Branches that will release new versions are defined in .releaserc.json
       - run: pnpm exec semantic-release
         env:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -23,13 +23,10 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/setup@v1
         with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+          cache: true
+          runtime: node@lts
 
       - id: pre-flight
         run: |

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -25,8 +25,14 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/setup@v1
         with:
+          install: false
           cache: true
-          runtime: node@lts
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+
+      - name: Install project dependencies
+        run: pnpm install
 
       - id: pre-flight
         run: |

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,8 +20,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/setup@v1
         with:
+          install: false
           cache: true
-          runtime: node@lts
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+      - run: pnpm install
       - run: pnpm format
       - run: git restore .github/workflows pnpm-lock.yaml
       - uses: actions/create-github-app-token@v2

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -18,11 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/setup@v1
         with:
-          node-version: lts/*
-      - run: pnpm install
+          cache: true
+          runtime: node@lts
       - run: pnpm format
       - run: git restore .github/workflows pnpm-lock.yaml
       - uses: actions/create-github-app-token@v2

--- a/.github/workflows/react-compiler.yml
+++ b/.github/workflows/react-compiler.yml
@@ -20,8 +20,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/setup@v1
         with:
+          install: false
           cache: true
-          runtime: node@lts
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
       - run: pnpm -r up --ignore-scripts react-compiler-runtime@latest babel-plugin-react-compiler@latest eslint-plugin-react-hooks@latest
       - uses: actions/create-github-app-token@v2
         id: generate-token

--- a/.github/workflows/react-compiler.yml
+++ b/.github/workflows/react-compiler.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/setup@v1
         with:
-          node-version: lts/*
+          cache: true
+          runtime: node@lts
       - run: pnpm -r up --ignore-scripts react-compiler-runtime@latest babel-plugin-react-compiler@latest eslint-plugin-react-hooks@latest
       - uses: actions/create-github-app-token@v2
         id: generate-token


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follows the pattern from [`sanity-io/.github#33`](https://github.com/sanity-io/.github/pull/33) / [`sanity-io/sanity#13233`](https://github.com/sanity-io/sanity/pull/13233), which replace the split `pnpm/action-setup` + `actions/setup-node` bootstrap with `pnpm/setup@v1`.

**This repo can't fully adopt that pattern yet** — see "Why not the full pattern?" below — so this PR does the safe subset: swap `pnpm/action-setup@v4` for `pnpm/setup@v1` (gaining real pnpm store caching, which none of these workflows had before) while keeping `actions/setup-node@v5` for Node.js provisioning, exactly as before.

- **`.github/workflows/main.yml`** — all five jobs (`build`, `lint`, `test`, `cypress`, `release`): `pnpm/action-setup@v4` → `pnpm/setup@v1` with `install: false` + `cache: true`, followed by the existing `actions/setup-node@v5` step and explicit `pnpm install` (unchanged).
- **`.github/workflows/prettier.yml`**, **`react-compiler.yml`**, **`pkg-pr-new.yml`** — same swap.

No other behavior changes: Node provisioning, the `pnpm` version, and every `run:` step are untouched.

### Why not the full pattern (single step, no `actions/setup-node`)?

`pnpm/setup@v1`'s combined runtime-install feature (`runtime: node@lts`) shells out to `pnpm runtime set`, a subcommand that only exists in **pnpm >= 11**. This repo pins `"packageManager": "pnpm@9.15.9"`, and `pnpm/setup@v1` always self-updates to that pinned version before invoking `pnpm runtime set`, so every job failed with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "runtime" not found` when I first tried the direct port (see earlier revision of this PR / commit history).

This is exactly what's happening right now in the still-open, still-failing [`sanity-io/plugins#1131`](https://github.com/sanity-io/plugins/pull/1131) (pinned to `pnpm@10.34.4`, which also predates the `runtime` subcommand). The only reference PR that actually passed CI, [`sanity-io/sanity#13233`](https://github.com/sanity-io/sanity/pull/13233), succeeded because that repo was already on `pnpm@11.9.0` beforehand.

Bumping this repo's pnpm major version felt out of scope for a CI-bootstrap change, and looked like a deliberate call already made by this repo's maintainers: Renovate's automated `chore(deps): update pnpm to v10 (main)` proposals (#1814, #1820) and the `v2`-branch equivalent (#1795) were all closed rather than merged, while only the separate `v4` branch was allowed to move to pnpm 10. I didn't want to override that by bumping to 11 as a drive-by in a CI PR — especially since I confirmed locally (by temporarily bumping to `pnpm@11.9.0`) that it would also require:

- Node **>= 22** to run the pnpm CLI itself (pnpm 11 dropped Node 18/20 support),
- moving the `pnpm.overrides` field from `package.json` into `pnpm-workspace.yaml` (pnpm 11 no longer reads `pnpm.*` settings from `package.json`),
- explicitly approving previously-implicit build scripts for `cypress`, `esbuild`, `core-js`, and `unrs-resolver` (blocked by default since pnpm 10's `ERR_PNPM_IGNORED_BUILDS`).

None of that is included here. Once `main` is ready to move to pnpm >= 11, completing the migration is a small diff: drop the `actions/setup-node` step and add `runtime: node@lts` to the `pnpm/setup@v1` step, same as `sanity-io/sanity` did.

### Testing

All workflow YAML validated with a YAML parser. Verified on this PR's own CI: `build`, `cypress`, `ESLint`, both `test` matrix legs (ubuntu/macos), and `release`'s dry-run `semantic-release` step all pass with the new `pnpm/setup@v1` step (see run [28503123247](https://github.com/sanity-io/ui/actions/runs/28503123247)). `prettier.yml`, `react-compiler.yml`, and `pkg-pr-new.yml` use the identical, now-proven construct but aren't `pull_request`-triggered, so they'll run on their normal triggers (push to `main`/schedule/etc).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1ca7-a2fa-76f1-a7ed-ec68aada54f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1ca7-a2fa-76f1-a7ed-ec68aada54f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

