### PR TITLE
fix(ui): restore Popover max-width after boundaryElement migration

### DIFF
--- a/.changeset/ui-deprecated-tombstones.md
+++ b/.changeset/ui-deprecated-tombstones.md
@@ -12,7 +12,7 @@ Migrate:
 - Grid `columns`/`rows`/`column*`/`row*` → `gridTemplateColumns`/`gridTemplateRows`/`gridColumn*`/`gridRow*`
 - Menu `focusFirst`/`focusLast` → `shouldFocus`
 - MenuButton top-level popover props → `popover={{…}}`
-- Popover `boundaryElement` → `floatingBoundary` / `referenceBoundary`
+- Popover `boundaryElement` → `floatingBoundary` / `referenceBoundary` (and `BoundaryElementProvider` for max-width / `constrainSize`)
 - Tooltip `allowedAutoPlacements` → `fallbackPlacements`
 - `useClickOutside` → `useClickOutsideEvent`
 - `useElementRect` → `useElementSize`

--- a/apps/storybook/stories/primitives/Popover.stories.tsx
+++ b/apps/storybook/stories/primitives/Popover.stories.tsx
@@ -451,28 +451,28 @@ function AlignedStory() {
   return (
     <Card height="fill" padding={[4, 5, 6]} sizing="border" tone="transparent">
       <Card height="fill" padding={2} ref={setBoundaryElement} shadow={1} sizing="border">
-        <Flex align="flex-start" height="fill" justify="flex-end">
-          <Popover
-            floatingBoundary={boundaryElement}
-            referenceBoundary={boundaryElement}
-            content={content}
-            open={open}
-            overflow="auto"
-            padding={3}
-            portal
-            placement="bottom"
-            ref={popoverElementRef}
-            width="auto"
-          >
-            <Button
-              icon={EllipsisVerticalIcon}
-              mode="bleed"
-              onClick={handleToggleOpen}
-              ref={buttonElementRef}
-              selected={open}
-            />
-          </Popover>
-        </Flex>
+        <BoundaryElementProvider element={boundaryElement}>
+          <Flex align="flex-start" height="fill" justify="flex-end">
+            <Popover
+              content={content}
+              open={open}
+              overflow="auto"
+              padding={3}
+              portal
+              placement="bottom"
+              ref={popoverElementRef}
+              width="auto"
+            >
+              <Button
+                icon={EllipsisVerticalIcon}
+                mode="bleed"
+                onClick={handleToggleOpen}
+                ref={buttonElementRef}
+                selected={open}
+              />
+            </Popover>
+          </Flex>
+        </BoundaryElementProvider>
       </Card>
     </Card>
   )

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -181,11 +181,13 @@ export const Popover = forwardRef(function Popover(
     updateRef,
     ...restProps
   } = props
-  const boundaryElement = boundaryElementContext?.element
   const fallbackPlacements =
     _fallbackPlacements ?? DEFAULT_FALLBACK_PLACEMENTS[props.placement ?? 'bottom']
   const floatingBoundary = _floatingBoundary ?? boundaryElementContext.element
   const referenceBoundary = _referenceBoundary ?? boundaryElementContext.element
+  // Max-width uses BoundaryElementProvider when present; otherwise the floating
+  // boundary (same element the old `boundaryElement` prop used for both).
+  const boundaryElement = boundaryElementContext.element ?? floatingBoundary
   const zOffsetProp = _zOffsetProp ?? layer.popover.zOffset
   const prefersReducedMotion = usePrefersReducedMotion()
   const animate = prefersReducedMotion ? false : _animate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the Bugbot finding from https://github.com/sanity-io/ui/pull/2511#discussion_r3682123251 on `next` (where the same migration landed in #2509).

After tombstoning `Popover`’s `boundaryElement` prop, max-width (`boundaryWidth` for `constrainSize` / `preventOverflow`) only came from `BoundaryElementProvider`. Migrating call sites to `floatingBoundary` / `referenceBoundary` alone dropped that constraint, so the Aligned popover story (and any similar migration) could render wider than before.

### Changes
- **`Popover`**: measure max-width from `BoundaryElementProvider` when present, otherwise fall back to `floatingBoundary` (same element the old prop used for both positioning and size).
- **Aligned story**: wrap with `BoundaryElementProvider` so the card remains the sizing boundary (matches `BoundaryTest`).
- **Changeset**: note `BoundaryElementProvider` in the `boundaryElement` migration line.

### Verification
- oxlint on the touched files — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6205c840-fbdb-40cd-83b3-53d40890fc77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6205c840-fbdb-40cd-83b3-53d40890fc77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

