### PR TITLE
Enable React Compiler linting and builds for apps/docs

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -106,8 +106,6 @@
       "rules": {
         // `import "server-only"` marks modules as server-only in Next.js
         "import/no-unassigned-import": ["error", {"allow": ["**/*.css", "server-only"]}],
-        // apps/docs does not build with the React Compiler
-        "react/react-compiler": "off",
         // The docs app narrows loosely-typed CMS (Portable Text) data with
         // `as` assertions throughout; too noisy to be useful here
         "typescript/no-unsafe-type-assertion": "off"

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
     styledComponents: true,
   },
   experimental: {
+    reactCompiler: true,
     taint: true,
   },
   eslint: {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -55,6 +55,7 @@
     "@types/qs": "^6.14.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "babel-plugin-react-compiler": "1.0.0",
     "mkdirp": "^3.0.1",
     "npm-run-all2": "^8.0.4",
     "typescript": "^5.8.3",

--- a/apps/docs/sanity.cli.ts
+++ b/apps/docs/sanity.cli.ts
@@ -3,6 +3,7 @@ import {defineCliConfig} from 'sanity/cli'
 // Object configs are merged into the base config with vite's `mergeConfig`,
 // which handles both array and object forms of `resolve.alias`.
 export default defineCliConfig({
+  reactCompiler: {target: '19'},
   vite: {
     resolve: {
       alias: {

--- a/apps/docs/src/app/RootLayout.tsx
+++ b/apps/docs/src/app/RootLayout.tsx
@@ -4,7 +4,7 @@ import {WrappedValue} from '@sanity/react-loader/jsx'
 import {LayerProvider, ThemeProvider, ToastProvider, usePrefersDark} from '@sanity/ui'
 import {buildTheme, ThemeColorSchemeKey} from '@sanity/ui/theme'
 import {Inter} from 'next/font/google'
-import {ReactNode, useEffect, useMemo, useState} from 'react'
+import {ReactNode, useMemo, useSyncExternalStore} from 'react'
 import Refractor from 'react-refractor'
 import bash from 'refractor/lang/bash'
 import json from 'refractor/lang/json'
@@ -27,6 +27,38 @@ const inter = Inter({subsets: ['latin']})
 
 const theme = buildTheme()
 
+// The color scheme lives in `localStorage` (an external store) and is read
+// with `useSyncExternalStore`: the server (and hydration) renders `system`,
+// and the persisted value is picked up in the client render that follows.
+const COLOR_SCHEME_KEY = 'sanityStudio:ui:colorScheme'
+
+const colorSchemeListeners = new Set<() => void>()
+
+function subscribeToColorScheme(listener: () => void): () => void {
+  colorSchemeListeners.add(listener)
+
+  return () => colorSchemeListeners.delete(listener)
+}
+
+function getColorScheme(): ThemeColorSchemeKey | 'system' {
+  const stored = window.localStorage.getItem(COLOR_SCHEME_KEY)
+
+  // Ignore invalid persisted values
+  return stored === 'dark' || stored === 'light' ? stored : 'system'
+}
+
+function getServerColorScheme(): 'system' {
+  return 'system'
+}
+
+function setColorScheme(scheme: ThemeColorSchemeKey | 'system'): void {
+  window.localStorage.setItem(COLOR_SCHEME_KEY, scheme)
+
+  for (const listener of colorSchemeListeners) {
+    listener()
+  }
+}
+
 export function RootLayout(props: {
   children?: ReactNode
   data: WrappedValue<GlobalData>
@@ -48,24 +80,11 @@ export function RootLayout(props: {
   } = props
   const prefersDark = usePrefersDark(() => prefersDarkServerSnapshot)
 
-  const [colorScheme, setColorScheme] = useState<ThemeColorSchemeKey | 'system'>('system')
-
-  useEffect(() => {
-    const localColorScheme = window.localStorage.getItem('sanityStudio:ui:colorScheme') || 'system'
-    if (
-      localColorScheme !== 'system' &&
-      localColorScheme !== 'dark' &&
-      localColorScheme !== 'light'
-    ) {
-      // If the restored value is invalid then ignore it
-      return
-    }
-    if (localColorScheme !== colorScheme) {
-      // If the value from local storage is different from the current state, update the state
-      // this typically only happens on mount
-      setColorScheme(localColorScheme)
-    }
-  }, [colorScheme])
+  const colorScheme = useSyncExternalStore(
+    subscribeToColorScheme,
+    getColorScheme,
+    getServerColorScheme,
+  )
 
   const {nav: navNode, settings} = data
 
@@ -80,13 +99,10 @@ export function RootLayout(props: {
       imageUrlBuilder: getImageUrlBuilder({dataset, projectId}).imageUrlBuilder,
       nav,
       projectId,
-      setColorScheme: (s) => {
-        window.localStorage.setItem('sanityStudio:ui:colorScheme', s)
-        setColorScheme(s)
-      },
+      setColorScheme,
       settings,
     }),
-    [colorScheme, dataset, hintHiddenContent, nav, projectId, setColorScheme, settings],
+    [colorScheme, dataset, hintHiddenContent, nav, projectId, settings],
   )
 
   return (

--- a/apps/docs/src/app/RootLayout.tsx
+++ b/apps/docs/src/app/RootLayout.tsx
@@ -4,7 +4,7 @@ import {WrappedValue} from '@sanity/react-loader/jsx'
 import {LayerProvider, ThemeProvider, ToastProvider, usePrefersDark} from '@sanity/ui'
 import {buildTheme, ThemeColorSchemeKey} from '@sanity/ui/theme'
 import {Inter} from 'next/font/google'
-import {ReactNode, useMemo, useSyncExternalStore} from 'react'
+import {ReactNode, useDeferredValue, useMemo, useSyncExternalStore} from 'react'
 import Refractor from 'react-refractor'
 import bash from 'refractor/lang/bash'
 import json from 'refractor/lang/json'
@@ -80,10 +80,12 @@ export function RootLayout(props: {
   } = props
   const prefersDark = usePrefersDark(() => prefersDarkServerSnapshot)
 
-  const colorScheme = useSyncExternalStore(
-    subscribeToColorScheme,
-    getColorScheme,
-    getServerColorScheme,
+  // `useDeferredValue` with the server snapshot as its initial value keeps
+  // hydration non-blocking: the persisted color scheme is applied in a
+  // deferred re-render instead of forcing a synchronous one
+  const colorScheme = useDeferredValue(
+    useSyncExternalStore(subscribeToColorScheme, getColorScheme, getServerColorScheme),
+    getServerColorScheme(),
   )
 
   const {nav: navNode, settings} = data

--- a/apps/docs/src/app/[...slug]/page.tsx
+++ b/apps/docs/src/app/[...slug]/page.tsx
@@ -1,3 +1,4 @@
+import {type QueryResponseInitial} from '@sanity/react-loader'
 import {wrapData} from '@sanity/react-loader/jsx'
 import {Metadata} from 'next'
 import {draftMode} from 'next/headers'
@@ -48,20 +49,27 @@ export async function generateMetadata(props: {params: {slug: string[]}}): Promi
 export default async function SlugRoute(props: {params: {slug: string[]}}) {
   const {params} = props
 
+  let initial: QueryResponseInitial<TargetData | null>
+
+  // Only the data loading is guarded: JSX must not be constructed inside
+  // try/catch, since components render later and rendering errors would not
+  // be caught here anyway.
   try {
-    const {data: rawData, sourceMap} = await loadQuery<TargetData | null>(TARGET_QUERY, {
+    initial = await loadQuery<TargetData | null>(TARGET_QUERY, {
       memberTypes: API_DOCUMENT_TYPES,
       path: params.slug,
     })
-
-    if ((await draftMode()).isEnabled) {
-      return <PreviewPage initial={{data: rawData, sourceMap}} path={params.slug} />
-    }
-
-    const data = rawData ? wrapData({baseUrl: '/studio'}, rawData, sourceMap) : null
-
-    return <Page data={data} path={params.slug} />
   } catch (error) {
     return <Page error={error as Error} path={params.slug} />
   }
+
+  const {data: rawData, sourceMap} = initial
+
+  if ((await draftMode()).isEnabled) {
+    return <PreviewPage initial={{data: rawData, sourceMap}} path={params.slug} />
+  }
+
+  const data = rawData ? wrapData({baseUrl: '/studio'}, rawData, sourceMap) : null
+
+  return <Page data={data} path={params.slug} />
 }

--- a/apps/docs/src/app/arcade/ArcadePage.tsx
+++ b/apps/docs/src/app/arcade/ArcadePage.tsx
@@ -1,7 +1,14 @@
 'use client'
-import {createElement, lazy, ReactNode, Suspense, useEffect, useState} from 'react'
+import {createElement, lazy, ReactNode, Suspense, useSyncExternalStore} from 'react'
 
 import {Layout} from '@/components/Layout'
+
+// The arcade can only run in the browser: `useSyncExternalStore` renders the
+// server snapshot (`false`) on the server and during hydration, and flips to
+// the client snapshot (`true`) right after
+const emptySubscribe = () => () => {}
+const getIsMounted = () => true
+const getServerIsMounted = () => false
 
 export function ArcadePage(props: {
   searchParams: {
@@ -11,9 +18,7 @@ export function ArcadePage(props: {
 }): ReactNode {
   const {searchParams: _searchParams} = props
 
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => setMounted(true), [])
+  const mounted = useSyncExternalStore(emptySubscribe, getIsMounted, getServerIsMounted)
 
   if (!mounted) return null
 

--- a/apps/docs/src/app/arcade/ArcadePage.tsx
+++ b/apps/docs/src/app/arcade/ArcadePage.tsx
@@ -1,5 +1,12 @@
 'use client'
-import {createElement, lazy, ReactNode, Suspense, useSyncExternalStore} from 'react'
+import {
+  createElement,
+  lazy,
+  ReactNode,
+  Suspense,
+  useDeferredValue,
+  useSyncExternalStore,
+} from 'react'
 
 import {Layout} from '@/components/Layout'
 
@@ -18,7 +25,13 @@ export function ArcadePage(props: {
 }): ReactNode {
   const {searchParams: _searchParams} = props
 
-  const mounted = useSyncExternalStore(emptySubscribe, getIsMounted, getServerIsMounted)
+  // `useDeferredValue` with the server snapshot as its initial value keeps
+  // hydration non-blocking: the arcade mounts in a deferred re-render instead
+  // of forcing a synchronous one
+  const mounted = useDeferredValue(
+    useSyncExternalStore(emptySubscribe, getIsMounted, getServerIsMounted),
+    getServerIsMounted(),
+  )
 
   if (!mounted) return null
 

--- a/apps/docs/src/app/arcade/frame/page.tsx
+++ b/apps/docs/src/app/arcade/frame/page.tsx
@@ -3,7 +3,7 @@
 import * as icons from '@sanity/icons'
 import * as ui from '@sanity/ui'
 import {Card, Code, ErrorBoundary, Text} from '@sanity/ui'
-import React, {ReactElement, useCallback, useEffect, useState} from 'react'
+import React, {ReactElement, useCallback, useEffect, useMemo, useState} from 'react'
 import {keyframes, styled} from 'styled-components'
 
 import {isRecord} from '@/lib/common'
@@ -13,7 +13,6 @@ import {useApp} from '../../useApp'
 
 export default function ArcadeFrameRoute(): ReactElement {
   const {setColorScheme} = useApp()
-  const [evalResult, setEvalResult] = useState<EvalComponentResult | null>(null)
   const [evalReady, setEvalReady] = useState(false)
   const [hookCode, setHookCode] = useState<string | null>(null)
   const [jsxCode, setJSXCode] = useState<string | null>(null)
@@ -31,6 +30,10 @@ export default function ArcadeFrameRoute(): ReactElement {
           setJSXCode(msg.jsxCode as any)
           setHookCode(msg.hookCode as any)
 
+          // New input: clear errors from the previous code
+          setRenderError(null)
+          setWindowError(null)
+
           return
         }
 
@@ -47,24 +50,17 @@ export default function ArcadeFrameRoute(): ReactElement {
     }
   }, [setColorScheme])
 
-  useEffect(() => {
-    if (!evalReady) return
-    if (hookCode === null) return
-    if (jsxCode === null) return
+  const evalResult = useMemo<EvalComponentResult | null>(() => {
+    if (!evalReady) return null
+    if (hookCode === null) return null
+    if (jsxCode === null) return null
 
-    setEvalResult(
-      evalComponent({
-        hookCode,
-        jsxCode,
-        scope: {...icons, ...ui, ...React, React, styled, keyframes},
-      }),
-    )
+    return evalComponent({
+      hookCode,
+      jsxCode,
+      scope: {...icons, ...ui, ...React, React, styled, keyframes},
+    })
   }, [hookCode, jsxCode, evalReady])
-
-  useEffect(() => {
-    setRenderError(null)
-    setWindowError(null)
-  }, [hookCode, jsxCode])
 
   useEffect(() => {
     void readyCheck().then(() => setEvalReady(true))

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -1,3 +1,4 @@
+import {type QueryResponseInitial} from '@sanity/react-loader'
 import {wrapData} from '@sanity/react-loader/jsx'
 import {draftMode} from 'next/headers'
 
@@ -8,20 +9,27 @@ import {loadQuery} from '@/lib/sanity/loadQuery'
 import {PreviewPage} from '../components/page/PreviewPage'
 
 export default async function RootRoute() {
+  let initial: QueryResponseInitial<TargetData | null>
+
+  // Only the data loading is guarded: JSX must not be constructed inside
+  // try/catch, since components render later and rendering errors would not
+  // be caught here anyway.
   try {
-    const {data: rawData, sourceMap} = await loadQuery<TargetData | null>(TARGET_QUERY, {
+    initial = await loadQuery<TargetData | null>(TARGET_QUERY, {
       memberTypes: API_DOCUMENT_TYPES,
       path: [null],
     })
-
-    if ((await draftMode()).isEnabled) {
-      return <PreviewPage initial={{data: rawData, sourceMap}} path={[]} />
-    }
-
-    const data = rawData ? wrapData({baseUrl: '/studio'}, rawData, sourceMap) : null
-
-    return <Page data={data} path={[]} />
   } catch (error) {
     return <Page error={error as Error} path={[]} />
   }
+
+  const {data: rawData, sourceMap} = initial
+
+  if ((await draftMode()).isEnabled) {
+    return <PreviewPage initial={{data: rawData, sourceMap}} path={[]} />
+  }
+
+  const data = rawData ? wrapData({baseUrl: '/studio'}, rawData, sourceMap) : null
+
+  return <Page data={data} path={[]} />
 }

--- a/apps/docs/src/components/page/ArticlePage.tsx
+++ b/apps/docs/src/components/page/ArticlePage.tsx
@@ -113,7 +113,22 @@ export function ArticlePage(props: {
 function NavBreadcrumbs(props: {nav: NavNode; path: string[]}) {
   const {nav, path} = props
 
+  // Resolve the nav node for each path segment up front, so that no variable
+  // is reassigned from within the JSX below (the React Compiler cannot prove
+  // that a callback which reassigns an outer variable runs during render)
+  const crumbs: {node: NavNode; segment: string}[] = []
+
   let node: NavNode | undefined = nav
+
+  for (const [index, segment] of path.entries()) {
+    if (index > 0) {
+      node = node?.children?.find((child) => child.segment === segment)
+    }
+
+    if (!node) break
+
+    crumbs.push({node, segment})
+  }
 
   return (
     <Breadcrumbs
@@ -124,28 +139,17 @@ function NavBreadcrumbs(props: {nav: NavNode; path: string[]}) {
       }
       space={2}
     >
-      {path.reduce<ReactElement[]>((children, segment, index) => {
-        if (index > 0) {
-          node = node?.children?.find((child) => child.segment === segment)
-        }
-
-        if (!node) {
-          return children
-        }
-
-        return [
-          ...children,
-          <Text key={segment} size={1} weight="medium">
-            {index === 0 ? (
-              <Link href={`/${node.segment}`} style={{color: 'inherit'}}>
-                <sanity.span>{node.title}</sanity.span>
-              </Link>
-            ) : (
-              <sanity.span>{node.title}</sanity.span>
-            )}
-          </Text>,
-        ]
-      }, [])}
+      {crumbs.map(({node: crumbNode, segment}, index) => (
+        <Text key={segment} size={1} weight="medium">
+          {index === 0 ? (
+            <Link href={`/${crumbNode.segment}`} style={{color: 'inherit'}}>
+              <sanity.span>{crumbNode.title}</sanity.span>
+            </Link>
+          ) : (
+            <sanity.span>{crumbNode.title}</sanity.span>
+          )}
+        </Text>
+      ))}
     </Breadcrumbs>
   )
 }

--- a/apps/docs/src/components/page/article/content/CodeExample.tsx
+++ b/apps/docs/src/components/page/article/content/CodeExample.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import {ArrowRightIcon} from '@sanity/icons'
-import {Box, Button, Card, Tab, TabList, TabPanel, Text} from '@sanity/ui'
+import {Box, Button, Card, Tab, TabList, TabPanel} from '@sanity/ui'
 import Link from 'next/link'
-import {ReactElement, useEffect, useState} from 'react'
+import {ReactElement, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {getArcadeQuery} from '@/lib/arcade'
@@ -25,11 +25,6 @@ export function CodeExample(props: {
   const [jsxCursor, setJSXCursor] = useState({anchor: 0, focus: 0})
   const [hookCode, setScopeCode] = useState<string>(hookCodeProp)
   const [hookCursor, setScopeCursor] = useState({anchor: 0, focus: 0})
-  const [renderError, setRenderError] = useState<Error | null>(null)
-
-  useEffect(() => {
-    setRenderError(null)
-  }, [hookCode, jsxCode])
 
   const arcadeQuery = getArcadeQuery({
     description,
@@ -46,12 +41,6 @@ export function CodeExample(props: {
         <FrameCard tone="transparent">
           <ArcadeFrame hookCode={hookCode} jsxCode={jsxCode} />
         </FrameCard>
-
-        {renderError && (
-          <Card padding={4} tone="critical">
-            <Text>An error occured while rendering</Text>
-          </Card>
-        )}
 
         <Card borderTop borderBottom paddingX={4} paddingY={2}>
           <TabList space={1} style={{textAlign: 'center'}}>

--- a/apps/docs/src/lib/arcade/ArcadeScreen.tsx
+++ b/apps/docs/src/lib/arcade/ArcadeScreen.tsx
@@ -29,7 +29,11 @@ export function ArcadeScreen(props: {title: string; description: string}): React
 
   const saveFnRef = useRef<DebouncedFunc<SaveFn> | null>(null)
 
-  routerRef.current = router
+  // Keep a ref to the latest router for the debounced save callback (refs
+  // must not be written to during render)
+  useEffect(() => {
+    routerRef.current = router
+  }, [router])
 
   // Create `saveFn` callback
   useEffect(() => {

--- a/apps/docs/src/lib/arcade/CanvasPane.tsx
+++ b/apps/docs/src/lib/arcade/CanvasPane.tsx
@@ -37,6 +37,16 @@ function MetaEditor({
   const titleInputRef = useRef<HTMLInputElement | null>(null)
   const {isTopLayer} = useLayer()
 
+  // Reset the form state when the value prop changes, by adjusting the state
+  // while rendering (https://react.dev/learn/you-might-not-need-an-effect)
+  const [prevValue, setPrevValue] = useState(value)
+
+  if (prevValue !== value) {
+    setPrevValue(value)
+    setFormTitle(value.title)
+    setFormDescription(value.description)
+  }
+
   const handleEditorSubmit = useCallback(
     (event: React.SubmitEvent) => {
       event.preventDefault()
@@ -52,10 +62,6 @@ function MetaEditor({
   useEffect(() => {
     titleInputRef.current?.focus()
   }, [])
-
-  useEffect(() => setFormTitle(value.title), [value.title])
-
-  useEffect(() => setFormDescription(value.description), [value.description])
 
   const handleGlobalKeyDown = useCallback(
     (event: KeyboardEvent) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
@@ -570,10 +573,6 @@ packages:
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -581,10 +580,6 @@ packages:
   '@babel/helper-string-parser@8.0.0':
     resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
     engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
@@ -1094,10 +1089,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -8409,13 +8400,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-string-parser@8.0.0': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -9046,7 +9033,7 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.7
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -9062,11 +9049,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -11582,7 +11564,7 @@ snapshots:
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.7
 
   '@types/chai@5.2.3':
     dependencies:
@@ -14599,7 +14581,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
       '@types/doctrine': 0.0.9


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables the React Compiler for `apps/docs`, both at lint time and at build time:

- Removes the `react/react-compiler: off` override for `apps/docs/**` in `.oxlintrc.json`, so the docs app is now linted with the same React Compiler rule as the rest of the repo.
- Builds the Next.js app with the compiler (`experimental.reactCompiler` in `next.config.mjs`; Next 15 runs `babel-plugin-react-compiler` in a standalone babel pass on top of SWC, so the SWC styled-components transform is unaffected).
- Builds the Sanity studio (`sanity dev`/`sanity build`) with the compiler via `reactCompiler: {target: '19'}` in `sanity.cli.ts`.
- Adds `babel-plugin-react-compiler` (pinned to the same `1.0.0` used by `packages/ui` and `apps/storybook`).

## Lint fixes

Enabling the rule uncovered 13 errors, fixed as follows:

- `src/app/page.tsx`, `src/app/[...slug]/page.tsx` (ErrorBoundaries): only the `loadQuery` await is guarded by try/catch; JSX is constructed outside it (rendering errors were never catchable there anyway).
- `src/app/RootLayout.tsx` (EffectSetState): the color scheme is now read from `localStorage` with `useSyncExternalStore` backed by a tiny module-level store, replacing the mount effect that called `setColorScheme`. Same behavior: SSR/hydration renders `system`, then the persisted value applies.
- `src/app/arcade/ArcadePage.tsx` (EffectSetState): the client-only "mounted" flag uses the `useSyncExternalStore` hydration idiom instead of a `useEffect` + `setState`.
- `src/app/arcade/frame/page.tsx` (EffectSetState ×2): `evalResult` is derived with `useMemo` instead of being mirrored into state from an effect, and the error states are reset in the `message` event handler (where new input arrives) instead of an effect.
- `src/lib/arcade/CanvasPane.tsx` (EffectSetState ×2): the meta editor form resets when the `value` prop changes using the render-phase adjustment pattern from [react.dev](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes), replacing two sync effects.
- `src/lib/arcade/ArcadeScreen.tsx` (Refs): `routerRef.current` is written in an effect instead of during render.
- `src/components/page/ArticlePage.tsx` (Immutability): breadcrumb nav nodes are resolved in a plain loop before rendering, instead of reassigning a closure variable inside a `reduce` callback in JSX.
- `src/components/page/article/content/CodeExample.tsx` (EffectSetState): removed the `renderError` state entirely — it was dead code (only ever reset to `null`, never set to an error; the arcade iframe renders its own error UI).

Both `useSyncExternalStore` reads are additionally wrapped in `useDeferredValue`, with the server snapshot as the initial value (React 19 signature), so the post-hydration switch to the client snapshot happens in a deferred re-render instead of a blocking one.

## Testing

- `pnpm lint` (includes the react-compiler rule and type-aware checks), `pnpm --filter sanity-ui-docs typecheck`, `pnpm --filter sanity-ui-docs test`, and `pnpm test` (packages/ui) all pass.
- `pnpm --filter sanity-ui-docs build` succeeds with `✓ reactCompiler`, and the emitted chunks for app code contain compiler memoization (`react/compiler-runtime` `c(n)` slots + `react.memo_cache_sentinel`). The Vite-compiled studio dev server output also shows compiled components.
- Manually verified in the browser (dev server): docs browsing, live code examples, the Arcade (live edit, eval error + recovery, meta editor), mobile breadcrumbs, dark mode via persisted `localStorage` color scheme, and the studio login screen on :3333.

Demo videos:

[docs_site_browsing_and_live_code_example_with_react_compiler.mp4](https://cursor.com/agents/bc-019f3ccc-005f-782c-b5f8-3e35edf9d86a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_site_browsing_and_live_code_example_with_react_compiler.mp4)

[arcade_live_edit_error_recovery_meta_editor_clean.mp4](https://cursor.com/agents/bc-019f3ccc-005f-782c-b5f8-3e35edf9d86a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farcade_live_edit_error_recovery_meta_editor_clean.mp4)

Screenshots:

[Dark mode via persisted color scheme (useSyncExternalStore + useDeferredValue)](https://cursor.com/agents/bc-019f3ccc-005f-782c-b5f8-3e35edf9d86a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_dark_mode_via_localstorage.webp)
[Mobile breadcrumbs (refactored NavBreadcrumbs)](https://cursor.com/agents/bc-019f3ccc-005f-782c-b5f8-3e35edf9d86a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_mobile_breadcrumbs.webp)
[Sanity studio dev server compiled by Vite with the React Compiler](https://cursor.com/agents/bc-019f3ccc-005f-782c-b5f8-3e35edf9d86a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_studio_dev_server_vite_react_compiler.webp)

Note: verifying the build/runtime in the Cloud Agent VM required a temporary local bypass of the `SANITY_API_READ_TOKEN` import-time check in `src/lib/sanity/token.ts` (no token secret is available in the VM; the production dataset is publicly readable). That debug edit is not part of this PR.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3ccc-005f-782c-b5f8-3e35edf9d86a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3ccc-005f-782c-b5f8-3e35edf9d86a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

