### PR TITLE
fix(build): keep entry d.ts filenames stable so named imports from @sanity/ui/theme type-check

### DIFF
--- a/.changeset/theme-dts-named-exports.md
+++ b/.changeset/theme-dts-named-exports.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+fix(build): restore named exports in `dist/theme.d.ts` so `import {buildTheme} from '@sanity/ui/theme'` type-checks again (TS2460). Shared chunks are now emitted to `dist/_chunks/` so they can no longer take an entry point's `.d.ts` filename.

--- a/packages/ui/tsdown.config.mts
+++ b/packages/ui/tsdown.config.mts
@@ -13,6 +13,29 @@ const config: UserConfig = await defineConfig({
   styledComponents: true,
 })
 
+const baseOutputOptions = config.outputOptions
+
+// Emit shared (non-entry) chunks to `dist/_chunks/` so they can never collide
+// with entry filenames. Code shared between the `index` and `theme` entries
+// forms a chunk that rolldown also names `theme`: the JS output deduplicates
+// in favor of the entry (`theme.mjs` + `theme2.mjs`), but the d.ts output
+// resolved the collision the other way around, placing the shared chunk (which
+// re-exports everything under minified aliases like `buildTheme as x`) at
+// `theme.d.ts` and the entry's declarations at `theme2.d.ts`. TypeScript picks
+// up the `theme.d.(m)ts` sibling of `theme.(m)js`, so named imports from
+// `@sanity/ui/theme` failed with TS2460 (https://github.com/sanity-io/ui/issues/2262).
+config.outputOptions = async (outputOptions, format, context) => {
+  const base =
+    typeof baseOutputOptions === 'function'
+      ? await baseOutputOptions(outputOptions, format, context)
+      : baseOutputOptions
+
+  return {
+    ...base,
+    chunkFileNames: `_chunks/[name].${format === 'cjs' ? 'js' : 'mjs'}`,
+  }
+}
+
 config.plugins = [
   ...(Array.isArray(config.plugins) ? config.plugins : [config.plugins]),
   // The `reactCompiler` option in @sanity/tsdown-config cannot be used yet: it


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2262

## Problem

Since 3.3.2 (the tsdown build migration in `edb7248`), `import {buildTheme} from '@sanity/ui/theme'` fails to type-check:

```
error TS2460: Module '"@sanity/ui/theme"' declares 'buildTheme' locally, but it is exported as 'x'.
```

The code shared between the `index` and `theme` entries forms a chunk that rolldown also names `theme`. The JS output deduplicates the filename collision in favor of the entry (`theme.mjs` + `theme2.mjs`), but the d.ts output resolved it the other way around: the shared chunk — which exports everything under minified aliases like `buildTheme as x` — was written to `theme.d.(m)ts`, and the entry's actual declarations to `theme2.d.(m)ts`. Since the exports map points at `dist/theme.mjs`/`dist/theme.js`, TypeScript resolves the sibling `theme.d.(m)ts` and lands on the aliased chunk, so every named import from `@sanity/ui/theme` breaks (runtime was unaffected).

## Fix

Emit shared (non-entry) chunks to `dist/_chunks/` via `outputOptions.chunkFileNames`, so they can never collide with entry filenames. `dist/` now contains only the three entries (JS + d.ts with proper named exports) at the top level:

```
dist/index.mjs            dist/index.d.mts           (+ .js / .d.ts)
dist/theme.mjs            dist/theme.d.mts
dist/_visual-editing.mjs  dist/_visual-editing.d.mts
dist/_chunks/theme.mjs, tabList.mjs, refractor.mjs, theme.d.mts, useTheme.d.mts, ...
```

## Verification

Packed the tarball (`pnpm pack`) and consumed it from a scratch project, before and after the fix:

```
=== BEFORE: @sanity/ui packed from main (issue #2262) ===
$ cat index.ts
import {buildTheme, type ThemeConfig} from '@sanity/ui/theme'

const config: ThemeConfig = {}
const theme = buildTheme(config)

console.log(theme.color.light.default.base.bg)

$ npx tsc -p tsconfig.json   # moduleResolution: bundler
index.ts(1,9): error TS2460: Module '"@sanity/ui/theme"' declares 'buildTheme' locally, but it is exported as 'x'.
index.ts(1,26): error TS2460: Module '"@sanity/ui/theme"' declares 'ThemeConfig' locally, but it is exported as 'C'.
exit code: 2

=== AFTER: @sanity/ui packed from this branch ===
$ npx tsc -p tsconfig.json   # moduleResolution: bundler
exit code: 0

$ npx tsc -p tsconfig.node16.json   # moduleResolution: node16
exit code: 0

$ node runtime-esm.mjs
ESM buildTheme OK: true

$ node runtime-cjs.cjs
CJS buildTheme OK: true
```

- `attw` (Are The Types Wrong) reports no problems across node10/node16/bundler resolution for all subpaths.
- ✅ `pnpm lint` (includes type checking) · ✅ `pnpm test` (125 tests) · ✅ `pnpm build` (publint clean)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f37c0-9180-7b8d-96fb-7701ef076f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f37c0-9180-7b8d-96fb-7701ef076f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

