### PR TITLE
chore: remove unnecessary publishConfig.access from package.json

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,8 +61,7 @@
         "require": "./dist/theme.js"
       },
       "./package.json": "./package.json"
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Removes `publishConfig.access: "public"` from `packages/ui/package.json`. It is redundant:

- `.changeset/config.json` already sets `"access": "public"`, which `changeset publish` uses when `publishConfig.access` is absent.
- The field never ships in the packed manifest anyway (verified with `pnpm pack`: the tarball's `package.json` has no `publishConfig`, and the dist `exports` are applied correctly).

### Verification

- `pnpm --filter @sanity/ui build` — the build's package.json regeneration does not re-add the field, and publint reports no issues.
- `pnpm pack` — packed manifest contains the correct dist `exports` and no `publishConfig`.
- `pnpm lint` and `pnpm format` — clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3402-694d-7d83-a6af-f8bddfec124a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3402-694d-7d83-a6af-f8bddfec124a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

