### PR TITLE
chore(renovate): restrict updates to npm production dependencies only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,11 +3,18 @@
   "baseBranchPatterns": ["v2", "$default", "v4"],
   "extends": ["github>sanity-io/renovate-config"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
+  "enabledManagers": ["npm"],
   "packageRules": [
     {
       "matchDepTypes": ["dependencies"],
       "semanticCommitType": "fix",
       "rangeStrategy": "bump"
+    },
+    {
+      "description": "Only update production dependencies; ignore devDependencies, peerDependencies and optionalDependencies",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies", "peerDependencies", "optionalDependencies"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restricts Renovate to only propose updates for npm production dependencies.

## Changes

- Added `enabledManagers: ["npm"]` at the top level, which disables every other manager (notably `github-actions`, so GitHub Action versions/digests will no longer be updated). Only the `npm` manager remains active.
- Added a `packageRules` entry that disables Renovate for `devDependencies`, `peerDependencies`, and `optionalDependencies` within the `npm` manager.
- The existing rule for `dependencies` (prod deps) is left untouched, so Renovate will continue to open PRs only for production `dependencies` updates.

## Why

Per request, Renovate should stop touching anything other than npm production dependencies: devDependencies, peerDependencies, and GitHub Actions updates are now ignored.

## Validation

- Verified `.github/renovate.json` is valid JSON.
- Ran Renovate's official `renovate-config-validator` (via `npx -p renovate renovate-config-validator .github/renovate.json`), which reported: `Config validated successfully`.
- Confirmed the repo has no Dockerfiles/CircleCI config, so GitHub Actions workflows (`.github/workflows/*.yml`) were the only non-npm manager surface affected by this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1cac-ea18-7c82-92dd-af7877e921c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1cac-ea18-7c82-92dd-af7877e921c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

