### PR TITLE
chore: set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`@sanity/ui` is a React component library published as `@sanity/ui`. It is a pnpm
+workspace: the root package plus a `figma` package (`pnpm-workspace.yaml`).
+Package manager is pnpm (`packageManager` pin in `package.json`); Node must satisfy
+`>=20.19 <22 || >=22.12`.
+
+Standard scripts live in `package.json` (`lint`, `ts:check`, `test`, `build`, `dev`).
+Notes that are not obvious from the scripts:
+
+- Tests require a built package first. `pnpm test` (jest) resolves `@sanity/ui` and
+  `@sanity/ui/theme` from `./dist` (via package `exports`), so you must run
+  `pnpm build` at least once before `pnpm test` or every suite fails with
+  "Cannot find module '@sanity/ui'". Re-run `pnpm build` after changing source that
+  tests import through the package entrypoints.
+- `pnpm dev` runs two servers in parallel (`run-p storybook:dev workshop:dev`):
+  Storybook on http://localhost:6006 and the Workshop on http://localhost:1337.
+  The Workshop is Vite-based and aliases `@sanity/ui` to the `exports/` source, so
+  it hot-reloads source edits directly (no rebuild needed); Storybook likewise reads
+  source. Only jest depends on `dist`.
+- The Workshop's first component render can show a long loading spinner while Vite
+  optimizes deps on demand; it is warm after the first load. This is expected, not a
+  failure.
+- Commits are linted by a husky `commit-msg` hook running commitlint
+  (conventional-commits). Use conventional commit messages (e.g. `chore: ...`,
+  `fix: ...`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `@sanity/ui` in Cursor Cloud and verifies the full dev toolchain works end-to-end.

- Adds `AGENTS.md` with Cursor Cloud specific notes (non-obvious caveats for future agents).

## Environment

- pnpm workspace (root + `figma`), Node `>=20.19 <22 || >=22.12` (used v22).
- Update script: `pnpm install`.

## Key learning

`pnpm test` (jest) resolves `@sanity/ui` from `./dist`, so `pnpm build` must run before tests or every suite fails with "Cannot find module '@sanity/ui'".

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Lint | `pnpm lint` | pass |
| Types | `pnpm ts:check` | pass |
| Build | `pnpm build` | pass |
| Tests | `pnpm test` | 42 suites / 125 tests pass |
| Dev | `pnpm dev` | Storybook :6006 + Workshop :1337 |

Interactive hello-world verified in both Storybook and the Workshop (rendered Button, edited props live).

[sanity_ui_storybook_hello_world.mp4](https://cursor.com/agents/bc-23e51b1d-2754-4316-8b62-870b9cba8f26/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsanity_ui_storybook_hello_world.mp4)
[sanity_ui_workshop_hello_world.mp4](https://cursor.com/agents/bc-23e51b1d-2754-4316-8b62-870b9cba8f26/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsanity_ui_workshop_hello_world.mp4)
[Storybook button hello world](https://cursor.com/agents/bc-23e51b1d-2754-4316-8b62-870b9cba8f26/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_button_hello_world.webp)
[Workshop button primary tone](https://cursor.com/agents/bc-23e51b1d-2754-4316-8b62-870b9cba8f26/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkshop_button_primary.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23e51b1d-2754-4316-8b62-870b9cba8f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23e51b1d-2754-4316-8b62-870b9cba8f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

