### PR TITLE
fix(ui): ship dist/styles.css unminified for diffable CSS output

### DIFF
--- a/.changeset/preserve-overflow-hidden-fallback.md
+++ b/.changeset/preserve-overflow-hidden-fallback.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Preserve the `overflow: hidden` fallback ahead of `overflow: clip` in `styles.css`. lightningcss collapses duplicate `overflow` declarations to the last value regardless of browser targets, so the stylesheet now ships exactly as authored (skipping the lightningcss minify/lowering pass) instead of dropping the fallback that browsers without `overflow: clip` support rely on.

--- a/.changeset/preserve-overflow-hidden-fallback.md
+++ b/.changeset/preserve-overflow-hidden-fallback.md
@@ -1,5 +1,0 @@
----
-"@sanity/ui": patch
----
-
-Preserve the `overflow: hidden` fallback ahead of `overflow: clip` in `styles.css`. lightningcss collapses duplicate `overflow` declarations to the last value regardless of browser targets, so the stylesheet now ships exactly as authored (skipping the lightningcss minify/lowering pass) instead of dropping the fallback that browsers without `overflow: clip` support rely on.

--- a/.changeset/unminified-styles-css.md
+++ b/.changeset/unminified-styles-css.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Ship `styles.css` unminified so the CSS output is easy to diff between published versions. It is still processed by lightningcss with the `@sanity/browserslist-config` lowering targets.

--- a/packages/ui/src/core/primitives/spinner/spinner.tsx
+++ b/packages/ui/src/core/primitives/spinner/spinner.tsx
@@ -1,6 +1,7 @@
 import {SpinnerIcon} from '@sanity/icons/Spinner'
 
 import {Text} from '../text/text'
+
 import {spinnerIcon} from './spinner.css'
 
 /**

--- a/packages/ui/tsdown.config.mts
+++ b/packages/ui/tsdown.config.mts
@@ -26,18 +26,15 @@ const config: UserConfig = await defineConfig({
   // same file name and consumer contract as the vanilla-extract based
   // successor of this library, to minimize churn when upgrading later.
   //
-  // `minify: false` + `target: false` skip the lightningcss pass entirely, so
-  // the stylesheet ships exactly as authored. That is what keeps the
-  // `overflow: hidden` fallback ahead of `overflow: clip` (needed by browsers
-  // in the support matrix without `overflow: clip`, e.g. iOS Safari 15): no
-  // browser target can preserve it, because lightningcss's OverflowHandler
-  // always collapses duplicate `overflow` declarations to the last value —
-  // unlike e.g. colors, it never consults compat data for the `clip` keyword —
-  // and setting any of `minify`, `target` or `lightningcss` runs that pass.
-  // Revisit when lightningcss learns to preserve keyword fallbacks, or when
-  // every supported browser understands `overflow: clip` and the `hidden`
-  // fallbacks can be deleted from the `.css.ts` sources instead.
-  vanillaExtract: {fileName: 'styles.css', inject: false, minify: false, target: false},
+  // `minify: false` keeps the output readable so CSS diffs between published
+  // versions are easy to eval. The lightningcss pass still runs with the
+  // lowering targets resolved from `@sanity/browserslist-config` (the
+  // `@sanity/tsdown-config` default when no `target` is set). Note that it
+  // collapses duplicate declarations to the last value regardless of targets
+  // (e.g. an authored `overflow: hidden` fallback before `overflow: clip`
+  // ships as just `overflow: clip` — fine, since `overflow: clip` is
+  // Baseline).
+  vanillaExtract: {fileName: 'styles.css', inject: false, minify: false},
 })
 
 export default config

--- a/packages/ui/tsdown.config.mts
+++ b/packages/ui/tsdown.config.mts
@@ -25,7 +25,19 @@ const config: UserConfig = await defineConfig({
   // the stylesheet to the consumer: `import '@sanity/ui/styles.css'` — the
   // same file name and consumer contract as the vanilla-extract based
   // successor of this library, to minimize churn when upgrading later.
-  vanillaExtract: {fileName: 'styles.css', inject: false},
+  //
+  // `minify: false` + `target: false` skip the lightningcss pass entirely, so
+  // the stylesheet ships exactly as authored. That is what keeps the
+  // `overflow: hidden` fallback ahead of `overflow: clip` (needed by browsers
+  // in the support matrix without `overflow: clip`, e.g. iOS Safari 15): no
+  // browser target can preserve it, because lightningcss's OverflowHandler
+  // always collapses duplicate `overflow` declarations to the last value —
+  // unlike e.g. colors, it never consults compat data for the `clip` keyword —
+  // and setting any of `minify`, `target` or `lightningcss` runs that pass.
+  // Revisit when lightningcss learns to preserve keyword fallbacks, or when
+  // every supported browser understands `overflow: clip` and the `hidden`
+  // fallbacks can be deleted from the `.css.ts` sources instead.
+  vanillaExtract: {fileName: 'styles.css', inject: false, minify: false, target: false},
 })
 
 export default config


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What

Sets `minify: false` on the `vanillaExtract` settings in `packages/ui/tsdown.config.mts`, so `dist/styles.css` ships pretty-printed and CSS output diffs easily between published versions of `@sanity/ui`. The lightningcss pass still runs with the lowering targets resolved from `@sanity/browserslist-config` (the `@sanity/tsdown-config` default when no `target` is set).

### Context

This started as an attempt to preserve the authored `overflow: hidden` fallback ahead of `overflow: clip` (from `overflow: ['hidden', 'clip']` in `spanWithTextOverflow.css.ts` and `srOnly.css.ts`), which the lightningcss pass strips from `dist/styles.css`. Browser targets can't preserve it: lightningcss's `OverflowHandler` unconditionally collapses duplicate `overflow` declarations to the last value regardless of `targets` — unlike e.g. colors, it never consults compat data for the `clip` keyword (verified against the [lightningcss source](https://github.com/parcel-bundler/lightningcss/blob/master/src/properties/overflow.rs) and empirically with `targets: {safari: 15 << 16}` and every other combination). Since `overflow: clip` is Baseline anyway, dropping the fallback is fine, and this PR only keeps the diffability half: minification off, lowering on. A config comment documents the collapse behavior.

Resulting `dist/styles.css`:

```css
.elmvdc0 {
  white-space: nowrap;
  text-overflow: ellipsis;
  display: block;
  overflow: clip;
}
...
```

Also includes a one-line pre-existing `oxfmt` drift fix in `spinner.tsx` (blank line between import groups) so `pnpm format` is clean, plus a patch changeset.

### Verification

- `pnpm --filter @sanity/ui build` → `dist/styles.css` is unminified with lowering applied; generated `package.json` exports unchanged; publint clean
- `pnpm lint` (includes type checking) passes
- `pnpm --filter @sanity/ui test` — 105 tests pass
- `pnpm knip` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8fae0c9-3c28-4525-9fb2-aef3b8d8bd70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8fae0c9-3c28-4525-9fb2-aef3b8d8bd70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

