### PR TITLE
fix(ui): emit types for styles css

### DIFF
--- a/.changeset/css-declaration.md
+++ b/.changeset/css-declaration.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Emit a declaration for `@sanity/ui/styles.css` so TypeScript can validate the side-effect import.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,7 +39,10 @@
     "./toast": "./src/exports/toast.ts",
     "./tooltip": "./src/exports/tooltip.ts",
     "./package.json": "./package.json",
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": {
+      "types": "./src/exports/styles.ts",
+      "default": "./dist/styles.css"
+    }
   },
   "publishConfig": {
     "exports": {
@@ -53,7 +56,10 @@
       "./toast": "./dist/toast.js",
       "./tooltip": "./dist/tooltip.js",
       "./package.json": "./package.json",
-      "./styles.css": "./dist/styles.css"
+      "./styles.css": {
+        "types": "./dist/styles.d.ts",
+        "default": "./dist/styles.css"
+      }
     }
   },
   "scripts": {

--- a/packages/ui/src/exports/styles.ts
+++ b/packages/ui/src/exports/styles.ts
@@ -1,0 +1,4 @@
+// Type-only entry point for `@sanity/ui/styles.css`.
+const styles: void = undefined
+
+export default styles

--- a/packages/ui/tsdown.config.mts
+++ b/packages/ui/tsdown.config.mts
@@ -18,7 +18,16 @@ const config: UserConfig = await defineConfig({
   },
   // `src/exports/styles.ts` emits the declaration for the CSS export, but its
   // JavaScript output is not a separate public `@sanity/ui/styles` entry point.
-  exports: {exclude: ['styles']},
+  exports: {
+    exclude: ['styles'],
+    customExports: (packageExports, {isPublish}) => ({
+      ...packageExports,
+      './styles.css': {
+        types: isPublish ? './dist/styles.d.ts' : './src/exports/styles.ts',
+        default: './dist/styles.css',
+      },
+    }),
+  },
   tsconfig: 'tsconfig.dist.json',
   styledComponents: true,
   reactCompiler: {target: '19'},

--- a/packages/ui/tsdown.config.mts
+++ b/packages/ui/tsdown.config.mts
@@ -16,6 +16,9 @@ const config: UserConfig = await defineConfig({
   entry: {
     '*': './src/exports/*.{ts,tsx}',
   },
+  // `src/exports/styles.ts` emits the declaration for the CSS export, but its
+  // JavaScript output is not a separate public `@sanity/ui/styles` entry point.
+  exports: {exclude: ['styles']},
   tsconfig: 'tsconfig.dist.json',
   styledComponents: true,
   reactCompiler: {target: '19'},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- emit a declaration entry for `@sanity/ui/styles.css`
- add development and published `types` conditions through tsdown’s generated exports
- keep the declaration entry’s JavaScript output private

## Testing

- `pnpm --filter @sanity/ui build` (emits `dist/styles.d.ts`; publint passes)
- `pnpm --filter @sanity/ui pack --pack-destination /tmp` (tarball includes `dist/styles.d.ts`)
- TypeScript 6.0.3 and 7.0.2 consumer checks with `noUncheckedSideEffectImports`
- `pnpm --filter @sanity/ui test` (47 files, 105 tests)
- `pnpm lint`
- `pnpm knip`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb8e5-0c52-7298-a316-07a7055f1e31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb8e5-0c52-7298-a316-07a7055f1e31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

