### PR TITLE
feat(docs): document deprecated props in property tables

### DIFF
--- a/apps/docs/sanity.types.ts
+++ b/apps/docs/sanity.types.ts
@@ -218,6 +218,7 @@ export type Article = {
       name?: string;
       type?: string;
       required?: boolean;
+      deprecated?: string;
       description?: Array<{
         children?: Array<{
           marks?: Array<string>;
@@ -690,6 +691,7 @@ export type TargetByPathQueryResult = null | {
       name?: string;
       type?: string;
       required?: boolean;
+      deprecated?: string;
       description?: Array<{
         children?: Array<{
           marks?: Array<string>;

--- a/apps/docs/schema.json
+++ b/apps/docs/schema.json
@@ -2255,6 +2255,13 @@
                             },
                             "optional": true
                           },
+                          "deprecated": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            },
+                            "optional": true
+                          },
                           "description": {
                             "type": "objectAttribute",
                             "value": {

--- a/apps/docs/src/components/page/article/content/PropertyTable.tsx
+++ b/apps/docs/src/components/page/article/content/PropertyTable.tsx
@@ -1,4 +1,4 @@
-import {Box, Card, Code, Stack, Text} from '@sanity/ui'
+import {Badge, Box, Card, Code, Flex, Stack, Text} from '@sanity/ui'
 import {stegaClean} from 'next-sanity'
 import {ReactElement} from 'react'
 import {styled} from 'styled-components'
@@ -44,6 +44,7 @@ type PropertyValue = NonNullable<PropertyTableValue['properties']>[number]
 function Property(props: {property: PropertyValue}) {
   // The type signature is rendered as (copyable) code, so strip stega metadata
   const {name, required, type} = stegaClean(props.property)
+  const {deprecated} = props.property
 
   let tsType = name
 
@@ -54,9 +55,23 @@ function Property(props: {property: PropertyValue}) {
   return (
     <PropertyBox padding={3}>
       <Stack gap={3}>
-        <Code language="typescript" size={1}>
-          {tsType}
-        </Code>
+        <Flex align="center" gap={2} wrap="wrap">
+          <Code language="typescript" size={1}>
+            {tsType}
+          </Code>
+
+          {deprecated && (
+            <Badge fontSize={0} tone="caution">
+              deprecated
+            </Badge>
+          )}
+        </Flex>
+
+        {deprecated && (
+          <Text muted size={1}>
+            {deprecated}
+          </Text>
+        )}
 
         {isArray(props.property.description) && (
           <PlainContent blocks={props.property.description} />

--- a/apps/docs/src/studio/schema/article/content/propertyTableField.ts
+++ b/apps/docs/src/studio/schema/article/content/propertyTableField.ts
@@ -8,6 +8,13 @@ const propertyField = defineArrayMember({
     {type: 'string', name: 'name', title: 'Name'},
     {type: 'string', name: 'type', title: 'Type (TS)'},
     {type: 'boolean', name: 'required', title: 'Required'},
+    {
+      type: 'string',
+      name: 'deprecated',
+      title: 'Deprecated (migration hint)',
+      description:
+        'When set, the property is rendered as deprecated. Use it for a short migration hint, e.g. "Use gap instead. Will be removed in v4."',
+    },
     {type: 'array', name: 'description', title: 'Description', of: [{type: 'block'}]},
   ],
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2266

The docs at sanity.io/ui did not reflect the v3.2.0 spacing-prop deprecations: `Stack`/`Button`/`Inline`/etc. still documented `space` with no `gap`, `Grid` documented `columns`/`rows` without `gridTemplateColumns`/`gridTemplateRows`, and deprecations were not shown anywhere.

Property tables are manually authored content in the `mos42crl/production` dataset, so this fix has two halves:

### 1. Code (this PR)

- Add an optional `deprecated` string field ("Deprecated (migration hint)") to the `property` object in `propertyTableField.ts`. Presence of the field marks the prop as deprecated.
- Render it in `PropertyTable.tsx`: a `caution`-tone `deprecated` badge next to the type signature plus the migration hint below it.
- Regenerate `schema.json` and `sanity.types.ts` (`sanity schema extract` + `sanity typegen generate`).

### 2. Content (staged in the "Docs fixes" release `rcJKUyy1y`, not published)

16 article version documents staged via the Actions API — published documents untouched, no drafts created. Publishing the release is one click in the Releases tool, ideally after this PR deploys so the badges render:

| Article | Change |
| --- | --- |
| Button, Inline, Select, TextInput, Menu, Hotkeys, Tab (TabList table) | added `gap`, marked `space` deprecated |
| Stack | re-added `space` as deprecated next to `gap` |
| Grid | added `gridTemplateColumns`/`gridTemplateRows` + missing `gapX`/`gapY`, marked `columns`/`rows` deprecated |
| Box, Card | added `gridColumn(Start/End)`/`gridRow(Start/End)`, marked the six old grid-item props deprecated |
| Flex | added missing `gap` |
| Tooltip | marked `allowedAutoPlacements` deprecated (`fallbackPlacements` already documented) |
| Menu | also: added `shouldFocus`, marked `focusLast` deprecated |
| MenuButton | added `popover`, marked `boundaryElement`/`placement`/`popoverScheme`/`popoverRadius`/`portal` deprecated |
| Popover | added `floatingBoundary`/`referenceBoundary`, marked `boundaryElement` deprecated |
| useClickOutside | caution callout: replaced by `useClickOutsideEvent` |

Deprecation hints mirror the JSDoc in `packages/ui` (e.g. "Use gap instead. Will be removed in v4."). Breadcrumbs/Tree/TreeItem/MenuItem/MenuGroup have no doc articles, so nothing to stage there.

### Demo

Release perspective previewed through the Presentation tool with this branch running locally (Button → Grid → Stack → Box):

[docs_release_preview_deprecated_props_demo.mp4](https://cursor.com/agents/bc-d868ff28-e00c-4a48-97c8-366cffd89e20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_release_preview_deprecated_props_demo.mp4)

Second batch (useClickOutside → Menu → MenuButton → Popover):

[docs_release_preview_menu_menubutton_popover_useclickoutside.mp4](https://cursor.com/agents/bc-d868ff28-e00c-4a48-97c8-366cffd89e20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_release_preview_menu_menubutton_popover_useclickoutside.mp4)

| Before (live site) | After (release preview) |
| --- | --- |
| [Button props before](https://cursor.com/agents/bc-d868ff28-e00c-4a48-97c8-366cffd89e20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_live_button_props.png) | [Button props after](https://cursor.com/agents/bc-d868ff28-e00c-4a48-97c8-366cffd89e20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_button_gap_deprecated_space.webp) |
| [Grid props before](https://cursor.com/agents/bc-d868ff28-e00c-4a48-97c8-366cffd89e20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_live_grid_props.png) | [Grid props after](https://cursor.com/agents/bc-d868ff28-e00c-4a48-97c8-366cffd89e20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_grid_gridtemplate_deprecated_columns_rows.webp) |

### Verification

- Staged release content reviewed in the local Studio (release document list + field-level check) and cross-checked via GROQ for all 16 articles.
- `pnpm lint`, `pnpm format`, `pnpm knip`, `pnpm test` all pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d868ff28-e00c-4a48-97c8-366cffd89e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d868ff28-e00c-4a48-97c8-366cffd89e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

