### PR TITLE
Crossfade the Storybook canvas when switching between light and dark

### DIFF
--- a/apps/storybook/.storybook/decorators/withSanityTheme.decorator.tsx
+++ b/apps/storybook/.storybook/decorators/withSanityTheme.decorator.tsx
@@ -2,9 +2,16 @@ import {Card, studioTheme, ThemeProvider} from '@sanity/ui'
 import {ThemeColorSchemeKey} from '@sanity/ui/theme'
 import {DecoratorHelpers} from '@storybook/addon-themes'
 import {Decorator} from '@storybook/react-vite'
+import {useLayoutEffect, useRef} from 'react'
 import {createGlobalStyle} from 'styled-components'
 
 const {initializeThemeState, pluckThemeFromContext} = DecoratorHelpers
+
+/** Class present on <html> while a scheme switch is in progress (see <SchemeTransition>) */
+const SCHEME_TRANSITION_CLASS = 'scheme-transition'
+const SCHEME_TRANSITION_DURATION_MS = 250
+/** Keep the class on slightly longer than the transitions run, so they are not cut short */
+const SCHEME_TRANSITION_WINDOW_MS = SCHEME_TRANSITION_DURATION_MS + 150
 
 const GlobalStyle = createGlobalStyle`
   body,
@@ -14,7 +21,55 @@ const GlobalStyle = createGlobalStyle`
       ({theme}) => theme.sanity.color.base.bg
     };
   }
+
+  /* Crossfade all color properties while a light/dark switch is in progress. The class is only
+     present during the switch (see <SchemeTransition>), so these transitions do not affect
+     anything else. */
+  @media (prefers-reduced-motion: no-preference) {
+    html.${SCHEME_TRANSITION_CLASS} body,
+    html.${SCHEME_TRANSITION_CLASS} body *,
+    html.${SCHEME_TRANSITION_CLASS} body *::before,
+    html.${SCHEME_TRANSITION_CLASS} body *::after {
+      transition:
+        background-color ${SCHEME_TRANSITION_DURATION_MS}ms ease,
+        border-color ${SCHEME_TRANSITION_DURATION_MS}ms ease,
+        box-shadow ${SCHEME_TRANSITION_DURATION_MS}ms ease,
+        color ${SCHEME_TRANSITION_DURATION_MS}ms ease,
+        fill ${SCHEME_TRANSITION_DURATION_MS}ms ease,
+        outline-color ${SCHEME_TRANSITION_DURATION_MS}ms ease,
+        stroke ${SCHEME_TRANSITION_DURATION_MS}ms ease;
+    }
+  }
 `
+
+let schemeTransitionTimeout: ReturnType<typeof setTimeout> | undefined
+
+/**
+ * Renders nothing, but opens a "transition window" whenever the color scheme changes: while the
+ * window is open, a class on the root element enables transitions on all color properties (see
+ * GlobalStyle above), so the canvas crossfades between light and dark instead of flipping
+ * abruptly.
+ *
+ * The window is shared by all story instances on the page (docs pages render many), so concurrent
+ * scheme changes simply extend it.
+ */
+function SchemeTransition({scheme}: {scheme: ThemeColorSchemeKey}) {
+  const previousScheme = useRef(scheme)
+
+  // useLayoutEffect so the class is added in the same frame as the color changes it animates
+  useLayoutEffect(() => {
+    if (previousScheme.current === scheme) return
+    previousScheme.current = scheme
+
+    document.documentElement.classList.add(SCHEME_TRANSITION_CLASS)
+    clearTimeout(schemeTransitionTimeout)
+    schemeTransitionTimeout = setTimeout(() => {
+      document.documentElement.classList.remove(SCHEME_TRANSITION_CLASS)
+    }, SCHEME_TRANSITION_WINDOW_MS)
+  }, [scheme])
+
+  return null
+}
 
 /**
  * Story decorator which wraps all stories in a Sanity <ThemeProvider> and passes the current theme
@@ -46,6 +101,7 @@ export const withSanityTheme = ({
       // oxlint-disable-next-line no-deprecated
       <ThemeProvider scheme={selected} theme={studioTheme}>
         <GlobalStyle />
+        <SchemeTransition scheme={selected} />
         <Card padding={padding}>
           <Story />
         </Card>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Toggling the light/dark scheme in the Storybook toolbar flips every color in the preview in a single frame, which feels abrupt.

Neither Storybook core nor the first-party `@storybook/addon-themes` offers a transition option — the addon's decorators swap the theme instantly and leave any smoothing to userland CSS (Storybook's own built-in backgrounds feature does exactly this internally with a `transition: background-color 0.3s`).

## Solution

`withSanityTheme` now opens a brief "transition window" whenever the selected scheme changes: a `scheme-transition` class on `<html>` enables a 250ms `transition` on all color properties (background, text, border, shadow, fill/stroke, outline), so the whole canvas crossfades between schemes. The class is removed 150ms after the transitions finish, so hover/focus/pressed states and component animations behave exactly as before outside the switch.

- The window is shared via a module-level timer, so docs pages (many story roots re-rendering at once) extend one window instead of fighting over it.
- Wrapped in `@media (prefers-reduced-motion: no-preference)`, so users who prefer reduced motion keep the instant flip.
- No effect on `pnpm test:browser` story tests: the window only opens when the scheme *changes* after mount, which never happens during test renders.

Before (instant flip) vs after (~250ms crossfade), 60fps frame extraction:

[Frame-by-frame comparison of the toggle before and after](https://cursor.com/agents/bc-9b774ebe-1adc-4bfa-8593-4723b99e1d78/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fframe_analysis_before_vs_after.png)

[theme_switching_after_smooth_crossfade.mp4](https://cursor.com/agents/bc-9b774ebe-1adc-4bfa-8593-4723b99e1d78/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_switching_after_smooth_crossfade.mp4)

## Notes

On most autodocs pages Storybook fully reloads the preview iframe when globals change (`StoryRender.teardown` falls back to `location.reload()` when renders are still pending — reproducible on a clean checkout and in production builds, see storybookjs/storybook#26941). That reload is unaffected by (and out of reach of) this change; docs pages that don't hit the race (e.g. Dialog) get the same crossfade as the story view.

## Testing

- `pnpm lint`, `pnpm knip`, `pnpm format` — clean
- `pnpm test` (612 tests) and `pnpm test:browser` (243 story/browser tests) — pass
- Playwright probe sampling `body` background at 40ms intervals during a toggle: ~5 intermediate colors normally, 0 with `prefers-reduced-motion: reduce`, and the `scheme-transition` class is added and removed correctly in both cases

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b774ebe-1adc-4bfa-8593-4723b99e1d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b774ebe-1adc-4bfa-8593-4723b99e1d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

