### PR TITLE
chore: skip Vercel builds for the docs app on v2

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "echo 'The docs app only exists on the main branch — skipping build on v2' && exit 0"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

The Vercel docs project (sanity.io/ui) has its root directory set to `apps/docs`, which only exists on `main`. On `v2` and branches based on it, the directory is missing, so every Vercel deployment fails.

### Solution

Add `apps/docs/vercel.json` containing only an `ignoreCommand` that always exits `0`. Per [Vercel's docs](https://vercel.com/docs/project-configuration/vercel-json#ignorecommand), an exit code of `0` cancels the build, so deployments from `v2`-based branches are skipped (canceled) instead of failing. The command also echoes a short explanation into the Vercel build log.

Because the file lives on `v2` (and therefore on all branches cut from it), it covers pushes to `v2` and all PR preview deployments targeting `v2`, while `main`-based branches are unaffected. The property was validated against Vercel's published JSON schema (`https://openapi.vercel.sh/vercel.json`).

No changeset: this doesn't affect the published `@sanity/ui` package.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f41d7-6c19-77ca-8665-ca31931a6d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f41d7-6c19-77ca-8665-ca31931a6d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

