### PR TITLE
chore: migrate from prettier to oxfmt

### DIFF
--- a/.changeset/verify-release-pipeline.md
+++ b/.changeset/verify-release-pipeline.md
@@ -1,5 +1,5 @@
 ---
-'@sanity/ui': patch
+"@sanity/ui": patch
 ---
 
 Set up Changesets-based releases with npm trusted publishing. No runtime changes.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,9 +1,9 @@
-name: "Setup Environment"
-description: "Sets up pnpm and a Node.js runtime, and installs dependencies"
+name: 'Setup Environment'
+description: 'Sets up pnpm and a Node.js runtime, and installs dependencies'
 
 inputs:
   runtime:
-    description: "Runtime to install, e.g. node@lts or node@latest"
+    description: 'Runtime to install, e.g. node@lts or node@latest'
     required: false
     default: node@lts
 

--- a/.github/workflows/format-if-needed.yml
+++ b/.github/workflows/format-if-needed.yml
@@ -1,35 +1,15 @@
-name: Format
+name: Auto format
 
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch:
+    branches: [main]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
-  cancel-in-progress: true
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read # for checkout
 
 jobs:
-  run:
-    name: Can the code be prettier? 🤔
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/setup
-      - run: pnpm format
-      - run: git restore .github/workflows pnpm-lock.yaml
-      - uses: actions/create-github-app-token@v2
-        id: generate-token
-        with:
-          app-id: ${{ secrets.ECOSPARK_APP_ID }}
-          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
-      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
-        with:
-          body: I ran `pnpm format` 🧑‍💻
-          branch: actions/prettier-${{ github.ref_name }}
-          commit-message: "chore(prettier): 🤖 ✨"
-          labels: 🤖 bot
-          sign-commits: true
-          title: "chore(prettier): 🤖 ✨"
-          token: ${{ steps.generate-token.outputs.token }}
+  if-needed:
+    uses: sanity-io/.github/.github/workflows/format.yml@main
+    secrets: inherit

--- a/.github/workflows/react-compiler.yml
+++ b/.github/workflows/react-compiler.yml
@@ -2,7 +2,7 @@ name: Maintain React Compiler
 
 on:
   schedule:
-    - cron: "10 12 * * 1" # Runs at 12:10 PM UTC every Monday, which is 3 hours after the React Compiler release: https://github.com/facebook/react/blob/989af12f72080c17db03ead91d99b6394a215564/.github/workflows/compiler_prereleases_weekly.yml#L5-L6
+    - cron: '10 12 * * 1' # Runs at 12:10 PM UTC every Monday, which is 3 hours after the React Compiler release: https://github.com/facebook/react/blob/989af12f72080c17db03ead91d99b6394a215564/.github/workflows/compiler_prereleases_weekly.yml#L5-L6
   workflow_dispatch:
 
 concurrency:
@@ -37,8 +37,8 @@ jobs:
         with:
           body: I ran `pnpm -r up --ignore-scripts react-compiler-runtime@latest babel-plugin-react-compiler@latest eslint-plugin-react-hooks@latest` 🧑‍💻
           branch: actions/react-compiler-${{ github.ref_name }}
-          commit-message: "fix(deps): update react compiler dependencies 🤖 ✨"
+          commit-message: 'fix(deps): update react compiler dependencies 🤖 ✨'
           labels: 🤖 bot
           sign-commits: true
-          title: "fix(deps): update React Compiler dependencies 🤖 ✨"
+          title: 'fix(deps): update React Compiler dependencies 🤖 ✨'
           token: ${{ steps.generate-token.outputs.token }}

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true,
+  "bracketSpacing": false,
+  "quoteProps": "consistent",
+  "sortImports": true,
+  "sortPackageJson": {"sortScripts": true},
+  "ignorePatterns": [".workshop/**", "dist/**", "pnpm-lock.yaml", "CHANGELOG.md"],
+  "overrides": [
+    {
+      "files": [".changeset/*.md"],
+      "options": {"singleQuote": false}
+    }
+  ]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,0 @@
-.workshop
-dist
-pnpm-lock.yaml
-CHANGELOG.md

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["oxc.oxc-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "oxc.fmt.configPath": ".oxfmtrc.json"
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "dev": "pnpm --filter @sanity/ui dev",
-    "format": "prettier --write --cache --ignore-unknown .",
+    "format": "oxfmt . --no-error-on-unmatched-pattern",
     "lint": "pnpm --filter @sanity/ui lint",
     "release": "changeset publish",
     "storybook:build": "pnpm --filter @sanity/ui storybook:build && cpx 'packages/ui/storybook/storybook-static/**' storybook/storybook-static/",
@@ -23,31 +23,29 @@
     "workshop:build": "pnpm --filter @sanity/ui workshop:build && cpx 'packages/ui/dist/**' dist/",
     "workshop:start": "http-server -a localhost -c-0 -p 1337 -s -P http://localhost:1337/index.html? dist"
   },
