### PR TITLE
fix(deps): update dependency motion to ^13.0.0

### DIFF
--- a/.changeset/motion-13.md
+++ b/.changeset/motion-13.md
@@ -1,0 +1,14 @@
+---
+"@sanity/ui": patch
+---
+
+fix(deps): update dependency motion to ^13.0.0
+
+Motion 13 no longer loads the optional `@emotion/is-prop-valid` dependency to decide which props a
+`motion` component forwards to the DOM; it now only does so when an `isValidProp` function is passed
+to `MotionConfig`. `@sanity/ui` composes motion the way the upgrade guide recommends
+(`motion.create(StyledComponent)`, never `styled(motion.div)`), so its own components are unaffected:
+for custom components motion still forwards every non-motion prop and lets the styled component
+filter, exactly as before. Apps that wrap a DOM-level motion component in a CSS-in-JS factory —
+`styled(motion.div)` — may need to pass `isValidProp` to `MotionConfig`, use transient props, or
+reverse the composition.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -75,7 +75,7 @@
     "@sanity/color": "workspace:^",
     "@sanity/icons": "workspace:^",
     "csstype": "^3.2.3",
-    "motion": "^12.43.0",
+    "motion": "^13.0.0",
     "react-compiler-runtime": "1.0.0",
     "react-is": "catalog:",
     "react-refractor": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,8 +629,8 @@ importers:
         specifier: ^3.2.3
         version: 3.2.3
       motion:
-        specifier: ^12.43.0
-        version: 12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^13.0.0
+        version: 13.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-compiler-runtime:
         specifier: 1.0.0
         version: 1.0.0(react@19.2.8)
@@ -5753,6 +5753,17 @@ packages:
       react-dom:
         optional: true
 
+  framer-motion@13.0.0:
+    resolution: {integrity: sha512-nQGZXlsiigN48nzvE7AL1GLekql+etcphp8v+PQ0X04oxO20yVmV9rU9XQ25c136RdeIYoaWlKT9oAwvJza3mg==}
+    peerDependencies:
+      react: ^19.2.8
+      react-dom: ^19.2.8
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -6529,8 +6540,14 @@ packages:
   motion-dom@12.43.0:
     resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
 
+  motion-dom@13.0.0:
+    resolution: {integrity: sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==}
+
   motion-utils@12.39.0:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion-utils@13.0.0:
+    resolution: {integrity: sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==}
 
   motion@12.43.0:
     resolution: {integrity: sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==}
@@ -6541,6 +6558,17 @@ packages:
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  motion@13.0.0:
+    resolution: {integrity: sha512-RYZjEpgHUCKjBNqjmUQzW93VJWLvEZGTPdKRFSqOdOl07IIMvz+WrsZmD1XXAkoFLruW/8bO1L7UF+ViQTxtLg==}
+    peerDependencies:
+      react: ^19.2.8
+      react-dom: ^19.2.8
+    peerDependenciesMeta:
       react:
         optional: true
       react-dom:
@@ -13602,6 +13630,15 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  framer-motion@13.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      motion-dom: 13.0.0
+      motion-utils: 13.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -14346,7 +14383,13 @@ snapshots:
     dependencies:
       motion-utils: 12.39.0
 
+  motion-dom@13.0.0:
+    dependencies:
+      motion-utils: 13.0.0
+
   motion-utils@12.39.0: {}
+
+  motion-utils@13.0.0: {}
 
   motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -14354,6 +14397,14 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@emotion/is-prop-valid': 1.4.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  motion@13.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      framer-motion: 13.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      tslib: 2.8.1
+    optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,9 @@ allowBuilds:
 # age gate for versions we deliberately pick). tsdown and its lightningcss /
 # verkit / @tsdown/* / publint transitive deps are included for the same
 # reason when we deliberately bump the catalog to `latest`.
+# Version-pinned entries approve one specific release we deliberately picked
+# before it aged out of the gate; the lockfile is re-verified against these on
+# every install, so they have to stay until the version is a day old.
 minimumReleaseAgeExclude:
   - '@next/*'
   - '@portabletext/react'
@@ -61,6 +64,10 @@ minimumReleaseAgeExclude:
   - sanity
   - tsdown
   - verkit
