### PR TITLE
fix(docs): disable segment-cache optimistic routing broken under basePath

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -17,6 +17,15 @@ const nextConfig: NextConfig = {
   transpilePackages: ['@sanity/color', '@sanity/icons', '@sanity/logos', '@sanity/ui'],
   reactCompiler: true,
   experimental: {
+    // The segment cache's optimistic route prediction (default-on in this
+    // canary) doesn't strip `basePath` when pattern-matching pathnames, so it
+    // predicts `{screen: 'ui'}` for e.g. /ui/docs/…. Every predicted
+    // navigation then mismatches the server's route tree, which triggers a
+    // soft-refresh retry, invalidates the whole route cache and re-prefetches
+    // every visible link — the prefetched content is never used and the
+    // `loading.tsx` boundary flashes on click. Disable it until the basePath
+    // handling is fixed upstream.
+    optimisticRouting: false,
     // Use the native Rust port of the React Compiler (runs directly on
     // Turbopack's swc AST) instead of the Babel transform
     turbopackRustReactCompiler: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #2457, resolving its "known remaining issue": even with all content prefetched, every sidebar navigation still issued a click-time dynamic request, which flashed the `loading.tsx` boundary under latency.

## Root cause (upstream Next.js bug)

The segment cache's **optimistic route prediction** (`experimental.optimisticRouting`, default-on in `next@16.3.0-preview.9`) pattern-matches pathnames **without stripping `basePath`**. For `/ui/docs/primitive/radio` it predicts `{screen: 'ui'}` while the server's route tree resolves `{screen: 'docs'}`.

Instrumented evidence chain (production build behind a logging proxy, temporary beacons in the Next client internals):

1. `writeDynamicDataIntoNavigationTask` fails to apply the server response to the navigation task: `server ["screen","docs","d",…]` vs `task ["screen","ui","d",…]` (`matchSegment` → false).
2. The `__PAGE__` task is left pending → `abortRemainingPendingTasks` → exit status 1 ("server response does not match the client").
3. `dispatchRetryDueToTreeMismatch` (soft refresh) → `invalidateRouteCacheEntries` → the whole route cache is evicted and **every visible link re-prefetches** after every navigation (observed: 131 runtime prefetch requests for 32 URLs in a two-click session).
4. With entries perpetually invalidated and re-fetching, navigation reads fall back to the always-partial shell entries → a full dynamic request per click → the `Loading…` flash under latency.

## Fix

Set `experimental.optimisticRouting: false` in `apps/docs/next.config.ts` (one line + comment). Prediction is compiled out; route trees come only from real prefetch responses.

Verified with the same instrumentation before removing it: **zero tree-mismatch retries, zero cache invalidations, zero partial cache reads, zero click-time dynamic requests** — sidebar navigations are served entirely from the prefetch cache. Even under 800 ms-per-request artificial latency there is no `Loading…` flash once prefetches have completed (a link whose background prefetch hasn't finished yet falls back to a single clean fetch, with no retry loop).

**After the fix, under 800 ms-per-request artificial latency** (contrast with the "before" video in #2457 where every click flashed `Loading…` for ~1 s):

[after_fix_sidebar_navigation_no_flash_800ms.mp4](https://cursor.com/agents/bc-3e815c2c-d43a-4133-82c2-78a971d64134/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_sidebar_navigation_no_flash_800ms.mp4)

The flag should be re-enabled once the basePath handling is fixed upstream — this is worth reporting to vercel/next.js with the evidence above.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e815c2c-d43a-4133-82c2-78a971d64134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e815c2c-d43a-4133-82c2-78a971d64134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

