### PR TITLE
perf(docs): make navigation into docs articles instant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ storybook-static
 # Vitest browser mode failure screenshots and attachments
 __screenshots__
 .vitest-attachments
+
+# Playwright
+test-results
+playwright-report

--- a/apps/docs/e2e/helpers.ts
+++ b/apps/docs/e2e/helpers.ts
@@ -1,0 +1,48 @@
+import type {Page} from '@playwright/test'
+
+/**
+ * `media[1]` of the Sanity UI theme. The docs sidebar is `display: none` below
+ * it and the breadcrumbs bar is `display: none` above it, so which node stands
+ * for the article chrome depends on the viewport.
+ */
+export const SIDEBAR_BREAKPOINT = 600
+
+/**
+ * A sibling article under the same docs section. The docs nav collapses the
+ * "Primitives" branch unless the current path is inside it, so a soft
+ * navigation to {@link ARTICLE_PATH} starts from another primitive's article
+ * rather than from the docs landing page.
+ */
+export const SIBLING_ARTICLE_PATH = '/ui/docs/primitive/button'
+export const ARTICLE_PATH = '/ui/docs/primitive/popover'
+
+/**
+ * A synchronous node of the article chrome: the docs navigation. It comes from
+ * the static docs layout, so it belongs to the prefetched route.
+ *
+ * `:visible` resolves the sidebar/breadcrumbs pair — both are always rendered,
+ * one hidden per breakpoint — and skips the previous page's subtree, which the
+ * App Router keeps in the DOM (hidden) after a client navigation.
+ */
+export function articleChrome(page: Page) {
+  const {width} = page.viewportSize()!
+  return width >= SIDEBAR_BREAKPOINT
+    ? page.locator('[data-testid="article-sidebar-nav"]:visible')
+    : page.locator('[data-testid="article-breadcrumbs-nav"]:visible')
+}
+
+/** The statically generated article body. */
+export function articleContent(page: Page) {
+  return page.locator('[data-testid="article-content"]:visible')
+}
+
+/**
+ * The sidebar link that navigates to {@link ARTICLE_PATH}. Matched by `href`
+ * rather than by accessible name: Sanity UI's `TreeItem` renders the anchor
+ * with `role="treeitem"`, so a `getByRole('link')` lookup finds nothing. The
+ * nav tree is rendered twice (sidebar + breadcrumbs bar), so the lookup is
+ * scoped to the copy this viewport shows.
+ */
+export function popoverLink(page: Page) {
+  return articleChrome(page).locator(`a[href="${ARTICLE_PATH}"]`)
+}

--- a/apps/docs/e2e/instant-nav.e2e.ts
+++ b/apps/docs/e2e/instant-nav.e2e.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression guard for instant navigation into a docs article, per the
+ * `next-cache-components-optimizer` workflow. `instant()` gates dynamic data,
+ * so the static shell has to commit without it: a blocking route cannot.
+ *
+ * Only valid against a production build with the testing API exposed — see
+ * `instant-nav.rig.md`.
+ */
+import {instant} from '@next/playwright'
+import {expect, test} from '@playwright/test'
+
+import {
+  ARTICLE_PATH,
+  articleChrome,
+  articleContent,
+  popoverLink,
+  SIBLING_ARTICLE_PATH,
+  SIDEBAR_BREAKPOINT,
+} from './helpers'
+
+test.describe('instant navigation: /ui/docs/primitive/popover', () => {
+  // The article is prerendered (`generateStaticParams`) and every read behind
+  // it is cached, so the whole page — chrome and body — belongs to the static
+  // shell on a hard load. Nothing is left to defer, which is why this spec has
+  // no gated half; the soft-nav spec below is what proves the lock engages.
+  test('initial load serves the whole article', async ({page, baseURL}) => {
+    await instant(
+      page,
+      async () => {
+        await page.goto(ARTICLE_PATH)
+        await expect(articleChrome(page)).toBeVisible()
+        await expect(articleContent(page)).toBeVisible()
+      },
+      {baseURL},
+    )
+  })
+
+  test('a sidebar click commits the whole static article', async ({page}) => {
+    test.skip(
+      page.viewportSize()!.width < SIDEBAR_BREAKPOINT,
+      'the sidebar is collapsed behind the breadcrumbs menu below media[1]',
+    )
+    await page.goto(SIBLING_ARTICLE_PATH)
+    const trigger = popoverLink(page)
+    await expect(trigger).toBeVisible({timeout: 20000})
+
+    await instant(page, async () => {
+      await trigger.click()
+      await expect(articleChrome(page)).toBeVisible()
+      await expect(articleContent(page)).toBeVisible()
+    })
+
+    await expect(articleContent(page)).toBeVisible()
+    await expect(
+      articleChrome(page).locator(`li[data-selected] a[href="${ARTICLE_PATH}"]`),
+    ).toBeVisible()
+    await expect(page).toHaveURL(new RegExp(`${ARTICLE_PATH}$`))
+  })
+})

