### PR TITLE
Add docs cache invalidation blueprint

### DIFF
--- a/.github/workflows/sanity-blueprint-docs.yml
+++ b/.github/workflows/sanity-blueprint-docs.yml
@@ -1,0 +1,62 @@
+name: Sanity Docs Blueprint Deploy
+
+on:
+  push:
+    paths:
+      - 'apps/blueprints/docs/sanity.blueprint.ts'
+      - 'apps/blueprints/docs/functions/**'
+      - '.github/workflows/sanity-blueprint-docs.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/blueprints/docs/sanity.blueprint.ts'
+      - 'apps/blueprints/docs/functions/**'
+      - '.github/workflows/sanity-blueprint-docs.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  SANITY_PROJECT_ID: mos42crl
+  # `pnpm dlx @sanity/runtime-cli@latest blueprints deploy` from
+  # apps/blueprints/docs (the first deploy creates the stack)
+  SANITY_BLUEPRINT_STACK_ID: ST-6hmzgz9rrn
+
+jobs:
+  blueprint-docs-plan:
+    name: Docs Blueprint Plan
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup
+
+      - name: Doctor Blueprint
+        working-directory: apps/blueprints/docs
+        run: pnpm dlx @sanity/runtime-cli@latest blueprints doctor
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_UI_DOCS_AUTH_TOKEN }}
+
+      - name: Plan Blueprint
+        working-directory: apps/blueprints/docs
+        run: pnpm dlx @sanity/runtime-cli@latest blueprints plan
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_UI_DOCS_AUTH_TOKEN }}
+
+  blueprint-docs-deploy:
+    name: Docs Blueprint Deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup
+
+      - name: Deploy Blueprint
+        working-directory: apps/blueprints/docs
+        run: pnpm dlx @sanity/runtime-cli@latest blueprints deploy
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_UI_DOCS_AUTH_TOKEN }}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -96,6 +96,14 @@
       }
     },
     {
+      // apps/blueprints packages contain server-side Sanity Functions, where
+      // structured console logging (including `console.info`) is the norm
+      "files": ["apps/blueprints/**"],
+      "rules": {
+        "eslint/no-console": ["error", {"allow": ["info", "warn", "error"]}]
+      }
+    },
+    {
       // apps/docs is a Next.js app; enable the Next.js rules on top of the
       // base plugins (override plugins extend the base `plugins` set).
       "files": ["apps/docs/**"],

--- a/apps/blueprints/docs/.gitignore
+++ b/apps/blueprints/docs/.gitignore
@@ -1,0 +1,8 @@
+# Local deploy state written by `blueprints deploy` (stack id etc.)
+.sanity
+
+# Build artifacts emitted next to the source when the runtime CLI bundles the
+# functions (deploy/test)
+functions/*/index.js
+functions/*/index.js.map
+functions/*/package.json

--- a/apps/blueprints/docs/README.md
+++ b/apps/blueprints/docs/README.md
@@ -1,0 +1,54 @@
+# blueprints-docs
+
+[Sanity Blueprint](https://www.sanity.io/docs/compute-and-ai/blueprints) for the
+sanity.io/ui docs (Sanity project `mos42crl`). It deploys the serverless
+functions that keep the Next.js cache of [`apps/docs`](../../docs) in sync with
+content changes.
+
+## Functions
+
+### `invalidate-sync-tags`
+
+Listens for [sync tag invalidation events](https://www.sanity.io/docs/compute-and-ai/functions)
+on the `mos42crl.production` dataset and forwards the invalidated sync tags to
+the docs deployment's expire-tags endpoint
+(`https://www.sanity.io/ui/api/expire-tags`, hardcoded in
+`functions/invalidate-sync-tags/index.ts`), which calls
+`revalidateTag('sanity:<tag>', 'max')` so cached pages are background-revalidated.
+
+The endpoint is guarded by a single shared secret, which must be set in two
+places with the same value:
+
+| Where                               | Key                  | How                                                                                                                           |
+| ----------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| the deployed function               | `EXPIRE_TAGS_SECRET` | `pnpm dlx @sanity/runtime-cli@latest functions env add invalidate-sync-tags EXPIRE_TAGS_SECRET <value>` (from this directory) |
+| the docs Vercel project (apps/docs) | `EXPIRE_TAGS_SECRET` | `vercel env add EXPIRE_TAGS_SECRET production` (or the Vercel dashboard), then redeploy                                       |
+
+## Deploys
+
+`.github/workflows/sanity-blueprint-docs.yml` runs
+`blueprints doctor` + `blueprints plan` on pull requests and
+`blueprints deploy` on pushes to `main`, via `@sanity/runtime-cli`. It uses the
+`SANITY_UI_DOCS_AUTH_TOKEN` repository secret (a token with deploy permissions
+on project `mos42crl`) and the stack id in the workflow's
+`SANITY_BLUEPRINT_STACK_ID` env.
+
+## Local development
+
+```sh
+# Validate the blueprint
+pnpm dlx @sanity/runtime-cli@latest blueprints doctor
+
+# Diff against the deployed stack
+pnpm dlx @sanity/runtime-cli@latest blueprints plan
+
+# Manage function env vars
+pnpm dlx @sanity/runtime-cli@latest functions env list invalidate-sync-tags
+
+# Tail function logs
+pnpm dlx @sanity/runtime-cli@latest functions logs invalidate-sync-tags
+```
+
+All commands expect `SANITY_AUTH_TOKEN`, `SANITY_PROJECT_ID=mos42crl` and
+`SANITY_BLUEPRINT_STACK_ID` in the environment (or a `.sanity/blueprint.config.json`
+from a previous `blueprints deploy`).

--- a/apps/blueprints/docs/README.md
+++ b/apps/blueprints/docs/README.md
@@ -14,7 +14,7 @@ on the `mos42crl.production` dataset and forwards the invalidated sync tags to
 the docs deployment's expire-tags endpoint
 (`https://www.sanity.io/ui/api/expire-tags`, hardcoded in
 `functions/invalidate-sync-tags/index.ts`), which calls
-`revalidateTag('sanity:<tag>', 'max')` so cached pages are background-revalidated.
+`revalidateTag('sanity:<tag>')` so cached pages are revalidated.
 
 The endpoint is guarded by a single shared secret, which must be set in two
 places with the same value:

--- a/apps/blueprints/docs/functions/invalidate-sync-tags/function.ts
+++ b/apps/blueprints/docs/functions/invalidate-sync-tags/function.ts
@@ -1,0 +1,12 @@
+import {defineSyncTagInvalidateFunction} from '@sanity/blueprints'
+
+// The dataset operated by https://www.sanity.io/ui
+export const invalidateSyncTagsFunction = defineSyncTagInvalidateFunction({
+  event: {
+    resource: {
+      id: 'mos42crl.production',
+      type: 'dataset',
+    },
+  },
+  name: 'invalidate-sync-tags',
+})

--- a/apps/blueprints/docs/functions/invalidate-sync-tags/index.ts
+++ b/apps/blueprints/docs/functions/invalidate-sync-tags/index.ts
@@ -1,0 +1,71 @@
+import {syncTagInvalidateEventHandler} from '@sanity/functions'
+
+// The sanity.io/ui docs deployment (apps/docs). `www` is required: the apex
+// domain 301-redirects, which would downgrade the POST to a GET.
+const EXPIRE_TAGS_URLS = ['https://www.sanity.io/ui/api/expire-tags']
+
+/*
+ * Env vars — set via
+ * `pnpm dlx @sanity/runtime-cli@latest functions env add invalidate-sync-tags <KEY> <VALUE>`:
+ *
+ *   EXPIRE_TAGS_SECRET   shared secret, must match the docs deployment's EXPIRE_TAGS_SECRET
+ */
+
+async function ack(done: (tags: string[]) => Promise<Response>, tags: string[]) {
+  const start = performance.now()
+  try {
+    const response = await done(tags)
+    const ms = Math.round(performance.now() - start)
+    console.info(`done() responded with HTTP ${response.status} (${ms}ms)`)
+  } catch (error) {
+    const ms = Math.round(performance.now() - start)
+    console.error(`Error invoking done callback (${ms}ms)`, error)
+  }
+}
+
+async function expireTags(url: string, secret: string, tags: string[]) {
+  const start = performance.now()
+  const res = await fetch(url, {
+    body: JSON.stringify({secret, tags}),
+    headers: {'Content-Type': 'application/json'},
+    method: 'POST',
+  })
+  const ms = Math.round(performance.now() - start)
+
+  if (res.ok) {
+    console.info(`Revalidated ${tags.length} tags via ${url} (${ms}ms)`, res.status)
+  } else {
+    const body = await res.text()
+    console.error(`Non-OK response from ${url} (${ms}ms)`, res.status, body)
+  }
+}
+
+export const handler = syncTagInvalidateEventHandler(async ({done, event}) => {
+  const start = performance.now()
+  const syncTags = event.data.syncTags
+  const secret = process.env.EXPIRE_TAGS_SECRET
+
+  if (!secret) {
+    console.error(
+      'EXPIRE_TAGS_SECRET is not configured — set it with `functions env add invalidate-sync-tags EXPIRE_TAGS_SECRET <value>`',
+    )
+    await ack(done, syncTags)
+    return
+  }
+
+  console.info(`Forwarding ${syncTags.length} tags to ${EXPIRE_TAGS_URLS.length} endpoint(s)`)
+
+  const results = await Promise.allSettled(
+    EXPIRE_TAGS_URLS.map((url) => expireTags(url, secret, syncTags)),
+  )
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    if (result.status === 'rejected') {
+      console.error(`Failed to call ${EXPIRE_TAGS_URLS[i]}`, result.reason)
+    }
+  }
+
+  await ack(done, syncTags)
+  console.info(`Total handler time: ${Math.round(performance.now() - start)}ms`)
+})

