### PR TITLE
feat: replace AnimatePresence with AnimateActivity

### DIFF
--- a/.changeset/animate-activity.md
+++ b/.changeset/animate-activity.md
@@ -2,4 +2,4 @@
 "@sanity/ui": minor
 ---
 
-Replace `AnimatePresence` with `AnimateActivity` (React `Activity` + exit animations) in Tooltip, Popover, and Toast.
+Replace `AnimatePresence` with `AnimateActivity` (React `Activity` + exit animations) in Tooltip and Popover.

--- a/.changeset/animate-activity.md
+++ b/.changeset/animate-activity.md
@@ -2,4 +2,4 @@
 "@sanity/ui": minor
 ---
 
-Replace `AnimatePresence` with `AnimateActivity` (React `Activity` + exit animations) in Tooltip and Popover.
+Tooltip and Popover now keep their content mounted with React's `<Activity>` when closed, preserving internal state and pre-rendering hidden content. When `animate` is enabled they use `AnimateActivity` (vendored from Motion), which defers hiding until exit animations complete. Popovers with recursive content must gate the recursion on `open` to avoid rendering an infinitely deep hidden tree.

--- a/.changeset/animate-activity.md
+++ b/.changeset/animate-activity.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": minor
+---
+
+Replace `AnimatePresence` with `AnimateActivity` (React `Activity` + exit animations) in Tooltip, Popover, and Toast.

--- a/apps/storybook/stories/components/MenuButton.stories.tsx
+++ b/apps/storybook/stories/components/MenuButton.stories.tsx
@@ -134,11 +134,16 @@ export const WithSelectedItem: Story = {
     await userEvent.click(button)
     await userEvent.click(button)
 
-    const menu = within(document.documentElement).queryByTestId('menu')
+    // Assertion: <Menu> with a selected item should not be visible when clicking the original
+    // <MenuButton> to close. The closed menu stays in the DOM inside a hidden <Activity>
+    // boundary, so assert visibility rather than absence.
+    await waitFor(async () => {
+      const menu = within(document.documentElement).queryByTestId('menu')
 
-    // Assertion: <Menu> with a selected item should not be visible when clicking the original <MenuButton> to close
-    // oxlint-disable-next-line no-floating-promises
-    expect(menu).toBeNull()
+      if (menu) {
+        await expect(menu).not.toBeVisible()
+      }
+    })
   },
 }
 

--- a/apps/storybook/stories/primitives/Popover.stories.tsx
+++ b/apps/storybook/stories/primitives/Popover.stories.tsx
@@ -334,7 +334,10 @@ function RecursiveExample({onClose}: {onClose?: () => void}) {
   return (
     <Popover
       fallbackPlacements={fallbackPlacements}
-      content={<RecursiveExample onClose={handleClose} />}
+      // Closed popovers keep their content mounted inside a hidden <Activity> boundary, so an
+      // unconditionally recursive `content` would render an infinitely deep hidden tree.
+      // Recursive structures must gate the recursion on `open`.
+      content={open ? <RecursiveExample onClose={handleClose} /> : null}
       open={open}
       padding={1}
       placement={fallbackPlacements[3]}

--- a/apps/storybook/stories/primitives/Tooltip.stories.tsx
+++ b/apps/storybook/stories/primitives/Tooltip.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from '@sanity/ui'
 import type {Meta, StoryFn, StoryObj} from '@storybook/react-vite'
 import {useCallback, useMemo, useState} from 'react'
-import {userEvent, within} from 'storybook/test'
+import {expect, userEvent, waitFor, within} from 'storybook/test'
 
 import {PLACEMENT_OPTIONS} from '../constants'
 import {getShadowControls, getSpaceControls} from '../controls'
@@ -102,7 +102,11 @@ export const WithOpenDelay: Story = {
     const button = canvas.getByText('Hover me')
 
     await userEvent.hover(button)
-    await canvas.findByText("I'm a tooltip")
+    // Animated tooltips are pre-rendered in the DOM inside a hidden <Activity>,
+    // so wait for the tooltip to become visible rather than just present.
+    await waitFor(() => {
+      expect(canvas.getByText("I'm a tooltip").checkVisibility()).toBe(true)
+    })
   },
 }
 
@@ -133,7 +137,12 @@ export const WithDelayGroup: Story = {
     const button = canvas.getAllByText('Hover me')[0]
 
     await userEvent.hover(button)
-    await canvas.findByText("I'm a tooltip")
+    // All animated tooltips are pre-rendered in the DOM inside hidden
+    // <Activity> boundaries, so wait for one of them to become visible.
+    await waitFor(() => {
+      const tooltips = canvas.getAllByText("I'm a tooltip")
+      expect(tooltips.some((element) => element.checkVisibility())).toBe(true)
+    })
   },
 }
 

