### PR TITLE
refactor(ui): use function declarations instead of named const expressions

### DIFF
--- a/apps/storybook/stories/components/MenuItem.stories.tsx
+++ b/apps/storybook/stories/components/MenuItem.stories.tsx
@@ -85,7 +85,7 @@ export const Custom: Story = {
   ),
 }
 
-const CustomLink = function CustomLink(
+function CustomLink(
   props: {req: string} & Omit<React.HTMLProps<HTMLAnchorElement>, 'as' | 'href'>,
 ): React.JSX.Element {
   const {children, req, ...restProps} = props

--- a/apps/storybook/stories/helpers/columnBuilder.tsx
+++ b/apps/storybook/stories/helpers/columnBuilder.tsx
@@ -9,7 +9,7 @@ interface ColumnBuilderProps<T> {
   scheme?: ThemeColorSchemeKey
 }
 
-export const columnBuilder = function <T>({
+export function columnBuilder<T>({
   gap = 3,
   renderItem,
   rows,

--- a/apps/storybook/stories/helpers/rowBuilder.tsx
+++ b/apps/storybook/stories/helpers/rowBuilder.tsx
@@ -9,12 +9,7 @@ interface RowBuilderProps<T> {
   scheme?: ThemeColorSchemeKey
 }
 
-export const rowBuilder = function <T>({
-  gap = 3,
-  renderItem,
-  rows,
-  scheme,
-}: RowBuilderProps<T>): ReactNode {
+export function rowBuilder<T>({gap = 3, renderItem, rows, scheme}: RowBuilderProps<T>): ReactNode {
   return (
     <Card border={!!scheme} padding={scheme ? 4 : 0} radius={scheme ? 2 : 0} scheme={scheme}>
       <Flex gap={gap} wrap="wrap">

--- a/apps/storybook/stories/primitives/Box.stories.tsx
+++ b/apps/storybook/stories/primitives/Box.stories.tsx
@@ -80,7 +80,7 @@ export const Responsive: Story = {
 // A custom component with its own props. When passed to `Box`'s `as` prop, these props are
 // inferred on `Box` itself: `href` is required and `target` is optional, and unknown props
 // are rejected by the type checker.
-const Link = function Link(
+function Link(
   props: {href: string; target?: string} & Omit<
     React.HTMLProps<HTMLAnchorElement>,
     'as' | 'href' | 'target'

--- a/apps/storybook/stories/primitives/Card.stories.tsx
+++ b/apps/storybook/stories/primitives/Card.stories.tsx
@@ -579,7 +579,7 @@ export const Checkered: Story = {
   ),
 }
 
-const CustomCardLink = function CustomCardLink(
+function CustomCardLink(
   props: {req: string} & Omit<React.HTMLProps<HTMLAnchorElement>, 'as' | 'href'>,
 ): React.JSX.Element {
   const {children, req, ...restProps} = props

--- a/packages/ui/src/core/components/autocomplete/autocomplete.tsx
+++ b/packages/ui/src/core/components/autocomplete/autocomplete.tsx
@@ -102,7 +102,7 @@ const DEFAULT_FILTER_OPTION = (query: string, option: BaseAutocompleteOption) =>
  *
  * @public
  */
-export const Autocomplete = function Autocomplete<Option extends BaseAutocompleteOption>(
+export function Autocomplete<Option extends BaseAutocompleteOption>(
   props: AutocompleteProps<Option> &
     Omit<
       HTMLProps<HTMLInputElement>,

--- a/packages/ui/src/core/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/ui/src/core/components/breadcrumbs/breadcrumbs.tsx
@@ -24,7 +24,7 @@ export interface BreadcrumbsProps {
 /**
  * @beta
  */
-export const Breadcrumbs = function Breadcrumbs(
+export function Breadcrumbs(
   props: BreadcrumbsProps & Omit<React.HTMLProps<HTMLOListElement>, 'as' | 'type'>,
 ) {
   const {children, gap = 2, maxLength, ref, separator, ...restProps} = props

--- a/packages/ui/src/core/components/dialog/dialog.tsx
+++ b/packages/ui/src/core/components/dialog/dialog.tsx
@@ -155,7 +155,7 @@ const DialogFooter = styled(Box)`
   z-index: 3;
 `
 
-const DialogCard = function DialogCard(props: DialogCardProps) {
+function DialogCard(props: DialogCardProps) {
   const {
     __unstable_autoFocus: autoFocus,
     __unstable_hideCloseButton: hideCloseButton,
@@ -288,7 +288,7 @@ const DialogCard = function DialogCard(props: DialogCardProps) {
  *
  * @public
  */
-export const Dialog = function Dialog(
+export function Dialog(
   props: DialogProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'id' | 'width'>,
 ) {
   const dialog = useDialog()

--- a/packages/ui/src/core/components/hotkeys/hotkeys.tsx
+++ b/packages/ui/src/core/components/hotkeys/hotkeys.tsx
@@ -40,9 +40,7 @@ const Key = styled(KBD)`
  *
  * @public
  */
-export const Hotkeys = function Hotkeys(
-  props: HotkeysProps & Omit<React.HTMLProps<HTMLElement>, 'as' | 'size'>,
-) {
+export function Hotkeys(props: HotkeysProps & Omit<React.HTMLProps<HTMLElement>, 'as' | 'size'>) {
   const {fontSize, gap = 0.5, keys, padding, radius, ref, ...restProps} = props
   const spacing = _getArrayProp(gap)
 

--- a/packages/ui/src/core/components/menu/menu.tsx
+++ b/packages/ui/src/core/components/menu/menu.tsx
@@ -48,7 +48,7 @@ const StyledMenu = styled(Box)`
  *
  * @public
  */
-export const Menu = function Menu(
+export function Menu(
   props: MenuProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'role' | 'tabIndex'>,
 ) {
   const {

--- a/packages/ui/src/core/components/menu/menuButton.tsx
+++ b/packages/ui/src/core/components/menu/menuButton.tsx
@@ -58,7 +58,7 @@ export interface MenuButtonProps {
  *
  * @public
  */
-export const MenuButton = function MenuButton(props: MenuButtonProps) {
+export function MenuButton(props: MenuButtonProps) {
   const {
     __unstable_disableRestoreFocusOnClose: disableRestoreFocusOnClose = false,
     button: buttonProp,

--- a/packages/ui/src/core/components/skeleton/skeleton.tsx
+++ b/packages/ui/src/core/components/skeleton/skeleton.tsx
@@ -25,9 +25,7 @@ export interface SkeletonProps extends ResponsiveRadiusProps, Omit<BoxOwnProps, 
  * This API might change. DO NOT USE IN PRODUCTION.
  * @beta
  */
-export const Skeleton = function Skeleton(
-  props: SkeletonProps & Omit<React.HTMLProps<HTMLDivElement>, 'height'>,
-) {
+export function Skeleton(props: SkeletonProps & Omit<React.HTMLProps<HTMLDivElement>, 'height'>) {
   const {animated = false, delay, radius, ref, ...restProps} = props
   // oxlint-disable-next-line no-unneeded-ternary
   const [visible, setVisible] = useState<boolean>(delay ? false : true)

--- a/packages/ui/src/core/components/skeleton/textSkeleton.tsx
+++ b/packages/ui/src/core/components/skeleton/textSkeleton.tsx
@@ -62,7 +62,7 @@ export interface CodeSkeletonProps extends SkeletonProps {
  * This API might change. DO NOT USE IN PRODUCTION.
  * @beta
  */
-export const TextSkeleton = function TextSkeleton(
+export function TextSkeleton(
   props: TextSkeletonProps &
     Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'height' | 'size'>,
 ) {
@@ -76,7 +76,7 @@ export const TextSkeleton = function TextSkeleton(
  * This API might change. DO NOT USE IN PRODUCTION.
  * @beta
  */
-export const LabelSkeleton = function LabelSkeleton(
+export function LabelSkeleton(
   props: LabelSkeletonProps &
     Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'height' | 'size'>,
 ) {
@@ -90,7 +90,7 @@ export const LabelSkeleton = function LabelSkeleton(
  * This API might change. DO NOT USE IN PRODUCTION.
  * @beta
  */
-export const HeadingSkeleton = function HeadingSkeleton(
+export function HeadingSkeleton(
   props: HeadingSkeletonProps &
     Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'height' | 'size'>,
 ) {
@@ -104,7 +104,7 @@ export const HeadingSkeleton = function HeadingSkeleton(
  * This API might change. DO NOT USE IN PRODUCTION.
  * @beta
  */
-export const CodeSkeleton = function CodeSkeleton(
+export function CodeSkeleton(
   props: CodeSkeletonProps &
     Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'height' | 'size'>,
 ) {

--- a/packages/ui/src/core/components/tab/tab.tsx
+++ b/packages/ui/src/core/components/tab/tab.tsx
@@ -30,7 +30,7 @@ const CustomButton = styled(Button)`
 /**
  * @public
  */
-export const Tab = function Tab(
+export function Tab(
   props: TabProps &
     Omit<
       React.HTMLProps<HTMLButtonElement>,

--- a/packages/ui/src/core/components/tab/tabList.tsx
+++ b/packages/ui/src/core/components/tab/tabList.tsx
@@ -23,7 +23,7 @@ const CustomInline = styled(Inline)`
 /**
  * @public
  */
-export const TabList = function TabList(
+export function TabList(
   props: TabListProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height'>,
 ) {
   const {children: childrenProp, ref, ...restProps} = props

--- a/packages/ui/src/core/components/tab/tabPanel.tsx
+++ b/packages/ui/src/core/components/tab/tabPanel.tsx
@@ -14,7 +14,7 @@ export interface TabPanelProps extends BoxOwnProps {
 /**
  * @public
  */
-export const TabPanel = function TabPanel(
+export function TabPanel(
   props: TabPanelProps &
     Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'aria-labelledby' | 'id' | 'role'>,
 ) {

--- a/packages/ui/src/core/components/tree/tree.tsx
+++ b/packages/ui/src/core/components/tree/tree.tsx
@@ -21,7 +21,7 @@ export interface TreeProps {
  * This API might change. DO NOT USE IN PRODUCTION.
  * @beta
  */
-export const Tree = function Tree(
+export function Tree(
   props: TreeProps &
     Omit<React.HTMLProps<HTMLUListElement>, 'align' | 'as' | 'height' | 'role' | 'wrap'>,
 ): React.JSX.Element {

--- a/packages/ui/src/core/primitives/avatar/avatarCounter.tsx
+++ b/packages/ui/src/core/primitives/avatar/avatarCounter.tsx
@@ -63,9 +63,7 @@ export interface AvatarCounterProps {
 /**
  * @public
  */
-export const AvatarCounter = function AvatarCounter(
-  props: AvatarCounterProps & {ref?: React.Ref<HTMLDivElement>},
-) {
+export function AvatarCounter(props: AvatarCounterProps & {ref?: React.Ref<HTMLDivElement>}) {
   const {count, ref, size: sizeProp = 1} = props
   const size = _getArrayProp(sizeProp)
 

--- a/packages/ui/src/core/primitives/avatar/avatarStack.tsx
+++ b/packages/ui/src/core/primitives/avatar/avatarStack.tsx
@@ -59,9 +59,7 @@ export interface AvatarStackProps {
 /**
  * @public
  */
-export const AvatarStack = function AvatarStack(
-  props: AvatarStackProps & Omit<React.HTMLProps<HTMLDivElement>, 'as'>,
-) {
+export function AvatarStack(props: AvatarStackProps & Omit<React.HTMLProps<HTMLDivElement>, 'as'>) {
   const {
     children: childrenProp,
     maxLength: maxLengthProp = 4,

--- a/packages/ui/src/core/primitives/checkbox/checkbox.tsx
+++ b/packages/ui/src/core/primitives/checkbox/checkbox.tsx
@@ -22,7 +22,7 @@ const Input = styled.input(inputElementStyles)
  *
  * @public
  */
-export const Checkbox = function Checkbox(
+export function Checkbox(
   props: Omit<React.HTMLProps<HTMLInputElement>, 'as' | 'type'> & CheckboxProps,
 ) {
   const {

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -141,7 +141,7 @@ const ViewportOverlay = () => {
  *
  * @public
  */
-export const Popover = function Popover(
+export function Popover(
   props: PopoverProps &
     Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content' | 'width'>,
 ): React.JSX.Element {

--- a/packages/ui/src/core/primitives/popover/popoverCard.tsx
+++ b/packages/ui/src/core/primitives/popover/popoverCard.tsx
@@ -38,7 +38,7 @@ const MotionFlex = styled(motion.create(Flex))`
 /**
  * @internal
  */
-export const PopoverCard = function PopoverCard(
+export function PopoverCard(
   props: {
     /** @beta*/
     __unstable_margins?: PopoverMargins

--- a/packages/ui/src/core/primitives/radio/radio.tsx
+++ b/packages/ui/src/core/primitives/radio/radio.tsx
@@ -19,9 +19,7 @@ const Input = styled.input(inputElementStyle)
  *
  * @public
  */
-export const Radio = function Radio(
-  props: Omit<React.HTMLProps<HTMLInputElement>, 'as' | 'type'> & RadioProps,
-) {
+export function Radio(props: Omit<React.HTMLProps<HTMLInputElement>, 'as' | 'type'> & RadioProps) {
   const {
     className,
     disabled,

--- a/packages/ui/src/core/primitives/select/select.tsx
+++ b/packages/ui/src/core/primitives/select/select.tsx
@@ -40,9 +40,7 @@ const IconBox = styled(Box)(selectStyle.iconBox)
  *
  * @public
  */
-export const Select = function Select(
-  props: SelectProps & Omit<React.HTMLProps<HTMLSelectElement>, 'as'>,
-) {
+export function Select(props: SelectProps & Omit<React.HTMLProps<HTMLSelectElement>, 'as'>) {
   const {
     children,
     customValidity,

--- a/packages/ui/src/core/primitives/spinner/spinner.tsx
+++ b/packages/ui/src/core/primitives/spinner/spinner.tsx
@@ -17,7 +17,7 @@ export interface SpinnerProps {
  *
  * @public
  */
-export const Spinner = function Spinner(
+export function Spinner(
   props: SpinnerProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'size'>,
 ) {
   return (

--- a/packages/ui/src/core/primitives/switch/switch.tsx
+++ b/packages/ui/src/core/primitives/switch/switch.tsx
@@ -29,7 +29,7 @@ const Thumb = styled.span<{$checked?: boolean; $indeterminate?: boolean}>(switch
  *
  * @public
  */
-export const Switch = function Switch(
+export function Switch(
   props: Omit<React.HTMLProps<HTMLInputElement>, 'as' | 'type'> & SwitchProps,
 ) {
   const {

--- a/packages/ui/src/core/primitives/textArea/textArea.tsx
+++ b/packages/ui/src/core/primitives/textArea/textArea.tsx
@@ -62,9 +62,7 @@ const Presentation = styled.div<ResponsiveRadiusStyleProps & TextInputRepresenta
 
  * @public
  */
-export const TextArea = function TextArea(
-  props: TextAreaProps & Omit<React.HTMLProps<HTMLTextAreaElement>, 'as'>,
-) {
+export function TextArea(props: TextAreaProps & Omit<React.HTMLProps<HTMLTextAreaElement>, 'as'>) {
   const {
     border = true,
     customValidity,

--- a/packages/ui/src/core/primitives/textInput/textInput.tsx
+++ b/packages/ui/src/core/primitives/textInput/textInput.tsx
@@ -160,7 +160,7 @@ const TextInputClearButton = styled(Button)({
  *
  * @public
  */
-export const TextInput = function TextInput(
+export function TextInput(
   props: TextInputProps & Omit<React.HTMLProps<HTMLInputElement>, 'as' | 'prefix' | 'type'>,
 ) {
   const {

--- a/packages/ui/src/core/primitives/tooltip/tooltip.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltip.tsx
@@ -98,7 +98,7 @@ const StyledTooltip = styled(Layer)`
  *
  * @public
  */
-export const Tooltip = function Tooltip(
+export function Tooltip(
   props: TooltipProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content'>,
 ) {
   const boundaryElementContext = useBoundaryElement()

--- a/packages/ui/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltipCard.tsx
@@ -21,7 +21,7 @@ const MotionCard = styled(motion.create(Card))`
 /**
  * @internal
  */
-export const TooltipCard = function TooltipCard(
+export function TooltipCard(
   props: {
     animate?: boolean
     arrow: boolean

--- a/packages/ui/src/core/utils/arrow/arrow.tsx
+++ b/packages/ui/src/core/utils/arrow/arrow.tsx
@@ -63,7 +63,7 @@ const ShapePath = styled.path`
 `
 
 /** @internal */
-export const Arrow = function Arrow(
+export function Arrow(
   props: {width: number; height: number; radius?: number} & Omit<
     HTMLProps<HTMLDivElement>,
     'width' | 'height'

--- a/packages/ui/src/core/utils/elementQuery/elementQuery.tsx
+++ b/packages/ui/src/core/utils/elementQuery/elementQuery.tsx
@@ -17,7 +17,7 @@ export interface MediaQueryProps {
  * DO NOT USE IN PRODUCTION.
  * @beta
  */
-export const ElementQuery = function ElementQuery(
+export function ElementQuery(
   props: MediaQueryProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'media'>,
 ) {
   const theme = useTheme_v2()

--- a/packages/ui/src/core/utils/layer/layer.tsx
+++ b/packages/ui/src/core/utils/layer/layer.tsx
@@ -23,9 +23,7 @@ interface LayerChildrenProps {
 
 const StyledLayer = styled.div({position: 'relative'})
 
-const LayerChildren = function LayerChildren(
-  props: LayerChildrenProps & Omit<React.HTMLProps<HTMLDivElement>, 'as'>,
-) {
+function LayerChildren(props: LayerChildrenProps & Omit<React.HTMLProps<HTMLDivElement>, 'as'>) {
   const {
     children,
     onActivate,
@@ -88,9 +86,7 @@ const LayerChildren = function LayerChildren(
 /**
  * @public
  */
-export const Layer = function Layer(
-  props: LayerProps & Omit<React.HTMLProps<HTMLDivElement>, 'as'>,
-) {
+export function Layer(props: LayerProps & Omit<React.HTMLProps<HTMLDivElement>, 'as'>) {
   const {children, zOffset = 1, ...restProps} = props
 
   return (

--- a/packages/ui/src/core/utils/srOnly/srOnly.tsx
+++ b/packages/ui/src/core/utils/srOnly/srOnly.tsx
@@ -11,7 +11,7 @@ export interface SrOnlyProps {
 /**
  * @public
  */
-export const SrOnly = function SrOnly(
+export function SrOnly(
   props: SrOnlyProps & Omit<React.HTMLProps<HTMLDivElement>, 'aria-hidden' | 'as'>,
 ) {
   const {as = 'div', children, ref} = props

--- a/packages/ui/src/core/utils/virtualList/virtualList.tsx
+++ b/packages/ui/src/core/utils/virtualList/virtualList.tsx
@@ -42,7 +42,7 @@ const ItemWrapper = styled.div`
 /**
  * @beta
  */
-export const VirtualList = function VirtualList(
+export function VirtualList(
   props: VirtualListProps &
     StackOwnProps &
     Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'onChange'>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace `export const Foo = function Foo(...)` with `export function Foo(...)` across `@sanity/ui` components and matching Storybook helpers.
- Also simplify same-name internal helpers (`DialogCard`, `LayerChildren`, story link stubs) the same way.
- Leave polymorphic `const XxxComponent = function Xxx` + `as unknown as` casts alone — those need a separate binding for the generic overload export while keeping the React display name.

## Test plan

- [x] `oxlint --type-aware` on `packages/ui/src/core` passes
- [x] `pnpm --filter @sanity/ui test` passes (105 tests)
- [x] CI lint/test jobs pass (build, knip, storybook-test, node@lts ubuntu/macos)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fec1c686-7743-42e5-bc7c-b8950eeaf632?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fec1c686-7743-42e5-bc7c-b8950eeaf632&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

