### PR TITLE
feat(docs): enable React production profiling on the studio

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -63,6 +63,7 @@
     "@types/react-dom": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
     "typescript": "^6.0.3",
+    "vite": "catalog:",
     "vitest": "^4.1.10"
   }
 }

--- a/apps/docs/sanity.cli.ts
+++ b/apps/docs/sanity.cli.ts
@@ -1,8 +1,33 @@
 import {createRequire} from 'node:module'
+import path from 'node:path'
+
 import {defineCliConfig} from 'sanity/cli'
-import {mergeConfig, type UserConfig} from 'vite'
+import {mergeConfig, type Plugin, type UserConfig} from 'vite'
 
 const require = createRequire(import.meta.url)
+
+const reactDomDir = path.dirname(require.resolve('react-dom/package.json'))
+const reactDomClientProduction = path.join(reactDomDir, 'cjs/react-dom-client.production.js')
+const reactDomProfiling = path.join(reactDomDir, 'cjs/react-dom-profiling.profiling.js')
+
+/**
+ * With `deployment.autoUpdates`, Sanity builds `react-dom/client` as a vendor
+ * entry that points at the absolute production CJS path — Vite `resolve.alias`
+ * never sees the `react-dom/client` specifier. Redirect that entry (and any
+ * other resolve of the production client) to the profiling build instead.
+ */
+function reactDomProfilingPlugin(): Plugin {
+  return {
+    name: 'sanity-ui-docs/react-dom-profiling',
+    enforce: 'pre',
+    resolveId(source) {
+      if (source === reactDomClientProduction || source === 'react-dom/client') {
+        return reactDomProfiling
+      }
+      return null
+    },
+  }
+}
 
 export default defineCliConfig({
   api: {
@@ -41,9 +66,13 @@ export default defineCliConfig({
     // DevTools can profile with readable component names (see sanity-io/sanity#13674).
     if (command === 'build') {
       return mergeConfig(nextConfig, {
-        // Aliasing to react-dom/profiling is necessary in the production build,
-        // otherwise React can't run the profiler on the deployed studio
-        resolve: {alias: {'react-dom/client': require.resolve('react-dom/profiling')}},
+        plugins: [reactDomProfilingPlugin()],
+        // Also alias the package specifier for any non-vendor resolution path
+        resolve: {
+          alias: {
+            'react-dom/client': reactDomProfiling,
+          },
+        },
         build: {
           // Enable production source maps to easier debug the deployed studio
           sourcemap: true,

--- a/apps/docs/sanity.cli.ts
+++ b/apps/docs/sanity.cli.ts
@@ -1,7 +1,9 @@
+import {createRequire} from 'node:module'
 import {defineCliConfig} from 'sanity/cli'
+import {mergeConfig, type UserConfig} from 'vite'
 
-// Object configs are merged into the base config with vite's `mergeConfig`,
-// which handles both array and object forms of `resolve.alias`.
+const require = createRequire(import.meta.url)
+
 export default defineCliConfig({
   api: {
     projectId: 'mos42crl',
@@ -26,11 +28,39 @@ export default defineCliConfig({
     overloadClientMethods: true,
     formatGeneratedCode: false,
   },
-  vite: {
-    resolve: {
-      alias: {
-        '@': './src',
+  vite(viteConfig, {command}): UserConfig {
+    const nextConfig = mergeConfig(viteConfig, {
+      resolve: {
+        alias: {
+          '@': './src',
+        },
       },
-    },
+    } satisfies UserConfig)
+
+    // Enable React production profiling on the deployed docs studio so React
+    // DevTools can profile with readable component names (see sanity-io/sanity#13674).
+    if (command === 'build') {
+      return mergeConfig(nextConfig, {
+        // Aliasing to react-dom/profiling is necessary in the production build,
+        // otherwise React can't run the profiler on the deployed studio
+        resolve: {alias: {'react-dom/client': require.resolve('react-dom/profiling')}},
+        build: {
+          // Enable production source maps to easier debug the deployed studio
+          sourcemap: true,
+          rolldownOptions: {
+            output: {
+              // Disabling `mangle` (while keeping compression and whitespace removal)
+              // ensures that the React DevTools components inspector has readable
+              // component names. This overrides the `build.minify: 'oxc'` default set
+              // by `sanity build`, replacing `esbuild: {minifyIdentifiers: false}`
+              // which the rolldown-powered Vite silently ignores.
+              minify: {compress: true, mangle: false, codegen: true},
+            },
+          },
+        },
+      } satisfies UserConfig)
+    }
+
+    return nextConfig
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enables React production profiling for the docs studio build, matching the approach from [sanity-io/sanity#13674](https://github.com/sanity-io/sanity/pull/13674) and the guidance in the `@sanity/ui` changelog.

### Changes
On `sanity build`:
- Ship `react-dom`'s **profiling** build as the `react-dom/client` vendor chunk (required because `deployment.autoUpdates` resolves that entry to an absolute production CJS path, so a plain `resolve.alias` never applies)
- Emit production sourcemaps
- Override Rolldown minify to `{compress: true, mangle: false, codegen: true}` so React DevTools keeps readable component names

`sanity dev` is unchanged.

### Verification
Local `pnpm --filter sanity-ui-docs sanity:build`:
- Vendor `react-dom/client-*.mjs` includes `startProfilerTimer` (profiling build; ~441 KB vs ~389 KB production)
- Readable names present in the studio chunk (`CodeInput`, `FullscreenEditor`, `ThemeColorProvider`, …)
- Production sourcemaps emitted for static + vendor chunks

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec13261f-4195-4664-a205-d97699256ad8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec13261f-4195-4664-a205-d97699256ad8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