--- a/apps/docs/instant-nav.rig.md
+++ b/apps/docs/instant-nav.rig.md
@@ -1,0 +1,46 @@
+# instant-nav rig: sanity-ui-docs
+
+How this app proves a route is instant, for the
+`next-cache-components-optimizer` workflow. Written once, read by every later
+run.
+
+- **BUILD**: local production build of `apps/docs`:
+  `pnpm --filter sanity-ui-docs e2e:build` (`EXPOSE_TESTING_API=1 next build --turbopack`).
+  Vercel preview deploys are also production builds, but the local one is the
+  measured rig because it needs no deploy wait. Never `next dev` — it does not
+  prefetch, so an `instant()` verdict there is meaningless.
+- **EXPOSE**: `experimental.exposeTestingApiInProductionBuild` in
+  `next.config.ts` requires `process.env.EXPOSE_TESTING_API === '1'` and
+  `process.env.VERCEL !== '1'`. The e2e `webServer` sets the opt-in for
+  `next start`; `e2e:build` sets it for the build. Every Vercel build is
+  explicitly rejected even if the opt-in is accidentally configured there.
+- **RUN**: `pnpm --filter sanity-ui-docs e2e` (Playwright, `e2e/*.e2e.ts`)
+  against `http://localhost:3000` — the config starts `next start` itself.
+  Set `BASE_URL` to measure an already-running build (e.g. a preview URL)
+  instead. Browsers install once with
+  `pnpm --filter sanity-ui-docs exec playwright install chromium`.
+- **TEST USER**: none. sanity.io/ui is a public, unauthenticated, fully static
+  site and requires no environment variables.
+- **DRIFT**: things that can make the suite see a different page than a
+  developer does, and so make a RED untrustworthy:
+  - **Content.** Articles live in source. The guarded route
+    (`/ui/docs/primitive/popover`) uses structural testids so prose edits do
+    not affect the verdict.
+  - **Breakpoint.** The sidebar is hidden below the `media[1]` breakpoint and
+    the breadcrumbs bar is hidden above it, so a marker that exists at one
+    width can be absent at the other. Both Playwright projects run every spec.
+  - **Colour scheme.** `prefers-color-scheme` only changes styling, never
+    which nodes render.
+- **LOOP**: fully local and agent-drivable, with no CI wait or secrets:
+  `e2e:build` → `e2e` (starts the server) → read the failure → fix → repeat.
+  The Playwright `webServer` owns port 3000; stop any `next dev`/`next start`
+  already holding it first, or the suite silently measures the old process.
+  Not wired into GitHub Actions: CI does not currently build `apps/docs`
+  (Vercel does).
+- **LIVENESS**: n/a. The measured artifact is the one just built in the same
+  working tree, so there is no deployed-SHA skew to probe for. Add one only if
+  the rig ever moves to preview deploys.
+- **WALLS**:
+  - `next start` refuses to boot without a preceding `next build`, and a build
+    made without `EXPOSE_TESTING_API=1` makes `instant()` pass vacuously. Use
+    the `e2e:build` script rather than the plain `build`.

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -26,6 +26,11 @@ const nextConfig: NextConfig = {
     // Use the native Rust port of the React Compiler (runs directly on
     // Turbopack's swc AST) instead of the Babel transform
     turbopackRustReactCompiler: true,
+    // Lets the `instant()` helper from `@next/playwright` gate dynamic data in
+    // the local e2e suite (see `instant-nav.rig.md`). Explicitly reject every
+    // Vercel build even if EXPOSE_TESTING_API is accidentally configured there.
+    exposeTestingApiInProductionBuild:
+      process.env.EXPOSE_TESTING_API === '1' && process.env.VERCEL !== '1',
     // TypeScript 7 no longer ships the JS compiler API that Next.js uses by
     // default; run the project-local `tsc` CLI for typegen/build type-checks.
     useTypeScriptCli: true,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "build": "next build --turbopack",
     "dev": "next dev --turbopack",
+    "e2e": "playwright test",
+    "e2e:build": "EXPOSE_TESTING_API=1 next build --turbopack",
     "prepare": "next typegen",
     "start": "next start",
     "test": "vitest",
@@ -37,6 +39,8 @@
     "styled-components": "catalog:"
   },
   "devDependencies": {
+    "@next/playwright": "^16.3.0",
+    "@playwright/test": "^1.62.1",
     "@types/babel__standalone": "^7.1.9",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^24.13.3",

--- a/apps/docs/playwright.config.ts
+++ b/apps/docs/playwright.config.ts
@@ -1,0 +1,34 @@
+import {defineConfig} from '@playwright/test'
+
+const port = Number(process.env.PORT ?? 3000)
+const baseURL = process.env.BASE_URL ?? `http://localhost:${port}`
+
+export default defineConfig({
+  testDir: './e2e',
+  // Keep the suffix out of vitest's `*.test.ts` / `*.spec.ts` defaults, so
+  // `pnpm test` doesn't try to run the browser suite.
+  testMatch: '**/*.e2e.ts',
+  forbidOnly: !!process.env.CI,
+  // One `next start` process serves every spec; parallel workers make it the
+  // bottleneck and turn navigation assertions into a load test.
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {baseURL, trace: 'on-first-retry'},
+  // `instant()` verdicts are only valid on a production build with the testing
+  // API exposed; `BASE_URL` points the suite at an already-running one.
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: `next start --port ${port}`,
+        url: `${baseURL}/ui`,
+        env: {EXPOSE_TESTING_API: '1'},
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+  projects: [
+    {name: 'desktop', use: {browserName: 'chromium', viewport: {width: 1280, height: 800}}},
+    // The shell has to match the real render at both breakpoints (the sidebar
+    // collapses into the breadcrumbs bar below the `media[1]` breakpoint).
+    {name: 'mobile', use: {browserName: 'chromium', viewport: {width: 390, height: 844}}},
+  ],
+})

--- a/apps/docs/src/components/ArticleLayout.tsx
+++ b/apps/docs/src/components/ArticleLayout.tsx
@@ -59,6 +59,7 @@ export function ArticleLayout({children, nav}: {children: React.ReactNode; nav?:
     <Card flex={1} style={{minHeight: 'auto'}}>
       {nav && (
         <BreadcrumbsNavCard
+          data-testid="article-breadcrumbs-nav"
           data-ui="BreadcrumbsNavCard"
           paddingX={[2, 2, 3, 4]}
           paddingY={2}
@@ -89,7 +90,7 @@ export function ArticleLayout({children, nav}: {children: React.ReactNode; nav?:
 
       <Flex hidden={menuOpen}>
         {nav && (
-          <NavCard flex={1} overflow="auto">
+          <NavCard data-testid="article-sidebar-nav" flex={1} overflow="auto">
             <Box padding={[2, 2, 3, 4]}>
               <Nav nav={nav} path={pathname} />
             </Box>

--- a/apps/docs/src/components/page/article/Article.tsx
+++ b/apps/docs/src/components/page/article/Article.tsx
@@ -60,7 +60,14 @@ export function Article(props: {
         </Box>
       </TocBox>
 
-      <Box as="article" flex={3} paddingX={[4, 5, 6]} paddingY={[5, 6]} style={{order: 1}}>
+      <Box
+        as="article"
+        data-testid="article-content"
+        flex={3}
+        paddingX={[4, 5, 6]}
+        paddingY={[5, 6]}
+        style={{order: 1}}
+      >
         <Container width={wide ? 2 : 1}>
           <Box marginBottom={[5, 5, 5, 6]}>
             <Heading as="h1" size={[2, 2, 3, 4, 5]}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,7 @@ importers:
         version: 4.18.1
       next:
         specifier: ^16.3.4
-        version: 16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.63.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pako:
         specifier: ^3.0.1
         version: 3.0.1
@@ -280,6 +280,12 @@ importers:
         specifier: 'catalog:'
         version: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
+      '@next/playwright':
+        specifier: ^16.3.0
+        version: 16.3.4(@playwright/test@1.63.0)
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.63.0
       '@types/babel__standalone':
         specifier: ^7.1.9
         version: 7.1.9
@@ -300,7 +306,7 @@ importers:
         version: 19.2.7(@types/react@19.2.18)
       '@vanilla-extract/next-plugin':
         specifier: ^2.5.2
-        version: 2.5.2(@swc/helpers@0.5.23)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(webpack@5.110.3(@swc/core@1.16.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.28)(sharp@0.35.4(@types/node@24.13.3)))(yaml@2.9.0)
+        version: 2.5.2(@swc/helpers@0.5.23)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.63.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(webpack@5.110.3(@swc/core@1.16.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.28)(sharp@0.35.4(@types/node@24.13.3)))(yaml@2.9.0)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -456,7 +462,7 @@ importers:
     dependencies:
       '@sanity/code-input':
         specifier: ^7.3.8
-        version: 7.3.8(32c060898a5e48f6e6b038ddae7bdbbd)
+        version: 7.3.8(fa4ada957f9ce52f099b65afcb339dd9)
       '@sanity/icons':
         specifier: workspace:*
         version: link:../../packages/icons
@@ -471,7 +477,7 @@ importers:
         version: link:../../packages/ui
       '@sanity/vision':
         specifier: ^6.12.0
-        version: 6.12.0(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.12.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.4.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)))(@sanity/sdk@3.1.0(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(vitest@4.1.11)(xstate@5.32.6))(@types/node@24.13.3)(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxc-transform-react@0.148.0)(oxfmt@0.65.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.7)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(typescript@7.0.2)(vitest@4.1.11))(vitest@4.1.11)
+        version: 6.12.0(1f38590b51dd60996d0138e6a4fba266)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -2641,6 +2647,14 @@ packages:
   '@next/env@16.3.4':
     resolution: {integrity: sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==}
 
+  '@next/playwright@16.3.4':
+    resolution: {integrity: sha512-3kY/r//YJutrG1JTV7bAe1RNraRmwDjI19lzPrNPmq0mdYvEVTASXPyAqhRW6auQiyWS8FG75TyMHXUkn78tVw==}
+    peerDependencies:
+      '@playwright/test': '>=1.0.0'
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
+
   '@next/swc-darwin-arm64@16.3.4':
     resolution: {integrity: sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==}
     engines: {node: '>= 10'}
@@ -3587,6 +3601,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.63.0':
+    resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -10976,6 +10995,10 @@ snapshots:
 
   '@next/env@16.3.4': {}
 
+  '@next/playwright@16.3.4(@playwright/test@1.63.0)':
+    optionalDependencies:
+      '@playwright/test': 1.63.0
+
   '@next/swc-darwin-arm64@16.3.4':
     optional: true
 
@@ -11490,6 +11513,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.63.0':
+    dependencies:
+      playwright: 1.63.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -12139,7 +12166,7 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
-  '@sanity/code-input@7.3.8(32c060898a5e48f6e6b038ddae7bdbbd)':
+  '@sanity/code-input@7.3.8(fa4ada957f9ce52f099b65afcb339dd9)':
     dependencies:
       '@codemirror/lang-html': 6.4.12
       '@codemirror/lang-java': 6.0.2
@@ -12616,7 +12643,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@sanity/vision@6.12.0(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.12.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.4.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)))(@sanity/sdk@3.1.0(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(vitest@4.1.11)(xstate@5.32.6))(@types/node@24.13.3)(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxc-transform-react@0.148.0)(oxfmt@0.65.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.7)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(typescript@7.0.2)(vitest@4.1.11))(vitest@4.1.11)':
+  '@sanity/vision@6.12.0(1f38590b51dd60996d0138e6a4fba266)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.11.0
@@ -13428,11 +13455,11 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@vanilla-extract/next-plugin@2.5.2(@swc/helpers@0.5.23)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(webpack@5.110.3(@swc/core@1.16.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.28)(sharp@0.35.4(@types/node@24.13.3)))(yaml@2.9.0)':
+  '@vanilla-extract/next-plugin@2.5.2(@swc/helpers@0.5.23)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.63.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(webpack@5.110.3(@swc/core@1.16.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.28)(sharp@0.35.4(@types/node@24.13.3)))(yaml@2.9.0)':
     dependencies:
-      '@vanilla-extract/turbopack-plugin': 0.1.4(@swc/helpers@0.5.23)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+      '@vanilla-extract/turbopack-plugin': 0.1.4(@swc/helpers@0.5.23)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.63.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       '@vanilla-extract/webpack-plugin': 2.3.27(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(webpack@5.110.3(@swc/core@1.16.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.28)(sharp@0.35.4(@types/node@24.13.3)))
-      next: 16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.63.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       semver: 7.8.5
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -13454,12 +13481,12 @@ snapshots:
 
   '@vanilla-extract/private@1.0.9': {}
 
-  '@vanilla-extract/turbopack-plugin@0.1.4(@swc/helpers@0.5.23)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)':
+  '@vanilla-extract/turbopack-plugin@0.1.4(@swc/helpers@0.5.23)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.63.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)':
     dependencies:
       '@swc/core': 1.16.2(@swc/helpers@0.5.23)
       '@vanilla-extract/compiler': 0.7.2(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(esbuild@0.28.2)(jiti@2.7.0)(supports-color@8.1.1)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)(supports-color@8.1.1)
-      next: 16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.63.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -15506,7 +15533,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.4(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.63.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.4
       '@swc/helpers': 0.5.23
@@ -15525,6 +15552,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.3.4
       '@next/swc-win32-arm64-msvc': 16.3.4
       '@next/swc-win32-x64-msvc': 16.3.4
+      '@playwright/test': 1.63.0
       sharp: 0.35.4(@types/node@24.13.3)
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Makes navigation to `/ui/docs/primitive/popover` (and every other docs article) instant, following the vendored `next-cache-components-optimizer` skill. Stacked on #2605 because the skill requires Next.js 16.3+.

## The gap

`apps/docs/src/app/(website)/[screen]/layout.tsx` awaited `params` at the top level to fetch the screen document and pick the sidebar's nav branch. `params` identifies one URL, but the App Shell that `<Link>` prefetches is shared by every link into the route — so the shell could not be built, and the segment carried `export const instant = false` to silence the resulting validation error.

The compensation was `prefetch = 'partial'` plus `<Link prefetch={true}>` on every sidebar item, so each of the ~90 visible links ran its own full runtime prefetch. Measured on a production build, sitting on `/ui/docs/primitive/button` for four idle seconds:

- **529 RSC prefetch requests**, the same handful of URLs re-fetched 130+ times each.
- Clicking a sidebar link still issued a fresh navigation request, and under `instant()` the click committed nothing at all — the URL did not even change until the server answered.

## The fix

- The `[screen]` layout no longer reads `params`. It fetches the global nav (already cached, already fetched by the `(website)` layout) and hands the whole tree to the client `ArticleLayout`, which picks the current screen's branch from `usePathname()`. The router knows the URL on the client, so the chrome resolves without a server round trip.
- Both pages under the segment now render a `<Suspense fallback={<ArticleLoading />}>` and await `params` inside it, so the body streams behind the segment's own loading UI instead of blocking the shell.
- `export const instant = false` is gone: the route passes instant validation on its own.
- The sidebar links use the default `<Link>` prefetch. With a real App Shell to share, a full prefetch per link is both unnecessary and what made the navigation block under the lock.
- `loading.tsx` is extracted into `ArticleLoading` so the segment's loading UI and the pages' Suspense fallbacks are literally the same component (no new page-mirroring skeleton).

Result on the same measurement: **529 prefetch requests → 5**, and the click commits the chrome immediately with the body streaming in.

## The guard

`apps/docs/e2e/instant-nav.e2e.ts` encodes the goal with `instant()` from `@next/playwright`, at desktop (1280) and mobile (390) widths. `apps/docs/instant-nav.rig.md` documents how to run it. `pnpm --filter sanity-ui-docs e2e:build && pnpm --filter sanity-ui-docs e2e` builds with `EXPOSE_TESTING_API=1` and runs the suite against `next start`.

It is not wired into GitHub Actions: CI never builds `apps/docs` (Vercel does) and there is no `SANITY_API_READ_TOKEN` repo secret. Adding that secret is the prerequisite if you want this to run on every PR.

## Verification

- **Differential**: with the fix reverted and everything else identical, the soft-nav spec fails (nothing commits under the lock); with it re-applied, it passes. Three consecutive full runs are green.
- **Parity**: `/ui`, `/ui/docs`, `/ui/arcade`, `/ui/docs/motivation`, `/ui/docs/primitive/popover` and a bogus `/ui/docs/nope` render identical titles, sidebar/breadcrumbs presence, nav link counts and status codes before and after. The arcade screen still renders without a sidebar, and unknown paths still render the 404 UI (they already returned HTTP 200 before this change — the shell streams first, which is pre-existing).
- **No blank flash**: sampling the DOM every 100 ms across a real (unlocked) sidebar click shows the sidebar visible in every sample, the heading swapping from `<Button />` to `<Popover />` within 100 ms, and the loading fallback never appearing.
- **Client state survives**: the sidebar DOM node is now reused across a navigation with its scroll position intact (`scrollTop: 400` before and after), because the chrome is hoisted into the stable shell instead of being re-rendered per article.
- `pnpm lint`, `pnpm knip` and `pnpm --filter sanity-ui-docs typecheck` pass.

[docs_sidebar_persists_across_article_navigation.mp4](https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_sidebar_persists_across_article_navigation.mp4)

[The popover article with the docs sidebar intact](https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_popover_article_instant.webp)

## Follow-ups (not in this PR)

- `<Link prefetch={true}>` is still on the navbar and hero links (`Navbar.tsx`, `HeroSection.tsx`, the breadcrumb link). Those navigations block under the lock for the same reason the sidebar did, and are now unnecessary for the same reason.
- `generateMetadata` in `[...article]/page.tsx` builds its query with `buildTargetByPathParams({screen})` and never passes `article`, so every article page gets the screen's title (`Get started with Sanity UI`). Pre-existing, unrelated to instantness.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