-  "lint-staged": {
-    "*": [
-      "prettier --write --cache --ignore-unknown"
-    ]
-  },
-  "prettier": "@sanity/prettier-config",
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
-    "@sanity/prettier-config": "^2.0.1",
     "cpx": "^1.5.0",
     "cypress": "^13.17.0",
     "cypress-real-events": "^1.14.0",
     "http-server": "^14.1.1",
     "lint-staged": "^14.0.1",
     "npm-run-all2": "^8.0.4",
-    "prettier": "^3.6.2",
+    "oxfmt": "^0.57.0",
     "rimraf": "^5.0.5",
     "start-server-and-test": "^2.1.0",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@11.9.0",
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,json,jsonc,md}": [
+      "oxfmt --no-error-on-unmatched-pattern"
+    ]
+  },
   "engines": {
     "node": ">=22.13"
   },
+  "packageManager": "pnpm@11.9.0",
   "pnpm": {
     "overrides": {
       "@types/react": "^19.2.2",

--- a/packages/figma/package.json
+++ b/packages/figma/package.json
@@ -5,8 +5,10 @@
   "description": "",
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",
-  "sideEffects": false,
   "type": "module",
+  "sideEffects": false,
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "source": "./src/index.ts",
@@ -15,8 +17,6 @@
     },
     "./package.json": "./package.json"
   },
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "pkg build --strict && pkg --strict",
     "watch": "pkg watch --strict"

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -6,7 +6,6 @@ import jsxA11y from 'eslint-plugin-jsx-a11y'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
-import simpleImportSort from 'eslint-plugin-simple-import-sort'
 import storybook from 'eslint-plugin-storybook'
 import globals from 'globals'
 import ts from 'typescript-eslint'
@@ -53,17 +52,6 @@ export default ts.config(
           },
         ],
         'no-warning-comments': ['warn', {location: 'start', terms: ['todo', '@todo', 'fixme']}],
-      },
-    },
-
-    // simple-import-sort
-    {
-      plugins: {
-        'simple-import-sort': simpleImportSort,
-      },
-      rules: {
-        'simple-import-sort/imports': 'error',
-        'simple-import-sort/exports': 'error',
       },
     },
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,26 +2,44 @@
   "name": "@sanity/ui",
   "version": "3.3.0",
   "keywords": [
-    "sanity",
-    "ui",
+    "components",
+    "design-system",
     "primitives",
     "react",
-    "components",
-    "design-system"
+    "sanity",
+    "ui"
   ],
   "homepage": "https://www.sanity.io/",
   "bugs": {
     "url": "https://github.com/sanity-io/ui/issues"
   },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/ui.git",
     "directory": "packages/ui"
   },
-  "license": "MIT",
-  "author": "Sanity.io <hello@sanity.io>",
-  "sideEffects": false,
+  "files": [
+    "dist",
+    "exports",
+    "src"
+  ],
   "type": "commonjs",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "_visual-editing": [
+        "./dist/_visual-editing.d.ts"
+      ],
+      "theme": [
+        "./dist/theme.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "source": "./exports/index.ts",
@@ -43,32 +61,17 @@
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "_visual-editing": [
-        "./dist/_visual-editing.d.ts"
-      ],
-      "theme": [
-        "./dist/theme.d.ts"
-      ]
-    }
+  "publishConfig": {
+    "access": "public"
   },
