### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,4 +83,14 @@ Standard scripts live in the root `package.json` (`lint`, `test`, `build`,
   `http://localhost:3333/#token={SANITY_AUTH_TOKEN}` (Sanity consumes the
   token from the URL hash on load). The same hash-token sign-in also works for
   the studio embedded in the Next.js app at
-  `http://localhost:3000/ui/studio/production#token={SANITY_AUTH_TOKEN}`.
+  `http://localhost:3000/ui/studio/production#token={SANITY_AUTH_TOKEN}`. The
+  standalone studio (`pnpm dev:docs`, project `mos42crl`) exposes two
+  workspaces — `/production` (dataset `production`) and `/development` (dataset
+  `development`); prefer `/development` when creating/publishing test documents
+  so you don't pollute production. When driving the studio through the browser
+  (e.g. computer-use), tokens are redacted from tool output, so you cannot paste
+  the `#token=...` URL into browser instructions. A reliable workaround is a
+  tiny local HTTP server that reads `SANITY_AUTH_TOKEN` from env and serves an
+  HTML page doing `location.replace(<studio-url-with-token>)`, then point the
+  browser at that server — this keeps the secret out of prompts/screenshots
+  while still landing you authenticated in the workspace.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified the full development environment for the `@sanity/ui` pnpm monorepo in a Cursor Cloud VM and captured one durable, non-obvious clarification in `AGENTS.md`.

The only code change is a docs addition to `AGENTS.md` documenting the dev studio workspaces (`/development` vs `/production`) and the token-redirect trick for authenticating the studio through a browser without exposing the redacted `SANITY_AUTH_TOKEN`.

## Environment verification

| Service / check | Command | Result |
| --- | --- | --- |
| Lint + type check | `pnpm lint` | ✅ pass |
| Unit tests | `pnpm test` | ✅ 125 passed (42 files) |
| Build | `pnpm build` | ✅ `@sanity/ui` + figma plugin |
| Storybook (dev) | `pnpm dev` | ✅ http://localhost:6006 |
| Docs Next.js + Studio (dev) | `pnpm dev:docs` | ✅ http://localhost:3000/ui and http://localhost:3333 |

## Hello-world

Authenticated the embedded Sanity Studio (dev workspace) and created + published a `Screen` document titled "Cursor Cloud hello world" in the `development` dataset.

[Authenticated studio](https://cursor.com/agents/bc-1fd7058d-e6bf-4776-af9d-84ed22972344/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_authenticated.webp)
[Document title filled in](https://cursor.com/agents/bc-1fd7058d-e6bf-4776-af9d-84ed22972344/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_document_title.webp)
[Published confirmation](https://cursor.com/agents/bc-1fd7058d-e6bf-4776-af9d-84ed22972344/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_published.webp)
[Storybook Button story rendered](https://cursor.com/agents/bc-1fd7058d-e6bf-4776-af9d-84ed22972344/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_button_rendered.webp)

## Update script

`pnpm install` (dependencies already resolve `@sanity/ui` to source, so no build is needed for dev/test).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fd7058d-e6bf-4776-af9d-84ed22972344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fd7058d-e6bf-4776-af9d-84ed22972344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

