### PR TITLE
chore(ui): only publish dist to npm

### DIFF
--- a/.changeset/trim-published-files.md
+++ b/.changeset/trim-published-files.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+The npm package no longer ships the `src` and `exports` folders — only `dist` (plus `package.json`, `README.md`, and `LICENSE`) is published. Nothing resolvable referenced those folders: the published `exports` map points exclusively at `dist`, and the JS sourcemaps embed `sourcesContent`. This cuts the unpacked package size roughly in half.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,9 +21,7 @@
     "directory": "packages/ui"
   },
   "files": [
-    "dist",
-    "exports",
-    "src"
+    "dist"
   ],
   "type": "commonjs",
   "sideEffects": false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Trims `packages/ui` `package.json#files` from `["dist", "exports", "src"]` to just `["dist"]`, so the npm package no longer ships the TypeScript source.

Nothing in the published package resolves to `src` or `exports`:

- The `publishConfig.exports` map (applied on `pnpm pack`/`publish`) points exclusively at `dist`, as do `main`, `module`, `types`, and `typesVersions`. The source-resolving dev `exports` are replaced at pack time.
- All runtime JS sourcemaps in `dist` embed `sourcesContent`, so debuggers reconstruct sources from the maps without the `src` folder. (Declaration maps don't embed sources, same as other tsdown-built packages like `@sanity/tsdown-config` which also publish only `dist`.)

### Impact

| | before (3.3.2) | after |
|---|---|---|
| unpacked size | 4.5 MB | 2.2 MB |
| files | 457 | 35 |
| tarball | 616 kB | 472 kB |

### Verification

- `pnpm pack` tarball contains only `dist`, `package.json`, `README.md`, `LICENSE`; the `dist` file list is byte-identical to the published 3.3.2 tarball.
- Installed the packed tarball into a scratch project: `require`/`import` of `@sanity/ui`, `@sanity/ui/theme`, and `@sanity/ui/_visual-editing` all work, and SSR-rendering `ThemeProvider`/`Card`/`Button`/`Text` with `buildTheme()` succeeds.
- `attw` on the packed tarball: no problems found (all green for node10, node16 CJS/ESM, bundler).
- `pnpm lint` and `pnpm test` (125 tests) pass.

Includes a patch changeset.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3403-0413-7631-b850-b103813ad193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3403-0413-7631-b850-b103813ad193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