--- a/apps/storybook/stories/primitives/Tooltip.stories.tsx
+++ b/apps/storybook/stories/primitives/Tooltip.stories.tsx
@@ -104,8 +104,8 @@ export const WithOpenDelay: Story = {
     await userEvent.hover(button)
     // Animated tooltips are pre-rendered in the DOM inside a hidden <Activity>,
     // so wait for the tooltip to become visible rather than just present.
-    await waitFor(() => {
-      expect(canvas.getByText("I'm a tooltip").checkVisibility()).toBe(true)
+    await waitFor(async () => {
+      await expect(canvas.getByText("I'm a tooltip").checkVisibility()).toBe(true)
     })
   },
 }
@@ -139,9 +139,9 @@ export const WithDelayGroup: Story = {
     await userEvent.hover(button)
     // All animated tooltips are pre-rendered in the DOM inside hidden
     // <Activity> boundaries, so wait for one of them to become visible.
-    await waitFor(() => {
+    await waitFor(async () => {
       const tooltips = canvas.getAllByText("I'm a tooltip")
-      expect(tooltips.some((element) => element.checkVisibility())).toBe(true)
+      await expect(tooltips.some((element) => element.checkVisibility())).toBe(true)
     })
   },
 }

--- a/packages/ui/src/core/components/menu/useMenuController.ts
+++ b/packages/ui/src/core/components/menu/useMenuController.ts
@@ -63,6 +63,13 @@ export function useMenuController(props: {
     [rootElementRef, setActiveIndex],
   )
 
+  // Reset the active item when the menu unmounts, or is hidden inside an <Activity> boundary
+  // (which unmounts effects while preserving state), so that reopening behaves like a fresh
+  // mount: `shouldFocus` applies again and `selected` items re-register through `mount`.
+  useEffect(() => {
+    return () => setActiveIndex(-1)
+  }, [setActiveIndex])
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       // Move focus to the element that opened the menu before handling the `Tab` press

--- a/packages/ui/src/core/components/toast/toastProvider.tsx
+++ b/packages/ui/src/core/components/toast/toastProvider.tsx
@@ -1,7 +1,7 @@
+import {AnimatePresence} from 'motion/react'
 import {startTransition, useMemo, useState} from 'react'
 
 import {useMounted} from '../../hooks/useMounted'
-import {AnimateActivity} from '../../utils/animateActivity'
 import {LayerProvider} from '../../utils/layer/layerProvider'
 import {Toast} from './toast'
 import {ToastContext} from './toastContext'
@@ -14,7 +14,6 @@ type ToastState = {
   id: string
   updatedAt: number
   params: ToastParams
-  mode: 'visible' | 'hidden'
 }[]
 
 /**
@@ -54,16 +53,10 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
            * Creates a function to dismiss this specific toast.
            * This function will be passed to the Toast component
            * and called either on close button click or after duration.
-           * Sets mode to "hidden" so AnimateActivity can play the exit animation
-           * before the toast is removed from state.
            */
           const dismiss = () =>
             startTransition(() =>
-              setState((currentState) =>
-                currentState.map((toast) =>
-                  toast.id === id ? {...toast, mode: 'hidden' as const} : toast,
-                ),
-              ),
+              setState((currentState) => currentState.filter((toast) => toast.id !== id)),
             )
 
           /**
@@ -79,7 +72,6 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
               id,
               updatedAt: Date.now(),
               params: {...params, duration},
-              mode: 'visible',
             },
           ]
         })
@@ -97,18 +89,10 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
       {mounted && (
         <LayerProvider zOffset={zOffset}>
           <ToastLayer padding={padding} paddingX={paddingX} paddingY={paddingY} gap={gap}>
-            {state.map(({dismiss, id, params, updatedAt, mode}) => (
-              <AnimateActivity
-                key={id}
-                layoutMode="pop"
-                mode={mode}
-                onExitComplete={() =>
-                  startTransition(() =>
-                    setState((currentState) => currentState.filter((toast) => toast.id !== id)),
-                  )
-                }
-              >
+            <AnimatePresence initial={false} mode="popLayout">
+              {state.map(({dismiss, id, params, updatedAt}) => (
                 <Toast
+                  key={id}
                   closable={params.closable}
                   description={params.description}
                   onClose={dismiss}
@@ -117,8 +101,8 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
                   duration={params.duration}
                   updatedAt={updatedAt}
                 />
-              </AnimateActivity>
-            ))}
+              ))}
+            </AnimatePresence>
           </ToastLayer>
         </LayerProvider>
       )}

--- a/packages/ui/src/core/components/toast/toastProvider.tsx
+++ b/packages/ui/src/core/components/toast/toastProvider.tsx
@@ -1,7 +1,7 @@
-import {AnimatePresence} from 'motion/react'
 import {startTransition, useMemo, useState} from 'react'
 
 import {useMounted} from '../../hooks/useMounted'
+import {AnimateActivity} from '../../utils/animateActivity'
 import {LayerProvider} from '../../utils/layer/layerProvider'
 import {Toast} from './toast'
 import {ToastContext} from './toastContext'
@@ -14,6 +14,7 @@ type ToastState = {
   id: string
   updatedAt: number
   params: ToastParams
+  mode: 'visible' | 'hidden'
 }[]
 
 /**
@@ -53,10 +54,16 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
            * Creates a function to dismiss this specific toast.
            * This function will be passed to the Toast component
            * and called either on close button click or after duration.
+           * Sets mode to "hidden" so AnimateActivity can play the exit animation
+           * before the toast is removed from state.
            */
           const dismiss = () =>
             startTransition(() =>
-              setState((currentState) => currentState.filter((toast) => toast.id !== id)),
+              setState((currentState) =>
+                currentState.map((toast) =>
+                  toast.id === id ? {...toast, mode: 'hidden' as const} : toast,
+                ),
+              ),
             )
 
           /**
@@ -72,6 +79,7 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
               id,
               updatedAt: Date.now(),
               params: {...params, duration},
+              mode: 'visible',
             },
           ]
         })
@@ -89,10 +97,18 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
       {mounted && (
         <LayerProvider zOffset={zOffset}>
           <ToastLayer padding={padding} paddingX={paddingX} paddingY={paddingY} gap={gap}>
-            <AnimatePresence initial={false} mode="popLayout">
-              {state.map(({dismiss, id, params, updatedAt}) => (
+            {state.map(({dismiss, id, params, updatedAt, mode}) => (
+              <AnimateActivity
+                key={id}
+                layoutMode="pop"
+                mode={mode}
+                onExitComplete={() =>
+                  startTransition(() =>
+                    setState((currentState) => currentState.filter((toast) => toast.id !== id)),
+                  )
+                }
+              >
                 <Toast
-                  key={id}
                   closable={params.closable}
                   description={params.description}
                   onClose={dismiss}
@@ -101,8 +117,8 @@ export function ToastProvider(props: ToastProviderProps): React.JSX.Element {
                   duration={params.duration}
                   updatedAt={updatedAt}
                 />
-              ))}
-            </AnimatePresence>
+              </AnimateActivity>
+            ))}
           </ToastLayer>
         </LayerProvider>
       )}

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -10,7 +10,6 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react-dom'
-import {AnimatePresence} from 'motion/react'
 import {
   cloneElement,
   forwardRef,
@@ -34,6 +33,7 @@ import {BoxOverflow} from '../../types/box'
 import {CardTone} from '../../types/card'
 import {Placement} from '../../types/placement'
 import {PopoverMargins} from '../../types/popover'
+import {AnimateActivity} from '../../utils/animateActivity'
 import {useBoundaryElement} from '../../utils/boundaryElement/useBoundaryElement'
 import {getElementRef} from '../../utils/getElementRef'
 import {LayerProps} from '../../utils/layer/layer'
@@ -359,18 +359,22 @@ export const Popover = forwardRef(function Popover(
     </LayerProvider>
   )
 
-  const children =
-    open &&
-    (portal ? (
-      <Portal __unstable_name={typeof portal === 'string' ? portal : undefined}>{popover}</Portal>
-    ) : (
-      popover
-    ))
+  const popoverNode = portal ? (
+    <Portal __unstable_name={typeof portal === 'string' ? portal : undefined}>{popover}</Portal>
+  ) : (
+    popover
+  )
 
   return (
     <>
       {/* the popover */}
-      {animate ? <AnimatePresence>{children}</AnimatePresence> : children}
+      {animate ? (
+        <AnimateActivity layoutMode="default" mode={open ? 'visible' : 'hidden'}>
+          {popoverNode}
+        </AnimateActivity>
+      ) : (
+        open && popoverNode
+      )}
 
       {/* the referred element */}
       {child}

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -11,6 +11,7 @@ import {
   useFloating,
 } from '@floating-ui/react-dom'
 import {
+  Activity,
   cloneElement,
   forwardRef,
   type Ref,
@@ -373,7 +374,7 @@ export const Popover = forwardRef(function Popover(
           {popoverNode}
         </AnimateActivity>
       ) : (
-        open && popoverNode
+        <Activity mode={open ? 'visible' : 'hidden'}>{popoverNode}</Activity>
       )}
 
       {/* the referred element */}

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -199,8 +199,6 @@ export const Popover = forwardRef(function Popover(
   const zOffset = _getArrayProp(zOffsetProp)
   const ref = useRef<HTMLDivElement | null>(null)
   const arrowRef = useRef<HTMLDivElement | null>(null)
-  /** Once opened with `animate`, keep the popover mounted under Activity for exit/re-entry. */
-  const hasBeenShownRef = useRef(false)
   const rootBoundary: RootBoundary = 'viewport'
 
   useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(forwardedRef, () => ref.current)
@@ -367,20 +365,16 @@ export const Popover = forwardRef(function Popover(
     popover
   )
 
-  if (open) {
-    hasBeenShownRef.current = true
-  }
-
   return (
     <>
       {/* the popover */}
-      {animate
-        ? hasBeenShownRef.current && (
-            <AnimateActivity layoutMode="default" mode={open ? 'visible' : 'hidden'}>
-              {popoverNode}
-            </AnimateActivity>
-          )
-        : open && popoverNode}
+      {animate ? (
+        <AnimateActivity layoutMode="default" mode={open ? 'visible' : 'hidden'}>
+          {popoverNode}
+        </AnimateActivity>
+      ) : (
+        open && popoverNode
+      )}
 
       {/* the referred element */}
       {child}

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -199,6 +199,8 @@ export const Popover = forwardRef(function Popover(
   const zOffset = _getArrayProp(zOffsetProp)
   const ref = useRef<HTMLDivElement | null>(null)
   const arrowRef = useRef<HTMLDivElement | null>(null)
+  /** Once opened with `animate`, keep the popover mounted under Activity for exit/re-entry. */
+  const hasBeenShownRef = useRef(false)
   const rootBoundary: RootBoundary = 'viewport'
 
   useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(forwardedRef, () => ref.current)
@@ -365,16 +367,20 @@ export const Popover = forwardRef(function Popover(
     popover
   )
 
+  if (open) {
+    hasBeenShownRef.current = true
+  }
+
   return (
     <>
       {/* the popover */}
-      {animate ? (
-        <AnimateActivity layoutMode="default" mode={open ? 'visible' : 'hidden'}>
-          {popoverNode}
-        </AnimateActivity>
-      ) : (
-        open && popoverNode
-      )}
+      {animate
+        ? hasBeenShownRef.current && (
+            <AnimateActivity layoutMode="default" mode={open ? 'visible' : 'hidden'}>
+              {popoverNode}
+            </AnimateActivity>
+          )
+        : open && popoverNode}
 
       {/* the referred element */}
       {child}

--- a/packages/ui/src/core/primitives/tooltip/tooltip.test.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltip.test.tsx
@@ -24,6 +24,23 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
+/**
+ * Closed tooltips are pre-rendered in the DOM inside a hidden `<Activity>` boundary (or not yet
+ * rendered at all, since hidden activities render at low priority), so "hidden" means either
+ * absent or present-but-invisible.
+ */
+function expectTooltipHidden(text: string) {
+  const element = screen.queryByText(text)
+
+  if (element) {
+    expect(element).not.toBeVisible()
+  }
+}
+
+function expectTooltipVisible(text: string) {
+  expect(screen.getByText(text)).toBeVisible()
+}
+
 describe('Tooltip', () => {
   describe('Using same delay for open and close', () => {
     it('should hide and show the tooltip content when hovered, with no delay', () => {
@@ -35,17 +52,17 @@ describe('Tooltip', () => {
 
       const button = screen.getByText('Hover me')
 
-      // Validate tooltip content is not rendered
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible
+      expectTooltipHidden('Tooltip content')
 
       fireEvent.mouseEnter(button)
 
-      // Validate tooltip content is rendered
-      screen.getByText('Tooltip content')
+      // Validate tooltip content is visible
+      expectTooltipVisible('Tooltip content')
 
       fireEvent.mouseOut(button)
-      // Validate tooltip content is not rendered anymore
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible anymore
+      expectTooltipHidden('Tooltip content')
     })
     it('should support delays to show and hide the tooltip.', () => {
       vi.useFakeTimers()
@@ -63,28 +80,28 @@ describe('Tooltip', () => {
 
       const button = screen.getByText('Hover me')
 
-      // Validate tooltip content is not rendered
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible
+      expectTooltipHidden('Tooltip content')
 
       fireEvent.mouseEnter(button)
 
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay / 2))
-      // Content should not be rendered yet
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Content should not be visible yet
+      expectTooltipHidden('Tooltip content')
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay / 2))
 
-      // Validate tooltip content is rendered
-      screen.getByText('Tooltip content')
+      // Validate tooltip content is visible
+      expectTooltipVisible('Tooltip content')
 
       fireEvent.mouseOut(button)
       // Validate tooltip content is still showing.
-      screen.getByText('Tooltip content')
+      expectTooltipVisible('Tooltip content')
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay))
-      // Validate tooltip content is not rendered anymore
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible anymore
+      expectTooltipHidden('Tooltip content')
     })
     it('should support different open and close delays to show and hide the tooltip.', () => {
       vi.useFakeTimers()
@@ -106,28 +123,28 @@ describe('Tooltip', () => {
 
       const button = screen.getByText('Hover me')
 
-      // Validate tooltip content is not rendered
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible
+      expectTooltipHidden('Tooltip content')
 
       fireEvent.mouseEnter(button)
 
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(openDelay / 2))
-      // Content should not be rendered yet
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Content should not be visible yet
+      expectTooltipHidden('Tooltip content')
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(openDelay / 2))
 
-      // Validate tooltip content is rendered
-      screen.getByText('Tooltip content')
+      // Validate tooltip content is visible
+      expectTooltipVisible('Tooltip content')
 
       fireEvent.mouseOut(button)
       // Validate tooltip content is still showing.
-      screen.getByText('Tooltip content')
+      expectTooltipVisible('Tooltip content')
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(closeDelay))
-      // Validate tooltip content is not rendered anymore
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible anymore
+      expectTooltipHidden('Tooltip content')
     })
   })
 
@@ -154,51 +171,51 @@ describe('Tooltip', () => {
       const button1 = screen.getByText('Button 1')
       const button2 = screen.getByText('Button 2')
 
-      // Validate tooltip content is not rendered
-      expect(screen.queryByText('Tooltip 1')).not.toBeInTheDocument()
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible
+      expectTooltipHidden('Tooltip 1')
+      expectTooltipHidden('Tooltip 2')
 
       // Hovers on first button, it should show first tooltip only
       fireEvent.mouseEnter(button1)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay / 2))
-      // Content should not be rendered yet, we have a delay of 150ms
-      expect(screen.queryByText('Tooltip 1')).not.toBeInTheDocument()
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      // Content should not be visible yet, we have a delay of 150ms
+      expectTooltipHidden('Tooltip 1')
+      expectTooltipHidden('Tooltip 2')
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay / 2))
 
-      // Validate Tooltip 1 is rendered
-      screen.getByText('Tooltip 1')
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      // Validate Tooltip 1 is visible
+      expectTooltipVisible('Tooltip 1')
+      expectTooltipHidden('Tooltip 2')
 
       // Hovers on second button.
       fireEvent.mouseOut(button1)
       fireEvent.mouseEnter(button2)
 
-      // Validate Tooltip 1 is not rendered, now tooltip 2 is open.
+      // Validate Tooltip 1 is not visible, now tooltip 2 is open.
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(1))
-      expect(screen.queryByText('Tooltip 1')).not.toBeInTheDocument()
-      screen.getByText('Tooltip 2')
+      expectTooltipHidden('Tooltip 1')
+      expectTooltipVisible('Tooltip 2')
 
-      // Validate tooltip content is not rendered anymore
+      // Validate tooltip content is not visible anymore
       fireEvent.mouseOut(button2)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay + 1))
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      expectTooltipHidden('Tooltip 2')
 
       // Hovering again, should trigger the tooltip to show immediately, as the group is not deactivated yet
       fireEvent.mouseEnter(button2)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(1))
-      screen.getByText('Tooltip 2')
+      expectTooltipVisible('Tooltip 2')
 
-      // Validate tooltip content is not rendered anymore
+      // Validate tooltip content is not visible anymore
       fireEvent.mouseOut(button2)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay + 1))
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      expectTooltipHidden('Tooltip 2')
 
       // Wait 200ms, the group is deactivated, hovering again should trigger the delay
       // oxlint-disable-next-line no-floating-promises
@@ -206,10 +223,10 @@ describe('Tooltip', () => {
       fireEvent.mouseEnter(button2)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay / 2))
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      expectTooltipHidden('Tooltip 2')
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay / 2))
-      screen.getByText('Tooltip 2')
+      expectTooltipVisible('Tooltip 2')
     })
     it('should support groups with different open and close delay.', () => {
       const openDelay = 250
@@ -239,51 +256,51 @@ describe('Tooltip', () => {
       const button1 = screen.getByText('Button 1')
       const button2 = screen.getByText('Button 2')
 
-      // Validate tooltip content is not rendered
-      expect(screen.queryByText('Tooltip 1')).not.toBeInTheDocument()
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible
+      expectTooltipHidden('Tooltip 1')
+      expectTooltipHidden('Tooltip 2')
 
       // Hovers on first button, it should show first tooltip only
       fireEvent.mouseEnter(button1)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(openDelay / 2))
-      // Content should not be rendered yet, we have a delay of2150ms
-      expect(screen.queryByText('Tooltip 1')).not.toBeInTheDocument()
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      // Content should not be visible yet, we have a delay of2150ms
+      expectTooltipHidden('Tooltip 1')
+      expectTooltipHidden('Tooltip 2')
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(openDelay / 2))
 
-      // Validate Tooltip 1 is rendered
-      screen.getByText('Tooltip 1')
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      // Validate Tooltip 1 is visible
+      expectTooltipVisible('Tooltip 1')
+      expectTooltipHidden('Tooltip 2')
 
       // Hovers on second button.
       fireEvent.mouseOut(button1)
       fireEvent.mouseEnter(button2)
 
-      // Validate Tooltip 1 is not rendered, now tooltip 2 is open.
+      // Validate Tooltip 1 is not visible, now tooltip 2 is open.
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(1))
-      expect(screen.queryByText('Tooltip 1')).not.toBeInTheDocument()
-      screen.getByText('Tooltip 2')
+      expectTooltipHidden('Tooltip 1')
+      expectTooltipVisible('Tooltip 2')
 
-      // Validate tooltip content is not rendered anymore
+      // Validate tooltip content is not visible anymore
       fireEvent.mouseOut(button2)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(closeDelay + 1))
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      expectTooltipHidden('Tooltip 2')
 
       // Hovering again, should trigger the tooltip to show immediately, as the group is not deactivated yet
       fireEvent.mouseEnter(button2)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(1))
