### PR TITLE
ci: add self-hosted renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,68 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # Every 2 hours
+  pull_request:
+    types: [closed]
+    branches: [main]
+  issues:
+    types: [edited]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    # Filter out noise: only run for schedule, manual dispatch, merged Renovate PRs,
+    # and human-edited issues (not bot updates to the Dependency Dashboard).
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'renovate/')) ||
+      (github.event_name == 'issues' && github.event.sender.type != 'Bot')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3 # zizmor: ignore[github-app]
+        id: app-token
+        with:
+          client-id: ${{ vars.ECOSPARK_CLIENT_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Generate Renovate runner config
+        id: config
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          CONFIG_FILE="$GITHUB_WORKSPACE/.renovate-runner-config.json5"
+
+          cat > "$CONFIG_FILE" <<'EOF'
+          {
+            $schema: "https://docs.renovatebot.com/renovate-schema.json",
+            onboarding: false,
+            requireConfig: "optional",
+          EOF
+
+          echo "  repositories: [\"$REPOSITORY\"]," >> "$CONFIG_FILE"
+          echo '}' >> "$CONFIG_FILE"
+
+          echo "Generated config:"
+          cat "$CONFIG_FILE"
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@dd5302ec17783b2fc721b19ae7209b57b1587765 # v46.1.17
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          configurationFile: .renovate-runner-config.json5
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          LOG_LEVEL: debug


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `.github/workflows/renovate.yml`, copied verbatim from [`sanity-io/plugins`](https://github.com/sanity-io/plugins/blob/main/.github/workflows/renovate.yml), to run Renovate as a self-hosted GitHub Action.

### How it works

- Runs on a 2-hour schedule, on manual dispatch, when a `renovate/*` PR is merged into `main`, and when the Dependency Dashboard issue is edited by a human (bot edits are filtered out).
- Mints an app token via `actions/create-github-app-token` using `vars.ECOSPARK_CLIENT_ID` + `secrets.ECOSPARK_APP_PRIVATE_KEY` (the same credentials `changesets-from-conventional-commits.yml` already uses, and the same client-id variable used by `sanity-io/plugins` and `sanity-io/pkg-utils`).
- Generates a minimal runner config (`onboarding: false`, `requireConfig: "optional"`, `repositories: ["sanity-io/ui"]`) and passes it to `renovatebot/github-action` pinned to v46.1.17. The existing `.github/renovate.json` remains the repo-level config, including its `baseBranchPatterns` covering `v2` and `main`.

### Notes for rollout

- Once this is merged and working, the repo should be removed from the hosted Mend Renovate app installation so updates aren't processed twice (recent Renovate PRs here are still authored by `app/renovate`).
- The merged-PR trigger only fires for merges into `main` (same as the plugins workflow). Renovate PRs merged into `v2` get picked up by the 2-hour schedule instead; add `v2` to the `pull_request.branches` filter if immediate re-runs are wanted there too.

### Verification

- File is byte-for-byte identical to the plugins workflow (`diff` clean).
- `actionlint` passes (the only two reports are false positives from actionlint's vendored, outdated schema for `create-github-app-token`, which doesn't know the `client-id` input introduced in v3).
- `zizmor` reports no findings under the same policy config the plugins repo uses.
- The runner-config generation script was executed locally and the resulting JSON5 parses to `{"$schema": "...", "onboarding": false, "requireConfig": "optional", "repositories": ["sanity-io/ui"]}`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f33db-5e4c-78a6-aa93-1c4af39031b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f33db-5e4c-78a6-aa93-1c4af39031b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

