### PR TITLE
chore: configure v3 maintenance releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config/schema.json",
   "changelog": ["@changesets/changelog-github", {"repo": "sanity-io/ui"}],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "v3",
   "privatePackages": false,
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   # Build on pushes branches that have a PR (including drafts)
   pull_request:
-  # Build on commits pushed to the default branch
+  # Build on commits pushed to the release branch
   push:
-    branches: [main]
+    branches: [v3]
 
 permissions:
   contents: read # for checkout

--- a/.github/workflows/format-if-needed.yml
+++ b/.github/workflows/format-if-needed.yml
@@ -2,7 +2,7 @@ name: Auto format
 
 on:
   push:
-    branches: [main]
+    branches: [v3]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - main
+      - v3
   pull_request:
     types: [opened, synchronize, labeled]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - v3
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,3 +17,27 @@ jobs:
       contents: read # for checkout
       id-token: write # to enable use of OIDC for npm provenance
     secrets: inherit
+
+  keep-v3-releases-from-latest:
+    name: Keep v3 releases from becoming latest
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.ECOSPARK_CLIENT_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Mark releases from this commit as not latest
+        run: |
+          git tag --points-at "$GITHUB_SHA" | while IFS= read -r tag; do
+            if gh release view "$tag" >/dev/null 2>&1; then
+              gh release edit "$tag" --latest=false
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 ## Cursor Cloud specific instructions
 
-This is the `@sanity/ui` React component library, structured as a pnpm monorepo:
+This is the `v3` maintenance branch of the `@sanity/ui` React component
+library, structured as a pnpm monorepo:
 the published `@sanity/ui` package lives in `packages/ui`, the published
 `@sanity/icons` icon library in `packages/icons`, the published
 `@sanity/color` package (the Sanity color palette, migrated from the
@@ -103,9 +104,10 @@ Standard scripts live in the root `package.json` (`lint`, `test`, `build`,
   `pnpm --filter sanity-ui-storybook exec playwright install chromium`.
   Stories opt out of being tested with the `!test` tag.
 - Releases are managed with Changesets: run `pnpm changeset` to add a changeset
-  to a PR that should trigger a release. Merging to `main` opens/updates a
-  "Version Packages" PR, and merging that publishes to npm via trusted
-  publishing.
+  to a PR that should trigger a release. Merging to `v3` opens/updates a
+  "Version Packages" PR, and merging that publishes to npm under the
+  `release-v3` dist-tag (the `latest` dist-tag belongs to the `main`
+  branch).
 - `apps/docs` was migrated from the standalone `sanity-io/ui-docs` repo. It is
   linted by the root oxlint config like everything else (an override in
   `.oxlintrc.json` additionally enables the Next.js plugin rules for it) and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ docs site lives in [`apps/docs`](apps/docs), and the
 [icons.sanity.dev](https://icons.sanity.dev) icon showcase lives in
 [`apps/icons`](apps/icons).
 
+This is the `v3` maintenance branch: it receives bug fixes and dependency
+updates for the `3.x` release line, while new feature development happens on
+[`main`](https://github.com/sanity-io/ui/tree/main).
+
 ## Getting started
 
 ```sh
@@ -55,10 +59,11 @@ request:
 pnpm changeset
 ```
 
-Once pull requests with changesets are merged into `main`, a "Version Packages"
+Once pull requests with changesets are merged into `v3`, a "Version Packages"
 pull request is opened (and kept up to date) that bumps the affected package
 versions and updates their changelogs. Merging that pull request publishes the
 packages to npm through the
 [`Release` workflow](https://github.com/sanity-io/ui/actions/workflows/release.yml),
 which uses npm [Trusted Publishing](https://docs.npmjs.com/trusted-publishers)
-(OIDC).
+(OIDC). Releases from this branch are published under the `release-v3`
+dist-tag — the `latest` dist-tag tracks releases from `main`.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "pnpm run oxlint",
     "lint:fix": "pnpm lint --fix --fix-suggestions",
     "oxlint": "oxlint --disable-nested-config",
-    "release": "changeset publish",
+    "release": "changeset publish --tag release-v3",
     "storybook:build": "pnpm --filter sanity-ui-storybook build",
     "test": "pnpm --filter @sanity/color --filter @sanity/icons --filter @sanity/themer --filter @sanity/ui test",
     "test:browser": "pnpm --filter sanity-ui-storybook test",

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -9,7 +9,7 @@ npm install @sanity/ui
 npm install react react-dom styled-components
 ```
 
-[![npm version](https://img.shields.io/npm/v/@sanity/ui.svg?style=flat-square)](https://www.npmjs.com/package/@sanity/ui)
+[![npm version](https://img.shields.io/npm/v/%40sanity%2Fui/release-v3?style=flat-square)](https://www.npmjs.com/package/@sanity/ui/v/release-v3)
 
 ## Usage
 
@@ -38,7 +38,7 @@ When you make a change that should be released, add a changeset to your pull req
 pnpm changeset
 ```
 
-Once pull requests with changesets are merged into the `main` branch, a "Version Packages" pull request is opened (and kept up to date) that bumps the affected package versions and updates their changelogs. Merging that pull request publishes the packages to npm through the [`Release` workflow](https://github.com/sanity-io/ui/actions/workflows/release.yml), which uses npm [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC).
+Once pull requests with changesets are merged into the `v3` branch, a "Version Packages" pull request is opened (and kept up to date) that bumps the affected package versions and updates their changelogs. Merging that pull request publishes the packages to npm under the `release-v3` dist-tag through the [`Release` workflow](https://github.com/sanity-io/ui/actions/workflows/release.yml), which uses npm [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC). The `latest` dist-tag tracks releases from `main`.
 
 ## License
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Mirrors the `v2` maintenance-branch setup, [react-rx#472](https://github.com/sanity-io/react-rx/pull/472), and [get-it#649](https://github.com/sanity-io/get-it/pull/649) so that once `main` publishes UI 4, patches and minors from this branch do not replace v4 as either npm’s `latest` dist-tag or GitHub’s Latest release.

## Changes

- Root `release` script: `changeset publish --tag release-v3` (same naming as `release-v2`)
- Changesets `baseBranch`: `v3`
- CI / Release / pkg.pr.new / auto-format workflows trigger on `v3` instead of `main`
- After publishing, a dependent workflow job finds all release tags created at that commit and marks their GitHub releases with `--latest=false`
- Docs (`AGENTS.md`, `CONTRIBUTING.md`, `packages/ui/README.md`) describe the maintenance branch and dist-tag

The GitHub-release safeguard works for this monorepo’s multi-package releases: it checks every tag pointing at the publishing commit. On ordinary pushes there are no release tags at the commit, so the job safely does nothing.

Left alone on purpose (same as `v2`): docs Blueprint deploy, seed-icons, and Renovate still target `main` / run from the default branch. Renovate already includes `v3` in `baseBranchPatterns` on `main`.

## Follow-up

After merge, the first Version Packages publish from `v3` will create the `release-v3` dist-tag. Optionally point it at the current line ahead of that with e.g. `npm dist-tag add @sanity/ui@3.5.1 release-v3` (and the same for any other packages you want consumers to pin).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3de5ac2-2791-4202-a70c-51fe0ecd041f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3de5ac2-2791-4202-a70c-51fe0ecd041f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

