### PR TITLE
fix(deps): make `react-is` a regular dependency of `@sanity/ui`

### DIFF
--- a/.changeset/react-is-regular-dep.md
+++ b/.changeset/react-is-regular-dep.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Make `react-is` a regular dependency instead of a peer dependency

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -34,7 +34,6 @@
     "playwright": "^1.61.1",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-is": "catalog:",
     "react-refractor": "catalog:",
     "refractor": "catalog:",
     "rimraf": "catalog:",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,6 +76,7 @@
     "csstype": "^3.2.3",
     "motion": "^12.42.2",
     "react-compiler-runtime": "1.0.0",
+    "react-is": "catalog:",
     "react-refractor": "catalog:",
     "use-effect-event": "^2.0.3"
   },
@@ -94,7 +95,6 @@
     "jsdom": "^29.1.1",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-is": "catalog:",
     "rimraf": "catalog:",
     "styled-components": "catalog:",
     "tsdown": "catalog:",
@@ -107,7 +107,6 @@
   "peerDependencies": {
     "react": "^18 || >=19.0.0-0",
     "react-dom": "^18 || >=19.0.0-0",
-    "react-is": "^18 || >=19.0.0-0",
     "styled-components": "^5.2 || ^6"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,9 @@ importers:
       react-compiler-runtime:
         specifier: 1.0.0
         version: 1.0.0(react@19.2.8)
+      react-is:
+        specifier: 'catalog:'
+        version: 19.2.8
       react-refractor:
         specifier: 'catalog:'
         version: 4.0.0(react@19.2.8)
@@ -628,9 +631,6 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
-      react-is:
-        specifier: 'catalog:'
-        version: 19.2.8
       rimraf:
         specifier: 'catalog:'
         version: 5.0.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,9 +350,6 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
-      react-is:
-        specifier: 'catalog:'
-        version: 19.2.8
       react-refractor:
         specifier: 'catalog:'
         version: 4.0.0(react@19.2.8)
@@ -8539,7 +8536,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.6
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move `react-is` from a peer dependency to a regular dependency of `@sanity/ui`.

Consumers no longer need to install `react-is` themselves — it's now shipped and versioned with the package (via the workspace catalog).

### Changes
- Add `react-is` to `@sanity/ui` `dependencies`
- Remove it from `@sanity/ui` `peerDependencies` and `devDependencies`
- Remove the now-unused `react-is` from `apps/storybook` (knip flagged it after the peer→dep move)
- Add a patch changeset for `@sanity/ui`

### Verification
- `pnpm --filter @sanity/ui test` — passed
- `pnpm knip` — passed after dropping storybook's unused `react-is`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86d8a929-b441-4da3-b430-d8d06058fb22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86d8a929-b441-4da3-b430-d8d06058fb22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