-  "files": [
-    "dist",
-    "exports",
-    "src"
-  ],
   "scripts": {
     "build": "run-s clean pkg:build pkg:check",
     "clean": "rimraf .workshop dist",
     "dev": "run-p storybook:dev workshop:dev",
     "lint": "eslint .",
-    "prepack": "pnpm build",
     "pkg:build": "pkg build --strict",
     "pkg:check": "pkg --strict",
+    "prepack": "pnpm build",
     "storybook:build": "storybook build -o storybook/storybook-static",
     "storybook:dev": "storybook dev -p 6006",
     "test": "jest",
@@ -132,7 +135,6 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-storybook": "^0.12.0",
     "globals": "^16.3.0",
     "jest": "^30.1.3",
@@ -161,9 +163,6 @@
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "esm.sh": {
     "bundle": false

--- a/packages/ui/src/core/components/menu/__workshop__/tones.tsx
+++ b/packages/ui/src/core/components/menu/__workshop__/tones.tsx
@@ -1,7 +1,7 @@
 import {CubeIcon} from '@sanity/icons'
 import {Box, Card, LayerProvider, Menu, MenuItem} from '@sanity/ui'
-import {THEME_COLOR_STATE_TONES} from '@sanity/ui/theme'
 import {useBoolean, useSelect} from '@sanity/ui-workshop'
+import {THEME_COLOR_STATE_TONES} from '@sanity/ui/theme'
 
 import {WORKSHOP_CARD_TONE_OPTIONS} from '../../../__workshop__/constants'
 

--- a/packages/ui/src/core/primitives/badge/__workshop__/tones.tsx
+++ b/packages/ui/src/core/primitives/badge/__workshop__/tones.tsx
@@ -1,6 +1,6 @@
 import {Badge, Flex, Inline} from '@sanity/ui'
-import {THEME_COLOR_STATE_TONES} from '@sanity/ui/theme'
 import {useSelect} from '@sanity/ui-workshop'
+import {THEME_COLOR_STATE_TONES} from '@sanity/ui/theme'
 
 import {WORKSHOP_BADGE_MODE_OPTIONS} from '../../../__workshop__/constants'
 

--- a/packages/ui/src/core/primitives/box/box.tsx
+++ b/packages/ui/src/core/primitives/box/box.tsx
@@ -30,7 +30,8 @@ import {
  * @public
  */
 export interface BoxOwnProps
-  extends ResponsiveFlexItemProps,
+  extends
+    ResponsiveFlexItemProps,
     ResponsiveBoxProps,
     ResponsiveGridItemProps,
     ResponsiveMarginProps,

--- a/packages/ui/src/core/primitives/card/__workshop__/selected.tsx
+++ b/packages/ui/src/core/primitives/card/__workshop__/selected.tsx
@@ -1,7 +1,7 @@
 import {EditIcon, PublishIcon} from '@sanity/icons'
 import {Box, Card, Container, Flex, Inline, Stack, Text, ThemeProps, useRootTheme} from '@sanity/ui'
-import {getTheme_v2, ThemeColorStateToneKey} from '@sanity/ui/theme'
 import {useBoolean} from '@sanity/ui-workshop'
+import {getTheme_v2, ThemeColorStateToneKey} from '@sanity/ui/theme'
 import {css, styled} from 'styled-components'
 
 const TextWithTone = styled(Text)<{$tone: ThemeColorStateToneKey}>((

--- a/packages/ui/src/core/primitives/card/card.tsx
+++ b/packages/ui/src/core/primitives/card/card.tsx
@@ -23,10 +23,7 @@ import {CardStyleProps} from './types'
  * @public
  */
 export interface CardOwnProps
-  extends BoxOwnProps,
-    ResponsiveBorderProps,
-    ResponsiveRadiusProps,
-    ResponsiveShadowProps {
+  extends BoxOwnProps, ResponsiveBorderProps, ResponsiveRadiusProps, ResponsiveShadowProps {
   /**
    * Do not use in production.
    * @beta

--- a/packages/ui/src/core/primitives/flex/flex.tsx
+++ b/packages/ui/src/core/primitives/flex/flex.tsx
@@ -16,9 +16,7 @@ import {ResponsiveFlexItemProps, ResponsiveFlexProps} from '../types'
  * @public
  */
 export interface FlexOwnProps
-  extends Omit<BoxOwnProps, 'display'>,
-    ResponsiveFlexProps,
-    ResponsiveFlexItemProps {
+  extends Omit<BoxOwnProps, 'display'>, ResponsiveFlexProps, ResponsiveFlexItemProps {
   gap?: number | number[]
 }
 

--- a/packages/ui/src/core/primitives/kbd/kbd.tsx
+++ b/packages/ui/src/core/primitives/kbd/kbd.tsx
@@ -42,7 +42,10 @@ function kbdStyle() {
 const StyledKBD = styled.kbd<ResponsiveRadiusStyleProps>(responsiveRadiusStyle, kbdStyle)
 
 const KBDComponent = forwardRef(function KBD(
-  props: KBDOwnProps & {as?: ElementType} & Omit<React.HTMLProps<HTMLElement>, 'as' | 'ref' | 'size'>,
+  props: KBDOwnProps & {as?: ElementType} & Omit<
+      React.HTMLProps<HTMLElement>,
+      'as' | 'ref' | 'size'
+    >,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   const {children, fontSize = 0, padding = 1, radius = 2, ...restProps} = props

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -45,9 +45,7 @@ import {PopoverUpdateCallback, PopoverWidth} from './types'
 
 /** @public */
 export interface PopoverProps
-  extends Omit<LayerProps, 'as'>,
-    ResponsiveRadiusProps,
-    ResponsiveShadowProps {
+  extends Omit<LayerProps, 'as'>, ResponsiveRadiusProps, ResponsiveShadowProps {
   /** @beta */
   __unstable_margins?: PopoverMargins
   /**

--- a/packages/ui/src/core/primitives/text/__workshop__/colored.tsx
+++ b/packages/ui/src/core/primitives/text/__workshop__/colored.tsx
@@ -1,6 +1,6 @@
 import {Flex, Text, ThemeProps} from '@sanity/ui'
-import {getTheme_v2, ThemeColorAvatarColorKey, ThemeColorSpotKey} from '@sanity/ui/theme'
 import {useSelect} from '@sanity/ui-workshop'
+import {getTheme_v2, ThemeColorAvatarColorKey, ThemeColorSpotKey} from '@sanity/ui/theme'
 import {css, styled} from 'styled-components'
 
 import {WORKSHOP_SPOT_COLOR_OPTIONS} from '../../../__workshop__/constants'

--- a/packages/ui/src/core/primitives/tooltip/tooltip.test.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltip.test.tsx
@@ -1,7 +1,6 @@
 /** @jest-environment jsdom */
 import '../../../../test/mocks/resizeObserver.mock'
 import '../../../../test/mocks/matchMedia.mock'
-
 import {act, fireEvent, screen} from '@testing-library/react'
 
 import {render} from '../../../../test'

--- a/packages/ui/src/core/styles/font/types.ts
+++ b/packages/ui/src/core/styles/font/types.ts
@@ -27,9 +27,7 @@ export interface ResponsiveTextAlignStyleProps {
  * @internal
  */
 export interface ResponsiveFontStyleProps
-  extends FontWeightStyleProps,
-    ResponsiveFontSizeStyleProps,
-    ResponsiveTextAlignStyleProps {
+  extends FontWeightStyleProps, ResponsiveFontSizeStyleProps, ResponsiveTextAlignStyleProps {
   $accent?: boolean
   $muted?: boolean
 }

--- a/packages/ui/src/core/theme/__workshop__/canvas.tsx
+++ b/packages/ui/src/core/theme/__workshop__/canvas.tsx
@@ -9,6 +9,7 @@ import {
   ThemeColorProvider,
   useRootTheme,
 } from '@sanity/ui'
+import {useBoolean} from '@sanity/ui-workshop'
 import {
   getContrastRatio,
   mix,
@@ -23,7 +24,6 @@ import {
   ThemeColorSelectableTone_v2,
   ThemeColorState_v2,
 } from '@sanity/ui/theme'
-import {useBoolean} from '@sanity/ui-workshop'
 import {createContext, useContext} from 'react'
 
 interface Features {

--- a/packages/ui/src/core/theme/__workshop__/debug/story.tsx
+++ b/packages/ui/src/core/theme/__workshop__/debug/story.tsx
@@ -1,4 +1,5 @@
 import {CropIcon} from '@sanity/icons'
+import {useBoolean, useSelect} from '@sanity/ui-workshop'
 import {
   THEME_COLOR_BUTTON_MODES,
   THEME_COLOR_STATE_TONES,
@@ -9,7 +10,6 @@ import {
   ThemeColorSchemeKey,
   ThemeColorState_v2,
 } from '@sanity/ui/theme'
-import {useBoolean, useSelect} from '@sanity/ui-workshop'
 import {CSSProperties} from 'react'
 
 import {Badge, Box, Flex, KBD, Stack, Text} from '../../../primitives'

--- a/packages/ui/src/theme/config/tokens/color/types.ts
+++ b/packages/ui/src/theme/config/tokens/color/types.ts
@@ -99,8 +99,9 @@ export interface ThemeColorStateTokens {
 export type ThemeColorStatesTokens = Partial<Record<ColorConfigState, ThemeColorStateTokens>>
 
 /** @public */
-export interface ThemeColorButtonTokens
-  extends Partial<Record<ColorConfigStateTone, ThemeColorStatesTokens>> {
+export interface ThemeColorButtonTokens extends Partial<
+  Record<ColorConfigStateTone, ThemeColorStatesTokens>
+> {
   _hue?: ColorHueKey
 }
 
@@ -118,8 +119,9 @@ export interface ThemeColorInputStateTokens {
 }
 
 /** @public */
-export interface ThemeColorInputTokens
-  extends Partial<Record<ColorConfigInputState, ThemeColorInputStateTokens>> {
+export interface ThemeColorInputTokens extends Partial<
+  Record<ColorConfigInputState, ThemeColorInputStateTokens>
+> {
   _hue?: ColorHueKey
 }
 

--- a/packages/ui/workshop.config.ts
+++ b/packages/ui/workshop.config.ts
@@ -1,6 +1,6 @@
-import {buildTheme} from '@sanity/ui/theme'
 import {defineConfig} from '@sanity/ui-workshop'
 import {perfPlugin} from '@sanity/ui-workshop/plugin-perf'
+import {buildTheme} from '@sanity/ui/theme'
 import {registerLanguage} from 'react-refractor'
 import javascript from 'refractor/javascript'
 import json from 'refractor/json'

--- a/packages/ui/workshop.runtime.ts
+++ b/packages/ui/workshop.runtime.ts
@@ -1,5 +1,6 @@
-import {defineRuntime} from '@sanity/ui-workshop'
 import path from 'path'
+
+import {defineRuntime} from '@sanity/ui-workshop'
 
 const EXPORTS_PATH = path.resolve(__dirname, 'exports')
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@22.18.6)
-      '@sanity/prettier-config':
-        specifier: ^2.0.1
-        version: 2.0.1(prettier@3.6.2)
       cpx:
         specifier: ^1.5.0
         version: 1.5.0
@@ -43,9 +40,9 @@ importers:
       npm-run-all2:
         specifier: ^8.0.4
         version: 8.0.4
-      prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
+      oxfmt:
+        specifier: ^0.57.0
+        version: 0.57.0
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
@@ -239,9 +236,6 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.24
         version: 0.4.24(eslint@9.39.1(jiti@2.5.1)(supports-color@8.1.1))
-      eslint-plugin-simple-import-sort:
-        specifier: ^12.1.1
-        version: 12.1.1(eslint@9.39.1(jiti@2.5.1)(supports-color@8.1.1))
       eslint-plugin-storybook:
         specifier: ^0.12.0
         version: 0.12.0(eslint@9.39.1(jiti@2.5.1)(supports-color@8.1.1))(typescript@5.9.3)
@@ -1523,106 +1517,130 @@ packages:
     resolution: {integrity: sha512-9+qMSaDpahC0+vX2ChM46/ls6a5Ankqs6RTLrHSaFpm7o1mFanP82e+jm9/0o5D660ueK8dWJGPCXQrBxBNNWA==}
     engines: {node: '>= 12'}
 
-  '@oxc-parser/binding-android-arm64@0.74.0':
-    resolution: {integrity: sha512-lgq8TJq22eyfojfa2jBFy2m66ckAo7iNRYDdyn9reXYA3I6Wx7tgGWVx1JAp1lO+aUiqdqP/uPlDaETL9tqRcg==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-project/types@0.95.0':
+    resolution: {integrity: sha512-vACy7vhpMPhjEJhULNxrdR0D943TkA/MigMpJCHmBHvMXxRStRi/dPtTlfQ3uDwWSzRpT8z+7ImjZVf8JWBocQ==}
+
+  '@oxfmt/binding-android-arm-eabi@0.57.0':
+    resolution: {integrity: sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.57.0':
+    resolution: {integrity: sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-darwin-arm64@0.74.0':
-    resolution: {integrity: sha512-xbY/io/hkARggbpYEMFX6CwFzb7f4iS6WuBoBeZtdqRWfIEi7sm/uYWXfyVeB8uqOATvJ07WRFC2upI8PSI83g==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-darwin-arm64@0.57.0':
+    resolution: {integrity: sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.74.0':
-    resolution: {integrity: sha512-FIj2gAGtFaW0Zk+TnGyenMUoRu1ju+kJ/h71D77xc1owOItbFZFGa+4WSVck1H8rTtceeJlK+kux+vCjGFCl9Q==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-darwin-x64@0.57.0':
+    resolution: {integrity: sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-freebsd-x64@0.74.0':
-    resolution: {integrity: sha512-W1I+g5TJg0TRRMHgEWNWsTIfe782V3QuaPgZxnfPNmDMywYdtlzllzclBgaDq6qzvZCCQc/UhvNb37KWTCTj8A==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-freebsd-x64@0.57.0':
+    resolution: {integrity: sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.74.0':
-    resolution: {integrity: sha512-gxqkyRGApeVI8dgvJ19SYe59XASW3uVxF1YUgkE7peW/XIg5QRAOVTFKyTjI9acYuK1MF6OJHqx30cmxmZLtiQ==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.57.0':
+    resolution: {integrity: sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.74.0':
-    resolution: {integrity: sha512-jpnAUP4Fa93VdPPDzxxBguJmldj/Gpz7wTXKFzpAueqBMfZsy9KNC+0qT2uZ9HGUDMzNuKw0Se3bPCpL/gfD2Q==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-linux-arm-musleabihf@0.57.0':
+    resolution: {integrity: sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.74.0':
-    resolution: {integrity: sha512-fcWyM7BNfCkHqIf3kll8fJctbR/PseL4RnS2isD9Y3FFBhp4efGAzhDaxIUK5GK7kIcFh1P+puIRig8WJ6IMVQ==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-linux-arm64-gnu@0.57.0':
+    resolution: {integrity: sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.74.0':
-    resolution: {integrity: sha512-AMY30z/C77HgiRRJX7YtVUaelKq1ex0aaj28XoJu4SCezdS8i0IftUNTtGS1UzGjGZB8zQz5SFwVy4dRu4GLwg==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-linux-arm64-musl@0.57.0':
+    resolution: {integrity: sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.74.0':
-    resolution: {integrity: sha512-/RZAP24TgZo4vV/01TBlzRqs0R7E6xvatww4LnmZEBBulQBU/SkypDywfriFqWuFoa61WFXPV7sLcTjJGjim/w==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-linux-ppc64-gnu@0.57.0':
+    resolution: {integrity: sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.57.0':
+    resolution: {integrity: sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.74.0':
-    resolution: {integrity: sha512-620J1beNAlGSPBD+Msb3ptvrwxu04B8iULCH03zlf0JSLy/5sqlD6qBs0XUVkUJv1vbakUw1gfVnUQqv0UTuEg==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-linux-riscv64-musl@0.57.0':
+    resolution: {integrity: sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.57.0':
+    resolution: {integrity: sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.74.0':
-    resolution: {integrity: sha512-WBFgQmGtFnPNzHyLKbC1wkYGaRIBxXGofO0+hz1xrrkPgbxbJS1Ukva1EB8sPaVBBQ52Bdc2GjLSp721NWRvww==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-linux-x64-gnu@0.57.0':
+    resolution: {integrity: sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-musl@0.74.0':
-    resolution: {integrity: sha512-y4mapxi0RGqlp3t6Sm+knJlAEqdKDYrEue2LlXOka/F2i4sRN0XhEMPiSOB3ppHmvK4I2zY2XBYTsX1Fel0fAg==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-linux-x64-musl@0.57.0':
+    resolution: {integrity: sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-wasm32-wasi@0.74.0':
-    resolution: {integrity: sha512-yDS9bRDh5ymobiS2xBmjlrGdUuU61IZoJBaJC5fELdYT5LJNBXlbr3Yc6m2PWfRJwkH6Aq5fRvxAZ4wCbkGa8w==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
+  '@oxfmt/binding-openharmony-arm64@0.57.0':
+    resolution: {integrity: sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.74.0':
-    resolution: {integrity: sha512-XFWY52Rfb4N5wEbMCTSBMxRkDLGbAI9CBSL24BIDywwDJMl31gHEVlmHdCDRoXAmanCI6gwbXYTrWe0HvXJ7Aw==}
-    engines: {node: '>=20.0.0'}
+  '@oxfmt/binding-win32-arm64-msvc@0.57.0':
+    resolution: {integrity: sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.74.0':
-    resolution: {integrity: sha512-1D3x6iU2apLyfTQHygbdaNbX3nZaHu4yaXpD7ilYpoLo7f0MX0tUuoDrqJyJrVGqvyXgc0uz4yXz9tH9ZZhvvg==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
+  '@oxfmt/binding-win32-ia32-msvc@0.57.0':
+    resolution: {integrity: sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
     os: [win32]
 
-  '@oxc-project/types@0.74.0':
-    resolution: {integrity: sha512-KOw/RZrVlHGhCXh1RufBFF7Nuo7HdY5w1lRJukM/igIl6x9qtz8QycDvZdzb4qnHO7znrPyo2sJrFJK2eKHgfQ==}
-
-  '@oxc-project/types@0.95.0':
-    resolution: {integrity: sha512-vACy7vhpMPhjEJhULNxrdR0D943TkA/MigMpJCHmBHvMXxRStRi/dPtTlfQ3uDwWSzRpT8z+7ImjZVf8JWBocQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.57.0':
+    resolution: {integrity: sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1643,10 +1661,6 @@ packages:
   '@pnpm/npm-conf@2.3.1':
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
-
-  '@prettier/plugin-oxc@0.0.4':
-    resolution: {integrity: sha512-UGXe+g/rSRbglL0FOJiar+a+nUrst7KaFmsg05wYbKiInGWP6eAj/f8A2Uobgo5KxEtb2X10zeflNH6RK2xeIQ==}
-    engines: {node: '>=14'}
 
   '@rolldown/binding-android-arm64@1.0.0-beta.45':
     resolution: {integrity: sha512-bfgKYhFiXJALeA/riil908+2vlyWGdwa7Ju5S+JgWZYdR4jtiPOGdM6WLfso1dojCh+4ZWeiTwPeV9IKQEX+4g==}
@@ -1994,11 +2008,6 @@ packages:
     peerDependenciesMeta:
       babel-plugin-react-compiler:
         optional: true
-
-  '@sanity/prettier-config@2.0.1':
-    resolution: {integrity: sha512-FwbBgFKOw72YujXRGCZraenYDbu5/HCyiWES5YkOVoKgUCwkCV1Nzkd4foWCmKI9eA+46L4xNbwKnojoZ124fQ==}
-    peerDependencies:
-      prettier: ^3.6.2
 
   '@sanity/styled-components@6.1.23':
     resolution: {integrity: sha512-zhyX17Qx/9AwXrV13T1qAM02zhZOtI9R9nEsoMampAKwyR155P8Kw7n2MBTADvxWaYBCAgh77wtOuNGAjCWeNw==}
@@ -3440,10 +3449,6 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
-  detect-indent@7.0.2:
-    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
-    engines: {node: '>=12.20'}
-
   detect-libc@2.1.0:
     resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
     engines: {node: '>=8'}
@@ -3451,10 +3456,6 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
-
-  detect-newline@4.0.1:
-    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -3699,11 +3700,6 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
-
-  eslint-plugin-simple-import-sort@12.1.1:
-    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
-    peerDependencies:
-      eslint: '>=5.0.0'
 
   eslint-plugin-storybook@0.12.0:
     resolution: {integrity: sha512-Lg5I0+npTgiYgZ4KSvGWGDFZi3eOCNJPaWX0c9rTEEXC5wvooOClsP9ZtbI4hhFKyKgYR877KiJxbRTSJq9gWA==}
@@ -4096,9 +4092,6 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-
-  git-hooks-list@4.1.1:
-    resolution: {integrity: sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==}
 
   git-up@8.1.1:
     resolution: {integrity: sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==}
@@ -5624,9 +5617,18 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  oxc-parser@0.74.0:
-    resolution: {integrity: sha512-2tDN/ttU8WE6oFh8EzKNam7KE7ZXSG5uXmvX85iNzxdJfMssDWcj3gpYzZi1E04XuE7m3v1dVWl/8BE886vPGw==}
-    engines: {node: '>=20.0.0'}
+  oxfmt@0.57.0:
+    resolution: {integrity: sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -5822,14 +5824,6 @@ packages:
   preserve@0.2.0:
     resolution: {integrity: sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==}
     engines: {node: '>=0.10.0'}
-
-  prettier-plugin-packagejson@2.5.19:
-    resolution: {integrity: sha512-Qsqp4+jsZbKMpEGZB1UP1pxeAT8sCzne2IwnKkr+QhUe665EXUo3BAvTf1kAPCqyMv9kg3ZmO0+7eOni/C6Uag==}
-    peerDependencies:
-      prettier: '>= 1.16.0'
-    peerDependenciesMeta:
-      prettier:
-        optional: true
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -6362,14 +6356,6 @@ packages:
     resolution: {integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==}
     engines: {node: '>=0.10.0'}
 
-  sort-object-keys@1.1.3:
-    resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
-
-  sort-package-json@3.4.0:
-    resolution: {integrity: sha512-97oFRRMM2/Js4oEA9LJhjyMlde+2ewpZQf53pgue27UkbEXfHJnDzHlUxQ/DWUkzqmp7DFwJp8D+wi/TYeQhpA==}
-    engines: {node: '>=20'}
-    hasBin: true
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -6595,6 +6581,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
@@ -8699,56 +8689,64 @@ snapshots:
       estree-walker: 2.0.2
       magic-string: 0.30.21
 
-  '@oxc-parser/binding-android-arm64@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-arm64@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-x64@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-freebsd-x64@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-wasm32-wasi@0.74.0':
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.12
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.74.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.74.0':
-    optional: true
-
-  '@oxc-project/types@0.74.0': {}
-
   '@oxc-project/types@0.95.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.57.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -8766,10 +8764,6 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
-
-  '@prettier/plugin-oxc@0.0.4':
-    dependencies:
-      oxc-parser: 0.74.0
 
   '@rolldown/binding-android-arm64@1.0.0-beta.45':
     optional: true
@@ -9060,12 +9054,6 @@ snapshots:
       - oxc-resolver
       - supports-color
       - vue-tsc
-
-  '@sanity/prettier-config@2.0.1(prettier@3.6.2)':
-    dependencies:
-      '@prettier/plugin-oxc': 0.0.4
-      prettier: 3.6.2
-      prettier-plugin-packagejson: 2.5.19(prettier@3.6.2)
 
   '@sanity/styled-components@6.1.23(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -10768,13 +10756,9 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-indent@7.0.2: {}
-
   detect-libc@2.1.0: {}
 
   detect-newline@3.1.0: {}
-
-  detect-newline@4.0.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -11135,10 +11119,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
-
-  eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.1(jiti@2.5.1)(supports-color@8.1.1)):
-    dependencies:
-      eslint: 9.39.1(jiti@2.5.1)(supports-color@8.1.1)
 
   eslint-plugin-storybook@0.12.0(eslint@9.39.1(jiti@2.5.1)(supports-color@8.1.1))(typescript@5.9.3):
     dependencies:
@@ -11659,8 +11639,6 @@ snapshots:
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
-
-  git-hooks-list@4.1.1: {}
 
   git-up@8.1.1:
     dependencies:
@@ -13552,25 +13530,29 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxc-parser@0.74.0:
+  oxfmt@0.57.0:
     dependencies:
-      '@oxc-project/types': 0.74.0
+      tinypool: 2.1.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm64': 0.74.0
-      '@oxc-parser/binding-darwin-arm64': 0.74.0
-      '@oxc-parser/binding-darwin-x64': 0.74.0
-      '@oxc-parser/binding-freebsd-x64': 0.74.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.74.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.74.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.74.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.74.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.74.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.74.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.74.0
-      '@oxc-parser/binding-linux-x64-musl': 0.74.0
-      '@oxc-parser/binding-wasm32-wasi': 0.74.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.74.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.74.0
+      '@oxfmt/binding-android-arm-eabi': 0.57.0
+      '@oxfmt/binding-android-arm64': 0.57.0
+      '@oxfmt/binding-darwin-arm64': 0.57.0
+      '@oxfmt/binding-darwin-x64': 0.57.0
+      '@oxfmt/binding-freebsd-x64': 0.57.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.57.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.57.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.57.0
+      '@oxfmt/binding-linux-arm64-musl': 0.57.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.57.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.57.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.57.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.57.0
+      '@oxfmt/binding-linux-x64-gnu': 0.57.0
+      '@oxfmt/binding-linux-x64-musl': 0.57.0
+      '@oxfmt/binding-openharmony-arm64': 0.57.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.57.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.57.0
+      '@oxfmt/binding-win32-x64-msvc': 0.57.0
 
   p-filter@2.1.0:
     dependencies:
@@ -13743,13 +13725,6 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   preserve@0.2.0: {}
-
-  prettier-plugin-packagejson@2.5.19(prettier@3.6.2):
-    dependencies:
-      sort-package-json: 3.4.0
-      synckit: 0.11.11
-    optionalDependencies:
-      prettier: 3.6.2
 
   prettier@2.8.8: {}
 
@@ -14408,18 +14383,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sort-object-keys@1.1.3: {}
-
-  sort-package-json@3.4.0:
-    dependencies:
-      detect-indent: 7.0.2
-      detect-newline: 4.0.1
-      git-hooks-list: 4.1.1
-      is-plain-obj: 4.1.0
-      semver: 7.7.2
-      sort-object-keys: 1.1.3
-      tinyglobby: 0.2.15
-
   source-map-js@1.2.1: {}
 
   source-map-resolve@0.5.3:
@@ -14676,6 +14639,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,6 @@ allowBuilds:
 
 publicHoistPattern:
   - '*eslint*'
-  - '*prettier*'
 
 # Keep in sync with the pnpm.overrides field in package.json, which exists for
 # tooling that still runs older pnpm versions (e.g. Vercel deploys with pnpm 9)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Migrates formatting from Prettier to [oxfmt](https://oxc.rs/docs/guide/usage/formatter), mirroring the setup in [sanity-io/plugins](https://github.com/sanity-io/plugins).

### Tooling changes

- Adds `.oxfmtrc.json` copied from the plugins repo (printWidth 100, no semicolons, single quotes, no bracket spacing, `sortImports`, `sortPackageJson` with `sortScripts`, double quotes kept for `.changeset/*.md` frontmatter), with `ignorePatterns` adapted from this repo's old `.prettierignore` (`pnpm-lock.yaml`, `CHANGELOG.md`, `dist`, `.workshop`; oxfmt also respects `.gitignore` by default).
- Replaces `prettier` + `@sanity/prettier-config` with `oxfmt` in the root `package.json`; `format` script and `lint-staged` config now match the plugins repo.
- Removes `.prettierignore` and the `*prettier*` `publicHoistPattern` from `pnpm-workspace.yaml`.
- Rewrites `format-if-needed.yml` to call the shared `sanity-io/.github/.github/workflows/format.yml@main` reusable workflow with `secrets: inherit`, verbatim from the plugins repo.
- Drops `eslint-plugin-simple-import-sort` (oxfmt's `sortImports` owns import sorting now; the two disagree on a few files, e.g. `@sanity/ui/theme` vs `@sanity/ui-workshop` ordering). `eslint-config-prettier` is kept since it still disables stylistic rules that conflict with any prettier-style formatter.
- Adds `.vscode` extension recommendation + settings for the oxc extension per the [official editor setup docs](https://oxc.rs/docs/guide/usage/formatter/editors), so format-on-save keeps working after the Prettier extension stops applying.

### Formatting churn (second commit)

Running `pnpm format` reformatted 20 files: import order adjustments, `extends` clause line-breaking differences in oxfmt, package.json key sorting, YAML double→single quotes, and the pending changeset's frontmatter to double quotes. The existing `<!-- prettier-ignore -->` comments in `manager-head.html` are kept as-is — oxfmt honors `prettier-ignore` (and it's the only supported directive for non-JS/TS files).

### Verification

- ✅ `pnpm format` is idempotent; `oxfmt --check` passes on 731 files
- ✅ `pnpm lint` (eslint, no errors)
- ✅ `pnpm ts:check`
- ✅ `pnpm build`
- ✅ `pnpm test` (42 suites, 125 tests passed)
- ✅ `pnpm-lock.yaml`, `CHANGELOG.md`, `dist`, `.workshop` confirmed excluded from formatting

No changeset added: formatting-only changes with no runtime behavior change, so no release is needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2893-e027-7fbd-93e5-78d56de0b19c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2893-e027-7fbd-93e5-78d56de0b19c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