+  - framer-motion@13.0.0
+  - motion-dom@13.0.0
+  - motion-utils@13.0.0
+  - motion@13.0.0
 
 # @testing-library/jest-dom/vitest imports `vitest` without declaring it, so it
 # falls back to pnpm's hidden hoist — which can resolve to another workspace


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Upgrades `@sanity/ui`'s `motion` dependency from `^12.43.0` to `^13.0.0`.

## The breaking change in Motion 13

Motion 13 has a single documented breaking change: it removes the optional `@emotion/is-prop-valid` dependency that `motion` components used to decide which props get forwarded to the DOM, in favour of explicit injection via `<MotionConfig isValidProp={...}>`.

Diffing the published `framer-motion` 12.43.0 and 13.0.0 bundles shows the entire change surface is five modules: `filter-props`, `use-render`, `motion/index` (threading `isValidProp` from `MotionConfig` context instead of a module-level global), `MotionConfig`, and one `AnimatePresence` fix for `propagate` with no `motion` children. `motion-utils` is byte-identical; `motion-dom` only changes SVG attribute handling (the changelog's hardware-accelerated SVG fix).

## Why it does not affect `@sanity/ui`

`filterProps` forwards a prop when any of its OR'd clauses passes, and one of them is `!isDom && !isValidMotionProp(key)`. Every motion component in this package wraps a custom component rather than a DOM string — `motion.create(Card)`, `motion.create(Flex)`, `motion.create(StyledToast)`, etc. — so `isDom` is always `false` and every non-motion prop is forwarded to the styled component, which does its own filtering, exactly as before. The `styled(motion.div)` pattern that the upgrade guide warns about does not appear anywhere in the repo.

Simulating both implementations over the exact prop sets `PopoverCard`, `TooltipCard` and `Toast` pass to motion confirms it: with `isDom=false` the only difference is that `style` is no longer copied into `filteredProps`, which is inert because `useHTMLProps` always sets `htmlProps.style` and the visual props are spread after the filtered props. All the real differences land on the `isDom=true` rows, which this package never hits.

Worth noting for context: in ESM builds the v12 `require("@emotion/is-prop-valid")` call already threw and fell back to the no-emotion path, so ESM consumers were effectively on the v13 behaviour already.

## Verification

A temporary jsdom test rendered `Popover` (open, animated, with arrow), `Tooltip` (open, animated) and `Toast` (closable, with duration bar) and dumped the resulting DOM. Snapshots taken before and after the upgrade are byte-identical, so no attribute, style or class output changed. The temporary test was removed before committing.

- `pnpm lint` (oxlint + type check) — passes
- `pnpm test` — 43 files / 130 tests pass in `@sanity/ui`, plus color, icons and themer
- `pnpm test:browser` — 61 story files / 245 tests pass in headless Chromium, covering the popover, tooltip and toast animations with their `play` interactions
- `pnpm build` — all packages build, publint clean
- `pnpm knip` — clean

Storybook running against motion 13, showing the animated tooltip, the popover placements story and stacking toasts:

[motion_13_tooltip_popover_toast_animations.mp4](https://cursor.com/agents/bc-ebffbe51-429f-4956-b46f-97e5bd351333/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmotion_13_tooltip_popover_toast_animations.mp4)

## `minimumReleaseAgeExclude`

`pnpm-workspace.yaml` gains version-pinned exclusions for `motion@13.0.0`, `framer-motion@13.0.0`, `motion-dom@13.0.0` and `motion-utils@13.0.0`, because 13.0.0 was published a few hours before this PR and falls inside the one-day release-age gate. pnpm re-verifies every lockfile entry against the active supply-chain policies on each install — including `--frozen-lockfile` — so without these the install aborts with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` and every CI job dies before it runs anything. They can come out once the release is more than a day old.

## One thing reviewers may want to weigh in on

`sanity` still declares `motion: ^12.43.0`, so apps that depend on both it and `@sanity/ui` will install two copies of motion until Studio bumps. Nothing crosses between them — `@sanity/ui` keeps its `AnimatePresence` trees entirely inside its own components — and the Storybook browser suite passes with both present, but it does mean extra bytes downstream in the meantime.

Consumers who wrap a DOM-level motion component in a CSS-in-JS factory (`styled(motion.div)`) may need to pass `isValidProp` to `MotionConfig`, switch to transient props, or reverse the composition; the changeset calls this out.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebffbe51-429f-4956-b46f-97e5bd351333?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebffbe51-429f-4956-b46f-97e5bd351333&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