-      screen.getByText('Tooltip 2')
+      expectTooltipVisible('Tooltip 2')
 
-      // Validate tooltip content is not rendered anymore
+      // Validate tooltip content is not visible anymore
       fireEvent.mouseOut(button2)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(closeDelay + 1))
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      expectTooltipHidden('Tooltip 2')
 
       // Wait 200ms, the group is deactivated, hovering again should trigger the delay
       // oxlint-disable-next-line no-floating-promises
@@ -291,10 +308,10 @@ describe('Tooltip', () => {
       fireEvent.mouseEnter(button2)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(openDelay / 2))
-      expect(screen.queryByText('Tooltip 2')).not.toBeInTheDocument()
+      expectTooltipHidden('Tooltip 2')
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(openDelay / 2))
-      screen.getByText('Tooltip 2')
+      expectTooltipVisible('Tooltip 2')
     })
   })
 
@@ -316,20 +333,20 @@ describe('Tooltip', () => {
 
       const button = screen.getByText('Hover me')
 
-      // Validate tooltip content is not rendered
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible
+      expectTooltipHidden('Tooltip content')
       fireEvent.focus(button)
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay))
 
-      // Validate tooltip content is rendered
-      screen.getByText('Tooltip content')
+      // Validate tooltip content is visible
+      expectTooltipVisible('Tooltip content')
 
       act(() => {
         fireEvent.keyDown(button, {key: 'Escape', code: 'Escape'})
       })
