### PR TITLE
chore(deps): bump pnpm to 11.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
   "engines": {
     "node": ">=22.13"
   },
-  "packageManager": "pnpm@11.10.0"
+  "packageManager": "pnpm@11.15.1"
 }

--- a/packages/figma-color/package.json
+++ b/packages/figma-color/package.json
@@ -5,6 +5,9 @@
   "description": "Figma plugin for syncing from `@sanity/color` to color styles and variables in Figma.",
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/figma/package.json
+++ b/packages/figma/package.json
@@ -5,6 +5,9 @@
   "description": "",
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps `packageManager` from `pnpm@11.10.0` to `pnpm@11.15.1` (latest v11) and adapts the two private Figma plugin packages to pnpm 11.15's new pack semantics.

## Regression found and fixed

pnpm 11.15.0 changed `pnpm pack` to honor the workspace-root `.gitignore`/`.npmignore` when packing workspace packages ([pnpm/pnpm#12878](https://github.com/pnpm/pnpm/pull/12878)). Our root `.gitignore` contains `dist`, so packages without a `files` field lost their build output from the packlist. This broke `pnpm build`: the publint check that tsdown runs (enabled via `@sanity/tsdown-config`) computes the packlist with `pnpm pack` and failed for both Figma plugins with `pkg.exports["."] is ./dist/index.js but the file does not exist`.

Fix: give `figma-plugin-sanity-ui` and `figma-plugin-sanity-color` the same `files: ["dist"]` field every published package already has — the `files` field takes priority over all ignore files ([pnpm/pnpm#13005](https://github.com/pnpm/pnpm/pull/13005)), and it is the portable npm-packlist mechanism rather than relying on pnpm-specific `.npmignore` precedence.

## `pnpm pack` verification (11.10.0 baseline vs 11.15.1)

Packed all 10 workspace packages under both versions and diffed the extracted tarballs:

- `@sanity/color`, `@sanity/icons`, `@sanity/logos`, `@sanity/ui`: tarball file lists and contents **byte-identical** (these have `files: ["dist"]`, so the new ignore handling never applies).
- `sanity-ui-docs`, `sanity-icons-showcase`, `sanity-ui-storybook`, `blueprints-docs`: file lists identical; packed manifests semantically identical. (Dependency key order for replaced `workspace:*` deps is nondeterministic per run — reproduced on 11.10.0 alone, pre-existing and unrelated.)
- Figma plugins: tarballs now contain `dist` + `package.json`/`LICENSE`/`README` via the new `files` field (previously raw `src`/config files without `dist` unless prebuilt). These packages are `private: true` and never published, so only the publint/packlist behavior matters.

Note: consecutive `pnpm pack` runs of `@sanity/ui` produce `.d.ts` files with shuffled union-member order (e.g. `"as" | "height" | "size" | "children"` vs `"as" | "children" | "height" | "size"`); this reproduces across back-to-back runs on the *same* pnpm version (tsdown/tsgo emit nondeterminism), unrelated to this bump.

## Other checks under 11.15.1

- `pnpm install`: lockfile unchanged (`--frozen-lockfile` passes; only diff was the already-pending `eslint-plugin-storybook` 10.5.2→10.5.3 store update)
- `pnpm build`: passes, publint clean on all packages
- `pnpm test`: 613 tests pass (color 1, icons 487, ui 125)
- `pnpm lint` (includes type checking): clean
- `pnpm knip`: clean
- `pnpm test:browser`: 59 files / 243 tests pass

No changeset: only the workspace root and private packages change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68f79008-d753-4ff5-aad4-4af92221d191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68f79008-d753-4ff5-aad4-4af92221d191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

