### PR TITLE
docs: add root README explaining the monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-packages/ui/README.md
+# Sanity UI monorepo
+
+pnpm workspace for Sanity’s design-system packages and related apps.
+
+Published packages live under `packages/`. Docs, Storybook, the icon showcase,
+and serverless functions live under `apps/`.
+
+## Packages
+
+| Package | Description |
+| --- | --- |
+| [`@sanity/ui`](packages/ui) | React component library |
+| [`@sanity/icons`](packages/icons) | Icon components (SVG → React) |
+| [`@sanity/color`](packages/color) | Color palette |
+| [`@sanity/logos`](packages/logos) | Sanity / GROQ logo components |
+| [`figma-plugin-sanity-ui`](packages/figma) | Figma plugin for Sanity UI theme tokens |
+| [`figma-plugin-sanity-color`](packages/figma-color) | Figma plugin for the `@sanity/color` palette |
+
+## Apps
+
+| App | Description |
+| --- | --- |
+| [`apps/storybook`](apps/storybook) | Component Storybook ([localhost:6006](http://localhost:6006) via `pnpm dev`) |
+| [`apps/docs`](apps/docs) | [sanity.io/ui](https://www.sanity.io/ui) docs site (Next.js + embedded Studio) |
+| [`apps/icons`](apps/icons) | [icons.sanity.dev](https://icons.sanity.dev) searchable icon catalog |
+| [`apps/blueprints/docs`](apps/blueprints/docs) | Sanity Blueprint (serverless functions for the docs site) |
+
+## Requirements
+
+- Node.js `>=22.13`
+- [pnpm](https://pnpm.io) `11` (pinned via `packageManager` in `package.json`)
+
+## Getting started
+
+```sh
+pnpm install
+pnpm build
+pnpm test
+```
+
+### Development
+
+```sh
+pnpm dev          # Storybook at http://localhost:6006
+pnpm dev:docs     # Docs at http://localhost:3000/ui (+ Studio at :3333)
+pnpm dev:icons    # Icon showcase at http://localhost:5173
+```
+
+In the monorepo, `@sanity/ui`, `@sanity/icons`, `@sanity/color`, and
+`@sanity/logos` resolve to TypeScript source through package `exports`, so
+Storybook and the apps hot-reload package edits without a rebuild.
+
+### Common scripts
+
+| Script | What it does |
+| --- | --- |
+| `pnpm build` | Build all publishable packages and Figma plugins |
+| `pnpm test` | Unit tests (`@sanity/ui`, `@sanity/icons`, `@sanity/color`) |
+| `pnpm test:browser` | Storybook browser tests (Chromium via Playwright) |
+| `pnpm lint` | Lint + type-check (oxlint) |
+| `pnpm format` | Format with oxfmt |
+| `pnpm knip` | Unused files / dependencies / exports |
+| `pnpm changeset` | Add a changeset for a release |
+
+## Contributing & releasing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Releases use
+[Changesets](https://github.com/changesets/changesets): add a changeset on your
+PR; merging to `main` opens a “Version Packages” PR that publishes to npm when
+merged.
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the root `README.md` symlink (previously pointing at `packages/ui/README.md`) with a real monorepo overview.

The new README covers:

- Published packages under `packages/` (`@sanity/ui`, `@sanity/icons`, `@sanity/color`, `@sanity/logos`, Figma plugins)
- Apps under `apps/` (Storybook, docs site, icon showcase, docs Blueprint)
- Node/pnpm requirements and getting started
- Common root scripts (`dev`, `build`, `test`, `lint`, etc.)
- Pointers to CONTRIBUTING.md and license

## Test plan

- [x] Confirm root `README.md` is a regular file (not a symlink)
- [x] Skim links to package/app paths and CONTRIBUTING.md
- [ ] Spot-check on GitHub that the rendered markdown looks correct
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5f995ff-f859-4908-a758-cb9e85e558ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5f995ff-f859-4908-a758-cb9e85e558ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

