### PR TITLE
chore: stop renovate from maintaining the v4 branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranchPatterns": ["v2", "$default", "v4"],
+  "baseBranchPatterns": ["v2", "$default"],
   "extends": ["github>sanity-io/renovate-config"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "packageRules": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes `v4` from the `baseBranchPatterns` list in `.github/renovate.json`, so Renovate no longer opens dependency-update PRs targeting the `v4` branch.

## Why

The `v4` branch has been inactive for a while (last commit predates recent `main` activity by a couple of months), so Renovate PRs against it are no longer useful and just add noise.

## Notes

- The `v2` and `$default` branches remain maintained, unchanged.
- The existing package rule for Storybook (`v4 is upgrading storybook, do not update it elsewhere`) is left as-is: it only restricts `v2`/`$default` and doesn't reference `v4` in `matchBaseBranches`, so it's unaffected by this change.
- Validated the updated config with Renovate's official `renovate-config-validator` (`INFO: Config validated successfully`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1caa-5f70-72cb-9eed-f849005e657d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1caa-5f70-72cb-9eed-f849005e657d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

