### PR TITLE
fix(ci): keep v2 releases from latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     secrets: inherit
 
   keep-v2-release-from-latest:
+    if: github.repository_owner == 'sanity-io'
     needs: release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,3 +17,28 @@ jobs:
       contents: read # for checkout
       id-token: write # to enable use of OIDC for npm provenance
     secrets: inherit
+
+  keep-v2-release-from-latest:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.ECOSPARK_CLIENT_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Keep v2 release from becoming latest
+        run: |
+          release_tag="@sanity/ui@$(node -p "require('./packages/ui/package.json').version")"
+          release_commit="$(git rev-list -n 1 "$release_tag" 2>/dev/null || true)"
+
+          if [[ "$release_commit" != "$GITHUB_SHA" ]]; then
+            exit 0
+          fi
+
+          gh release edit "$release_tag" --latest=false
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prevent v2 GitHub releases from replacing the current main-line release as the repository's latest release.

Because the shared Changesets workflow does not expose its `published` output, a dependent job checks whether the current `@sanity/ui@<version>` tag resolves to the triggering commit. When it does, the job marks that release with `--latest=false`; ordinary v2 pushes safely no-op. The follow-up job also retains the shared workflow's `sanity-io` owner guard so forks do not require release secrets.

This mirrors the existing npm strategy, where v2 publishes under the `release-v2` dist-tag.

Validation:
- `pnpm exec oxfmt --check .github/workflows/release.yml`
- `actionlint` (excluding its stale v3 app-token input metadata warnings)
- Shell guard simulation covering both ordinary and tagged release commits
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-927b9490-0bb8-4fbf-abc0-01ecd8c9e9b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-927b9490-0bb8-4fbf-abc0-01ecd8c9e9b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

