### PR TITLE
fix(themer): widen react and sanity peer dependency ranges

### DIFF
--- a/.changeset/widen-themer-peer-deps.md
+++ b/.changeset/widen-themer-peer-deps.md
@@ -2,4 +2,4 @@
 "@sanity/themer": minor
 ---
 
-Widen `@sanity/themer` peer dependencies. `react` now allows `^18 || >=19.0.0-0` (so consumers of only `@sanity/themer/legacy` don't hit peer dep errors on React 18), and `sanity` now allows `^3 || ^4 || ^5 || ^6` to support the migration path off the hosted themer.sanity.build service. These peer dep ranges do not indicate whether `themerTool` itself will work.
+Widen `@sanity/themer` peer dependencies. `react` now allows `^18 || >=19.0.0-0`, `sanity` allows `^3 || ^4 || ^5 || ^6`, and `styled-components` allows `^5.2 || ^6`. This avoids peer dependency errors for consumers using only `@sanity/themer/legacy` as a migration path off the hosted themer.sanity.build service. These peer dependency ranges do not indicate whether `themerTool` itself will work.

--- a/.changeset/widen-themer-peer-deps.md
+++ b/.changeset/widen-themer-peer-deps.md
@@ -2,4 +2,4 @@
 "@sanity/themer": minor
 ---
 
-Widen `@sanity/themer` peer dependencies. `react` now allows `^18 || >=19.0.0-0`, `sanity` allows `^3 || ^4 || ^5 || ^6`, and `styled-components` allows `^5.2 || ^6`. This avoids peer dependency errors for consumers using only `@sanity/themer/legacy` as a migration path off the hosted themer.sanity.build service. These peer dependency ranges do not indicate whether `themerTool` itself will work.
+Widen `@sanity/themer` peer dependencies. `react` now allows `^18 || ^19`, `sanity` allows `^3 || ^4 || ^5 || ^6`, and `styled-components` allows `^5.2 || ^6`. This avoids peer dependency errors for consumers using only `@sanity/themer/legacy` as a migration path off the hosted themer.sanity.build service. These peer dependency ranges do not indicate whether `themerTool` itself will work.

--- a/.changeset/widen-themer-peer-deps.md
+++ b/.changeset/widen-themer-peer-deps.md
@@ -1,0 +1,5 @@
+---
+"@sanity/themer": minor
+---
+
+Widen `@sanity/themer` peer dependencies. `react` now allows `^18 || >=19.0.0-0` (so consumers of only `@sanity/themer/legacy` don't hit peer dep errors on React 18), and `sanity` now allows `^3 || ^4 || ^5 || ^6` to support the migration path off the hosted themer.sanity.build service. These peer dep ranges do not indicate whether `themerTool` itself will work.

--- a/packages/themer/package.json
+++ b/packages/themer/package.json
@@ -72,7 +72,7 @@
   "peerDependencies": {
     "react": "^18 || >=19.0.0-0",
     "sanity": "^3 || ^4 || ^5 || ^6",
-    "styled-components": "^6"
+    "styled-components": "^5.2 || ^6"
   },
   "peerDependenciesMeta": {
     "sanity": {

--- a/packages/themer/package.json
+++ b/packages/themer/package.json
@@ -70,7 +70,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": "^18 || >=19.0.0-0",
+    "react": "^18 || ^19",
     "sanity": "^3 || ^4 || ^5 || ^6",
     "styled-components": "^5.2 || ^6"
   },

--- a/packages/themer/package.json
+++ b/packages/themer/package.json
@@ -70,8 +70,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": "^19",
-    "sanity": "^6",
+    "react": "^18 || >=19.0.0-0",
+    "sanity": "^3 || ^4 || ^5 || ^6",
     "styled-components": "^6"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Widens the peer dependencies of `@sanity/themer` so consumers that only use `@sanity/themer/legacy` don't run into peer dependency errors, and to support migration off the hosted themer.sanity.build service.

- `react`: `^19` → `^18 || ^19`
- `sanity`: `^6` → `^3 || ^4 || ^5 || ^6`
- `styled-components`: `^6` → `^5.2 || ^6`, matching the compatibility range declared by `@sanity/ui@^1`

`sanity` and `styled-components` remain optional peers. These ranges intentionally do not signal whether `themerTool` itself works on every version; they avoid spurious peer dependency errors for consumers using the `/legacy` migration path.

## Changeset

Includes a `minor` changeset for `@sanity/themer`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eea82af5-240b-4856-b64f-622ad30e2361?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eea82af5-240b-4856-b64f-622ad30e2361&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