--- a/apps/blueprints/docs/package.json
+++ b/apps/blueprints/docs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "blueprints-docs",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Sanity Blueprint deploying serverless functions for the sanity.io/ui docs (project mos42crl)",
+  "type": "module",
+  "devDependencies": {
+    "@sanity/blueprints": "catalog:",
+    "@sanity/functions": "catalog:",
+    "@types/node": "catalog:",
+    "sanity": "catalog:"
+  }
+}

--- a/apps/blueprints/docs/package.json
+++ b/apps/blueprints/docs/package.json
@@ -7,7 +7,6 @@
   "devDependencies": {
     "@sanity/blueprints": "catalog:",
     "@sanity/functions": "catalog:",
-    "@types/node": "catalog:",
-    "sanity": "catalog:"
+    "@types/node": "catalog:"
   }
 }

--- a/apps/blueprints/docs/sanity.blueprint.ts
+++ b/apps/blueprints/docs/sanity.blueprint.ts
@@ -1,0 +1,7 @@
+import {defineBlueprint} from '@sanity/blueprints'
+
+import {invalidateSyncTagsFunction} from './functions/invalidate-sync-tags/function'
+
+export default defineBlueprint({
+  resources: [invalidateSyncTagsFunction],
+})

--- a/apps/blueprints/docs/tsconfig.json
+++ b/apps/blueprints/docs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2023",
+    "types": ["node"]
+  }
+}

