### PR TITLE
chore: v5 alpha automated release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "v5-alpha",
   "updateInternalDependencies": "patch",
   "ignore": [
     "ui-frameworks",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,16 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "depth-testing": "0.0.1-alpha.0",
+    "ui-frameworks": "1.0.0",
+    "ui-next": "0.1.0",
+    "ui-vite": "0.0.0",
+    "inp-testing": "0.0.1-alpha.2",
+    "mount-testing": "0.0.0",
+    "ui-storybook": "0.0.0",
+    "@sanity/ui": "5.0.0-alpha.1",
+    "@sanity/ui-codemod": "1.0.0-alpha.1"
+  },
+  "changesets": []
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,11 +2,11 @@
   "mode": "pre",
   "tag": "alpha",
   "initialVersions": {
-    "depth-testing": "0.0.1-alpha.0",
+    "depth-testing": "0.0.0",
     "ui-frameworks": "1.0.0",
     "ui-next": "0.1.0",
     "ui-vite": "0.0.0",
-    "inp-testing": "0.0.1-alpha.2",
+    "inp-testing": "0.0.0",
     "mount-testing": "0.0.0",
     "ui-storybook": "0.0.0",
     "@sanity/ui": "5.0.0-alpha.1",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,15 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  contents: read # for checkout
+  contents: read
 
 jobs:
   release:
     uses: sanity-io/.github/.github/workflows/changesets.yml@main
     permissions:
-      contents: read # for checkout
-      id-token: write # to enable use of OIDC for npm provenance
+      contents: read
+      id-token: write
     secrets: inherit
     with:
-      # Satisfy conventional-commit PR title checks used on this branch
       versionPrTitle: 'chore: version packages'
       versionCommitMessage: 'chore: version packages'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - v5-alpha
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  release:
+    uses: sanity-io/.github/.github/workflows/changesets.yml@main
+    permissions:
+      contents: read # for checkout
+      id-token: write # to enable use of OIDC for npm provenance
+    secrets: inherit
+    with:
+      # Satisfy conventional-commit PR title checks used on this branch
+      versionPrTitle: 'chore: version packages'
+      versionCommitMessage: 'chore: version packages'

--- a/apps/depth-testing/package.json
+++ b/apps/depth-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depth-testing",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/inp-testing/package.json
+++ b/apps/inp-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inp-testing",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
   "scripts": {
     "build": "turbo build --filter=./packages/*",
     "changeset": "changeset",
-    "changeset:publish": "changeset publish",
-    "changeset:status": "changeset status",
-    "changeset:version": "changeset version && pnpm --filter @sanity/ui sync-version",
     "create:ui": "node bin/create-ui.js",
     "dev": "turbo dev --ui=tui --filter=./packages/ui --filter=./apps/storybook",
     "format": "oxfmt . --no-error-on-unmatched-pattern",
@@ -20,7 +17,7 @@
     "lint:fix": "pnpm lint --fix",
     "perf": "turbo dev --ui=tui --filter=./apps/*-testing",
     "prepare": "husky",
-    "release": "pnpm run changeset:version && pnpm run build && pnpm run changeset:publish",
+    "release": "pnpm --filter @sanity/ui sync-version && pnpm run build && changeset publish",
     "test": "turbo test -- --run",
     "test:e2e": "turbo test:e2e --filter=./apps/frameworks",
     "ts:check": "turbo ts:check --filter=./packages/*"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,7 +61,7 @@
     }
   },
   "scripts": {
-    "build": "pnpm run clean && pnpm run build:css && pnpm run build:js && pnpm run build:cli",
+    "build": "pnpm run sync-version && pnpm run clean && pnpm run build:css && pnpm run build:js && pnpm run build:cli",
     "build:cli": "tsc -p tsconfig.cli.json",
     "build:css": "NODE_ENV=production postcss src/index.css -o dist/styles.css",
     "build:js": "pkg build --strict --check",


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds a release workflow that mimics the one on `main`. The only difference is that we aren't having Squiggler write changesets that get copied into the changelog. We might want to re-add that later but for now it seemed unnecessary.

The workflow should be:

1. A PR with a changeset is merged into `v5-alpha`
2. The release workflow runs and  Squiggler opens a PR to bump the version and update the changelog
3. When that PR merges, the release workflow runs again and publishes to NPM using our `release` command

In our current state, with an unpublished release but no changesets, it should skip straight to step 3 and publish @sanity/ui@5.0.0-alpha.1 (fingers crossed).
 
This PR also includes re-entering prerelease mode with changesets.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the updated `build` and `release` commands make sense. 

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b4126b1c71c031527b54ee3edc48722bdebd6147. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->