-      // Validate tooltip content is not rendered anymore
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible anymore
+      expectTooltipHidden('Tooltip content')
     })
     it('With <TooltipDelayGroupProvider />  closes immediately with Escape key', () => {
       const delay = 150
@@ -350,21 +367,21 @@ describe('Tooltip', () => {
 
       const button = screen.getByText('Hover me')
 
-      // Validate tooltip content is not rendered
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible
+      expectTooltipHidden('Tooltip content')
       fireEvent.focus(button)
 
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay))
 
-      // Validate tooltip content is rendered
-      screen.getByText('Tooltip content')
+      // Validate tooltip content is visible
+      expectTooltipVisible('Tooltip content')
 
       act(() => {
         fireEvent.keyDown(button, {key: 'Escape', code: 'Escape'})
       })
-      // Validate tooltip content is not rendered anymore
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Validate tooltip content is not visible anymore
+      expectTooltipHidden('Tooltip content')
     })
   })
 
@@ -380,21 +397,21 @@ describe('Tooltip', () => {
 
       const button = screen.getByText('Hover me')
 
-      // Assertion: tooltip does not exist in the document
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Assertion: tooltip is not visible
+      expectTooltipHidden('Tooltip content')
       fireEvent.focus(button)
 
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay))
 
-      // Assertion: the tooltip is not visible
-      expect(screen.queryByText('Tooltip content')).toBeVisible()
+      // Assertion: the tooltip is visible
+      expectTooltipVisible('Tooltip content')
 
       // oxlint-disable-next-line no-floating-promises
       act(() => fireEvent.click(button))
 