--- a/apps/docs/src/app/api/expire-tags/route.ts
+++ b/apps/docs/src/app/api/expire-tags/route.ts
@@ -41,11 +41,7 @@ export async function POST(request: NextRequest) {
   console.info('Expiring tags from expirator service', tags)
 
   for (const tag of tags) {
-    // The 'max' profile is recommended so that it's background revalidated, and
-    // serves stale content for as long as necessary until the background
-    // revalidation is complete. Otherwise it might cause affected URLs to
-    // suddenly switch to dynamic rendering.
-    revalidateTag(`sanity:${tag}`, 'max')
+    revalidateTag(`sanity:${tag}`)
   }
 
   return Response.json({service: 'sanity-ui-docs', tags})

--- a/apps/docs/src/app/api/expire-tags/route.ts
+++ b/apps/docs/src/app/api/expire-tags/route.ts
@@ -1,0 +1,52 @@
+import {revalidateTag} from 'next/cache'
+import type {NextRequest} from 'next/server'
+
+const expireTagsSecret = process.env.EXPIRE_TAGS_SECRET
+
+/**
+ * Called by the `invalidate-sync-tags` Sanity Function (deployed from
+ * `apps/blueprints/docs`) whenever content changes, with the sync tags that
+ * the Live Content API reported as expired.
+ */
+export async function POST(request: NextRequest) {
+  const url = new URL(request.url)
+
+  if (!expireTagsSecret) {
+    console.error('EXPIRE_TAGS_SECRET environment variable is required')
+    return Response.json({error: 'Unexpected error'}, {status: 500})
+  }
+
+  let secret = url.searchParams.get('secret')
+  let tags = url.searchParams.getAll('tag')
+
+  if (!secret || tags.length === 0) {
+    try {
+      const body = await request.json()
+      if (!secret && body.secret) secret = body.secret
+      if (tags.length === 0 && Array.isArray(body.tags)) tags = body.tags
+    } catch {
+      // no valid JSON body
+    }
+  }
+
+  if (secret !== expireTagsSecret) {
+    return Response.json({error: 'Unauthorized'}, {status: 401})
+  }
+
+  if (tags.length === 0) {
+    return Response.json({error: 'No tags provided'}, {status: 400})
+  }
+
+  // oxlint-disable-next-line no-console
+  console.info('Expiring tags from expirator service', tags)
+
+  for (const tag of tags) {
+    // The 'max' profile is recommended so that it's background revalidated, and
+    // serves stale content for as long as necessary until the background
+    // revalidation is complete. Otherwise it might cause affected URLs to
+    // suddenly switch to dynamic rendering.
+    revalidateTag(`sanity:${tag}`, 'max')
+  }
+
+  return Response.json({service: 'sanity-ui-docs', tags})
+}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -3,10 +3,9 @@
   "workspaces": {
     ".": {},
     "apps/blueprints/docs": {
-      // The function handlers are entry points for the Sanity runtime (deployed
-      // via @sanity/runtime-cli), not imported anywhere (sanity.blueprint.ts is
-      // already a default entry of knip's Sanity plugin)
-      "entry": ["functions/*/index.ts"],
+      // The Blueprint config and function handlers are runtime entry points
+      // deployed via @sanity/runtime-cli, not imported by application code
+      "entry": ["sanity.blueprint.ts", "functions/*/index.ts"],
     },
     "packages/ui": {
       "ignoreDependencies": [

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -2,6 +2,14 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {},
+    "apps/blueprints/docs": {
+      // The function handlers are entry points for the Sanity runtime (deployed
+      // via @sanity/runtime-cli), not imported anywhere (sanity.blueprint.ts is
+      // already a default entry of knip's Sanity plugin)
+      "entry": ["functions/*/index.ts"],
+      // Only used for its CLI (`sanity functions env ...`, `sanity blueprints ...`)
+      "ignoreDependencies": ["sanity"],
+    },
     "packages/ui": {
       "ignoreDependencies": [
         // babel-plugin-react-compiler (target '18') injects imports of this runtime

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -7,8 +7,6 @@
       // via @sanity/runtime-cli), not imported anywhere (sanity.blueprint.ts is
       // already a default entry of knip's Sanity plugin)
       "entry": ["functions/*/index.ts"],
-      // Only used for its CLI (`sanity functions env ...`, `sanity blueprints ...`)
-      "ignoreDependencies": ["sanity"],
     },
     "packages/ui": {
       "ignoreDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,15 @@ settings:
 
 catalogs:
   default:
+    '@sanity/blueprints':
+      specifier: ^0.21.0
+      version: 0.21.0
     '@sanity/color':
       specifier: ^3.0.6
       version: 3.0.6
+    '@sanity/functions':
+      specifier: ^1.4.0
+      version: 1.4.0
     '@sanity/icons':
       specifier: ^3.8.0
       version: 3.8.0
@@ -90,6 +96,18 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+
+  apps/blueprints/docs:
+    devDependencies:
+      '@sanity/blueprints':
+        specifier: 'catalog:'
+        version: 0.21.0
+      '@sanity/functions':
+        specifier: 'catalog:'
+        version: 1.4.0(@aws-lite/client@0.21.10)(@aws-lite/dynamodb@0.3.9)(@aws-lite/lambda@0.1.5)(@aws-lite/sns@0.0.8)(@aws-lite/sqs@0.2.4)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
 
   apps/docs:
     dependencies:
@@ -507,8 +525,24 @@ packages:
     resolution: {integrity: sha512-fOn3lg1ynBAxqcELRf084bNJ6gu+GGoNyC+hwitW/hg3Vc1z1ZbK5HWWTrDw8HdM/fEQ0UN++g7GXVN1GVctdQ==}
     engines: {node: '>=16'}
 
+  '@aws-lite/dynamodb@0.3.9':
+    resolution: {integrity: sha512-jrMAWwxoAMVJ3z0/mI/GzPM5AfGmH+xzTpNIbjg3+2WdYJRqvIf8025XJdCDtS9/4x8zogdchEp3ZelXnwYyqw==}
+    engines: {node: '>=16'}
+
+  '@aws-lite/lambda@0.1.5':
+    resolution: {integrity: sha512-Sa6AxBQwzqGsUr2ifxcpAvFlTkoDwIQIYgcEFVQ+0qKeV9ci+ggsOOSRGBxrGEdRsnQxUsQ2x0ES/29c8crzQw==}
+    engines: {node: '>=16'}
+
   '@aws-lite/s3@0.1.22':
     resolution: {integrity: sha512-9OL95fTvHV80JvFTxLx8hhWQ6DgwHUts02KpXITA8syCDnYgua2rNcpwQ5b6GZzpL7yNXU0dud/Y6edThbffig==}
+    engines: {node: '>=16'}
+
+  '@aws-lite/sns@0.0.8':
+    resolution: {integrity: sha512-MIzHe66kLNyzPFY/DX30uN7DlVQsnBiHPYbq/7syNWuoYSG8bkWuUX2CVIuSL7Ji5jaLpQ4lf8/VQ+SiAeoIZA==}
+    engines: {node: '>=16'}
+
+  '@aws-lite/sqs@0.2.4':
+    resolution: {integrity: sha512-a1M3HDdkNE/xJfASlfisAaZ8XF6FpvoJbJsH/gr6pogEFWgNQyvmPVNRElnDY7JW3ee82sEOkMukYRdAbjytNQ==}
     engines: {node: '>=16'}
 
   '@aws-lite/ssm@0.2.5':
@@ -3449,6 +3483,10 @@ packages:
   '@sanity/bifur-client@0.4.1':
     resolution: {integrity: sha512-mHM8WR7pujbIw2qxuV0lzinS1izOoyLza/ejWV6quITTLpBhUoPIQGPER3Ar0SON5JV0VEEqkJGa1kjiYYgx2w==}
 
+  '@sanity/blueprints@0.21.0':
+    resolution: {integrity: sha512-gWUkqvNB5YHHclKUGVVr1wPBV65/4Vs0Lch8JPWM5sTV56sM7EEoNsjOOl/zYmOx11YDYLUDXVyXYPClANjTQw==}
+    engines: {node: '>=20'}
+
   '@sanity/browserslist-config@1.0.5':
     resolution: {integrity: sha512-so+/UtCge8t1jq509hH0otbbptRz0zM/Aa0dh5MhMD7HGT6n2igWIL2VWH/9QR9e77Jn3dJsjz23mW1WCxT+sg==}
 
@@ -3512,6 +3550,16 @@ packages:
   '@sanity/export@3.45.3':
     resolution: {integrity: sha512-NmN7nfilwza7ztdA8/SPnX1V4RjKVUL8epbcIvIymYRwfjclbjOLP4DgZlvhVS1mtgZAo9kB4pC49HjuGi/Cng==}
     engines: {node: '>=18'}
+
+  '@sanity/functions@1.4.0':
+    resolution: {integrity: sha512-4PIGV0Ec/SyJpYhHv/VHnAo+z3rO4GvqXk0EJiPsRTjn6hB6+j7n8WyBgZqVHrdUKcCGgXvmB3RmgcYcnah+sQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@aws-lite/client': ^0.23.6
+      '@aws-lite/dynamodb': ^0.3.9
+      '@aws-lite/lambda': ^0.1.5
+      '@aws-lite/sns': ^0.0.8
+      '@aws-lite/sqs': ^0.2.4
 
   '@sanity/generate-help-url@3.0.1':
     resolution: {integrity: sha512-bKqCEqFP7qXpNcHxJZnXFLrti8/HYQhhJtMRYFSNJ8bkUXCuUmhHKckzoyiH1n1WAZpI2Y05z2h5yZWbi3gThQ==}
@@ -8630,7 +8678,15 @@ snapshots:
     dependencies:
       aws4: 1.13.2
 
+  '@aws-lite/dynamodb@0.3.9': {}
+
+  '@aws-lite/lambda@0.1.5': {}
+
   '@aws-lite/s3@0.1.22': {}
+
+  '@aws-lite/sns@0.0.8': {}
+
+  '@aws-lite/sqs@0.2.4': {}
 
   '@aws-lite/ssm@0.2.5': {}
 
@@ -11263,6 +11319,8 @@ snapshots:
       nanoid: 3.3.15
       rxjs: 7.8.2
 
+  '@sanity/blueprints@0.21.0': {}
+
   '@sanity/browserslist-config@1.0.5': {}
 
   '@sanity/cli@3.99.0(@types/node@24.13.2)(@types/react@19.2.17)(lightningcss@1.32.0)(react@19.2.7)(supports-color@8.1.1)(typescript@5.9.3)(yaml@2.9.0)':
@@ -11434,6 +11492,14 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@sanity/functions@1.4.0(@aws-lite/client@0.21.10)(@aws-lite/dynamodb@0.3.9)(@aws-lite/lambda@0.1.5)(@aws-lite/sns@0.0.8)(@aws-lite/sqs@0.2.4)':
+    dependencies:
+      '@aws-lite/client': 0.21.10
+      '@aws-lite/dynamodb': 0.3.9
+      '@aws-lite/lambda': 0.1.5
+      '@aws-lite/sns': 0.0.8
+      '@aws-lite/sqs': 0.2.4
 
   '@sanity/generate-help-url@3.0.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'apps/*'
+  - 'apps/blueprints/*'
   - 'packages/*'
 
 linkWorkspacePackages: deep
@@ -11,7 +12,9 @@ strictPeerDependencies: false
 # v6), @types/node (v24 vs v22) and vitest (v3 vs v4, see the
 # packageExtensions note) versions, so those keep explicit ranges there.
 catalog:
+  '@sanity/blueprints': ^0.21.0
   '@sanity/color': ^3.0.6
+  '@sanity/functions': ^1.4.0
   '@sanity/icons': ^3.8.0
   '@sanity/tsdown-config': ^0.13.0
   '@types/node': ^22.20.1
@@ -25,6 +28,7 @@ catalog:
   react-refractor: ^4.0.0
   refractor: ^5.0.0
   rimraf: ^5.0.5
+  sanity: ^6.4.0
   styled-components: ^6.4.3
   tsdown: ^0.22.5
   typescript: 6.0.3
@@ -40,9 +44,14 @@ allowBuilds:
   unrs-resolver: true
 
 # Sanity-owned build tooling releases frequently; don't gate it on the
-# default minimum release age (1 day)
+# default minimum release age (1 day). Same for next's `preview` dist-tag
+# (apps/docs pins an exact preview version, so the exclusion only lifts the
+# age gate for versions we deliberately pick).
 minimumReleaseAgeExclude:
+  - '@next/*'
+  - '@sanity/code-input@7.2.7'
   - '@sanity/tsdown-config'
+  - next
 
 # @testing-library/jest-dom/vitest imports `vitest` without declaring it, so it
 # falls back to pnpm's hidden hoist — which can resolve to another workspace

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,6 @@ catalog:
   react-refractor: ^4.0.0
   refractor: ^5.0.0
   rimraf: ^5.0.5
-  sanity: ^6.4.0
   styled-components: ^6.4.3
   tsdown: ^0.22.5
   typescript: 6.0.3
@@ -44,14 +43,9 @@ allowBuilds:
   unrs-resolver: true
 
 # Sanity-owned build tooling releases frequently; don't gate it on the
-# default minimum release age (1 day). Same for next's `preview` dist-tag
-# (apps/docs pins an exact preview version, so the exclusion only lifts the
-# age gate for versions we deliberately pick).
+# default minimum release age (1 day)
 minimumReleaseAgeExclude:
-  - '@next/*'
-  - '@sanity/code-input@7.2.7'
   - '@sanity/tsdown-config'
-  - next
 
 # @testing-library/jest-dom/vitest imports `vitest` without declaring it, so it
 # falls back to pnpm's hidden hoist — which can resolve to another workspace


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- split the docs Blueprint deployment workflow and package out of #2375
- add the docs cache-tag expiration endpoint, adapted to the current Next.js API on `main`
- register the Blueprint workspace and explicit runtime entries for lint/knip
- add only the new workspace glob and the `@sanity/blueprints` / `@sanity/functions` catalog entries
- regenerate only the lockfile entries required by the new workspace

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm knip`
- `pnpm --filter sanity-ui-docs typecheck`
- `pnpm exec tsc --project apps/blueprints/docs/tsconfig.json`
- `pnpm test` (42 files, 125 tests)
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/sanity-blueprint-docs.yml`
- exercised the expiration API over HTTP: unauthorized (401), missing tags (400), JSON success (200), and query-string success (200)
- exercised the function handler with successful forwarding, missing-secret acknowledgement, and failed-delivery acknowledgement
- all 12 applicable CI checks pass, including the authenticated Docs Blueprint Plan

## Validation evidence

[blueprint_docs_validation_2376.log](https://cursor.com/agents/bc-9b021080-a414-4a1b-bf60-003be1cf24e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblueprint_docs_validation_2376.log)

[blueprint_function_handler_validation_2376.log](https://cursor.com/agents/bc-9b021080-a414-4a1b-bf60-003be1cf24e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblueprint_function_handler_validation_2376.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b021080-a414-4a1b-bf60-003be1cf24e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b021080-a414-4a1b-bf60-003be1cf24e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