-      // Assertion: tooltip does not exist in the document
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Assertion: tooltip is not visible
+      expectTooltipHidden('Tooltip content')
     })
 
     it('Should close the tooltip when the context menu is opened (right click)', () => {
@@ -408,21 +425,21 @@ describe('Tooltip', () => {
 
       const button = screen.getByText('Hover me')
 
-      // Assertion: tooltip does not exist in the document
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Assertion: tooltip is not visible
+      expectTooltipHidden('Tooltip content')
       fireEvent.focus(button)
 
       // oxlint-disable-next-line no-floating-promises
       act(() => vi.advanceTimersByTime(delay))
 
-      // Assertion: the tooltip is not visible
-      expect(screen.queryByText('Tooltip content')).toBeVisible()
+      // Assertion: the tooltip is visible
+      expectTooltipVisible('Tooltip content')
 
       // oxlint-disable-next-line no-floating-promises
       act(() => fireEvent.contextMenu(button))
 
-      // Assertion: tooltip does not exist in the document
-      expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument()
+      // Assertion: tooltip is not visible
+      expectTooltipHidden('Tooltip content')
     })
   })
 

--- a/packages/ui/src/core/primitives/tooltip/tooltip.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltip.tsx
@@ -8,7 +8,6 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react-dom'
-import {AnimatePresence} from 'motion/react'
 import {
   cloneElement,
   forwardRef,
@@ -31,6 +30,7 @@ import {origin} from '../../middleware/origin'
 import {_getArrayProp} from '../../styles/helpers'
 import {useTheme_v2} from '../../theme/useTheme'
 import type {Placement} from '../../types/placement'
+import {AnimateActivity} from '../../utils/animateActivity'
 import {useBoundaryElement} from '../../utils/boundaryElement/useBoundaryElement'
 import {getElementRef} from '../../utils/getElementRef'
 import {Layer, type LayerProps} from '../../utils/layer/layer'
@@ -374,20 +374,24 @@ export const Tooltip = forwardRef(function Tooltip(
     </StyledTooltip>
   )
 
-  const children =
-    showTooltip &&
-    (portalProp ? (
-      <Portal __unstable_name={typeof portalProp === 'string' ? portalProp : undefined}>
-        {tooltip}
-      </Portal>
-    ) : (
-      tooltip
-    ))
+  const tooltipNode = portalProp ? (
+    <Portal __unstable_name={typeof portalProp === 'string' ? portalProp : undefined}>
+      {tooltip}
+    </Portal>
+  ) : (
+    tooltip
+  )
 
   return (
     <>
       {/* the tooltip */}
-      {animate ? <AnimatePresence>{children}</AnimatePresence> : children}
+      {animate ? (
+        <AnimateActivity layoutMode="default" mode={showTooltip ? 'visible' : 'hidden'}>
+          {tooltipNode}
+        </AnimateActivity>
+      ) : (
+        showTooltip && tooltipNode
+      )}
 
       {/* the referred element */}
       {child}

--- a/packages/ui/src/core/primitives/tooltip/tooltip.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltip.tsx
@@ -127,8 +127,6 @@ export const Tooltip = forwardRef(function Tooltip(
   const ref = useRef<HTMLDivElement | null>(null)
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
   const arrowRef = useRef<HTMLDivElement | null>(null)
-  /** Once opened with `animate`, keep the tooltip mounted under Activity for exit/re-entry. */
-  const hasBeenShownRef = useRef(false)
   const rootBoundary: RootBoundary = 'viewport'
   const [tooltipMaxWidth, setTooltipMaxWidth] = useState(0)
 
@@ -384,20 +382,16 @@ export const Tooltip = forwardRef(function Tooltip(
     tooltip
   )
 
-  if (showTooltip) {
-    hasBeenShownRef.current = true
-  }
-
   return (
     <>
       {/* the tooltip */}
-      {animate
-        ? hasBeenShownRef.current && (
-            <AnimateActivity layoutMode="default" mode={showTooltip ? 'visible' : 'hidden'}>
-              {tooltipNode}
-            </AnimateActivity>
-          )
-        : showTooltip && tooltipNode}
+      {animate ? (
+        <AnimateActivity layoutMode="default" mode={showTooltip ? 'visible' : 'hidden'}>
+          {tooltipNode}
+        </AnimateActivity>
+      ) : (
+        showTooltip && tooltipNode
+      )}
 
       {/* the referred element */}
       {child}

--- a/packages/ui/src/core/primitives/tooltip/tooltip.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltip.tsx
@@ -9,6 +9,7 @@ import {
   useFloating,
 } from '@floating-ui/react-dom'
 import {
+  Activity,
   cloneElement,
   forwardRef,
   useCallback,
@@ -390,7 +391,7 @@ export const Tooltip = forwardRef(function Tooltip(
           {tooltipNode}
         </AnimateActivity>
       ) : (
-        showTooltip && tooltipNode
+        <Activity mode={showTooltip ? 'visible' : 'hidden'}>{tooltipNode}</Activity>
       )}
 
       {/* the referred element */}

--- a/packages/ui/src/core/primitives/tooltip/tooltip.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltip.tsx
@@ -127,6 +127,8 @@ export const Tooltip = forwardRef(function Tooltip(
   const ref = useRef<HTMLDivElement | null>(null)
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
   const arrowRef = useRef<HTMLDivElement | null>(null)
+  /** Once opened with `animate`, keep the tooltip mounted under Activity for exit/re-entry. */
+  const hasBeenShownRef = useRef(false)
   const rootBoundary: RootBoundary = 'viewport'
   const [tooltipMaxWidth, setTooltipMaxWidth] = useState(0)
 
@@ -382,16 +384,20 @@ export const Tooltip = forwardRef(function Tooltip(
     tooltip
   )
 
+  if (showTooltip) {
+    hasBeenShownRef.current = true
+  }
+
   return (
     <>
       {/* the tooltip */}
-      {animate ? (
-        <AnimateActivity layoutMode="default" mode={showTooltip ? 'visible' : 'hidden'}>
-          {tooltipNode}
-        </AnimateActivity>
-      ) : (
-        showTooltip && tooltipNode
-      )}
+      {animate
+        ? hasBeenShownRef.current && (
+            <AnimateActivity layoutMode="default" mode={showTooltip ? 'visible' : 'hidden'}>
+              {tooltipNode}
+            </AnimateActivity>
+          )
+        : showTooltip && tooltipNode}
 
       {/* the referred element */}
       {child}

--- a/packages/ui/src/core/utils/animateActivity.tsx
+++ b/packages/ui/src/core/utils/animateActivity.tsx
@@ -1,0 +1,93 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2024 Motion One
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {invariant, PresenceChild} from 'motion/react'
+import {Activity, useState} from 'react'
+
+/**
+ * @internal
+ */
+export interface AnimateActivityProps {
+  mode: 'visible' | 'hidden'
+  layoutMode: 'default' | 'pop'
+  children: React.ReactNode
+  /** Called after exit animations finish and the activity is about to hide. */
+  onExitComplete?: () => void
+}
+
+/**
+ * Animated version of React's `Activity` that defers `mode="hidden"` until
+ * child exit animations have finished.
+ *
+ * @internal
+ */
+export function AnimateActivity({
+  mode: modeFromProps,
+  layoutMode,
+  children,
+  onExitComplete: onExitCompleteProp,
+}: AnimateActivityProps) {
+  /**
+   * This is the mode that we'll render.
+   */
+  const [mode, setMode] = useState(modeFromProps)
+
+  /**
+   * This is the goal state as defined by props.
+   */
+  const isPresent = modeFromProps === 'visible'
+
+  /**
+   * Immediately switch to mode="visible" when the user
+   * changes the mode prop.
+   */
+  if (isPresent && mode !== 'visible') {
+    setMode('visible')
+    return null
+  }
+
+  /**
+   * Set mode to "hidden" only when the exit animation is complete.
+   */
+  const onExitComplete = () => {
+    setMode('hidden')
+    onExitCompleteProp?.()
+  }
+
+  invariant(Boolean(Activity), 'Activity component not found - upgrade to React 19.2.0 or higher')
+
+  return (
+    <Activity mode={mode}>
+      <PresenceChild
+        isPresent={isPresent}
+        onExitComplete={!isPresent ? onExitComplete : undefined}
+        presenceAffectsLayout={false}
+        mode={layoutMode === 'pop' ? 'popLayout' : 'sync'}
+      >
+        {/* oxlint-disable-next-line no-unsafe-type-assertion -- PresenceChild expects a single ReactElement */}
+        {children as any}
+      </PresenceChild>
+    </Activity>
+  )
+}

--- a/packages/ui/src/core/utils/animateActivity.tsx
+++ b/packages/ui/src/core/utils/animateActivity.tsx
@@ -25,10 +25,7 @@
 import {invariant, PresenceChild} from 'motion/react'
 import {Activity, useState} from 'react'
 
-/**
- * @internal
- */
-export interface AnimateActivityProps {
+interface AnimateActivityProps {
   mode: 'visible' | 'hidden'
   layoutMode: 'default' | 'pop'
   children: React.ReactNode

--- a/packages/ui/src/core/utils/animateActivity.tsx
+++ b/packages/ui/src/core/utils/animateActivity.tsx
@@ -29,8 +29,6 @@ interface AnimateActivityProps {
   mode: 'visible' | 'hidden'
   layoutMode: 'default' | 'pop'
   children: React.ReactNode
-  /** Called after exit animations finish and the activity is about to hide. */
-  onExitComplete?: () => void
 }
 
 /**
@@ -39,12 +37,7 @@ interface AnimateActivityProps {
  *
  * @internal
  */
-export function AnimateActivity({
-  mode: modeFromProps,
-  layoutMode,
-  children,
-  onExitComplete: onExitCompleteProp,
-}: AnimateActivityProps) {
+export function AnimateActivity({mode: modeFromProps, layoutMode, children}: AnimateActivityProps) {
   /**
    * This is the mode that we'll render.
    */
@@ -67,10 +60,7 @@ export function AnimateActivity({
   /**
    * Set mode to "hidden" only when the exit animation is complete.
    */
-  const onExitComplete = () => {
-    setMode('hidden')
-    onExitCompleteProp?.()
-  }
+  const onExitComplete = () => setMode('hidden')
 
   invariant(Boolean(Activity), 'Activity component not found - upgrade to React 19.2.0 or higher')
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tooltip and Popover now keep their content mounted when closed, using React 19.2's `Activity`:

- With `animate`, they use `AnimateActivity` (vendored from Motion, MIT license header included), which wraps `Activity` with Motion's `PresenceChild` so exit animations finish before the content is hidden.
- Without `animate`, they wrap content in plain `<Activity>` — show/hide instead of mount/unmount, preserving internal state in both modes. Flipping `animate` off while open skips the exit animation, which is acceptable since `animate` is not toggled in practice.

Toast keeps `AnimatePresence` — toasts are mount/unmount list items pushed when already visible, so Activity has nothing to offer there.

## Changes

- Add internal `AnimateActivity` in `packages/ui/src/core/utils/animateActivity.tsx`
- Tooltip / Popover render `<AnimateActivity>` (animated) or `<Activity>` (non-animated) with `mode={open ? 'visible' : 'hidden'}`
- `useMenuController` resets the active item via effect cleanup — `Activity` unmounts effects on hide, so reopening a menu behaves like a fresh mount (`shouldFocus` and `selected` registration apply again)
- Tooltip unit tests and Tooltip/MenuButton stories assert visibility instead of DOM presence, since closed content is now pre-rendered hidden
- The `Recursive` popover story gates its recursive `content` on `open`: hidden activities pre-render, so unconditional recursion would render an infinitely deep hidden tree (this is the required pattern for recursive popover content)

## Notes

- React 19.2 peer requirement is handled in a separate PR; this changeset is `minor`
- Consumers relying on closed tooltip/popover content being absent from the DOM (e.g. tests querying by text) need visibility-based assertions instead

## Test plan

- [x] `@sanity/ui` unit tests (104)
- [x] Full storybook browser suite (245 tests, 61 files)
- [x] `pnpm lint` and `pnpm knip`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b90be5f-1bdb-44a3-afd9-308d677edeb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b90be5f-1bdb-44a3-afd9-308d677edeb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

