### PR TITLE
perf(docs): finish the Partial Prefetching adoption

### DIFF
--- a/apps/docs/src/app/(website)/layout.tsx
+++ b/apps/docs/src/app/(website)/layout.tsx
@@ -1,9 +1,9 @@
 import {Flex} from '@sanity/ui'
-import {PropsWithChildren} from 'react'
+import {PropsWithChildren, Suspense} from 'react'
 
 import {Banner, type BannerData} from '@/components/Banner'
 import {AppFooter} from '@/components/Footer'
-import {Navbar} from '@/components/Navbar'
+import {Navbar, NavbarWithActiveSegment} from '@/components/Navbar'
 
 import {navTree} from './navTree'
 
@@ -25,7 +25,9 @@ export default function WebsiteLayout(props: PropsWithChildren) {
   return (
     <Flex direction="column" height="fill">
       <Banner banner={banner} />
-      <Navbar nav={navTree} />
+      <Suspense fallback={<Navbar nav={navTree} />}>
+        <NavbarWithActiveSegment nav={navTree} />
+      </Suspense>
       {children}
       <AppFooter />
     </Flex>

--- a/apps/docs/src/components/ArticleLayout.tsx
+++ b/apps/docs/src/components/ArticleLayout.tsx
@@ -8,7 +8,7 @@ import {Breadcrumbs} from '@sanity/ui/breadcrumbs'
 import {getTheme_v2} from '@sanity/ui/theme'
 import Link from 'next/link'
 import {usePathname} from 'next/navigation'
-import {useState} from 'react'
+import {Suspense, useState} from 'react'
 import {styled} from 'styled-components'
 
 import type {NavNode} from '#lib/nav/types.ts'
@@ -51,55 +51,87 @@ const BreadcrumbsNavCard = styled(Card)((props) => {
 export function ArticleLayout({children, nav}: {children: React.ReactNode; nav?: NavNode}) {
   const [menuOpen, setMenuOpen] = useState(false)
 
-  // `usePathname` excludes the `/ui` basePath, matching the nav tree hrefs
-  const pathname = usePathname()
-  const path = pathname.split('/').filter(Boolean)
-
   return (
     <Card flex={1} style={{minHeight: 'auto'}}>
       {nav && (
-        <BreadcrumbsNavCard
-          data-testid="article-breadcrumbs-nav"
-          data-ui="BreadcrumbsNavCard"
-          paddingX={[2, 2, 3, 4]}
-          paddingY={2}
-          shadow={1}
-        >
-          <Flex align="center" gap={1}>
-            <Box flex={1} padding={3}>
-              <NavBreadcrumbs nav={nav} path={path} />
-            </Box>
-            <Box flex="none">
-              <Button
-                fontSize={1}
-                icon={menuOpen ? CloseIcon : MenuIcon}
-                mode="bleed"
-                onClick={() => setMenuOpen((o) => !o)}
-                padding={3}
-              />
-            </Box>
-          </Flex>
-
-          {menuOpen && (
-            <Box marginTop={2}>
-              <Nav nav={nav} path={pathname} />
-            </Box>
-          )}
-        </BreadcrumbsNavCard>
+        <Suspense>
+          <BreadcrumbsNav menuOpen={menuOpen} nav={nav} onToggleMenu={setMenuOpen} />
+        </Suspense>
       )}
 
-      <Flex hidden={menuOpen}>
+      <Flex height="fill" hidden={menuOpen}>
         {nav && (
-          <NavCard data-testid="article-sidebar-nav" flex={1} overflow="auto">
-            <Box padding={[2, 2, 3, 4]}>
-              <Nav nav={nav} path={pathname} />
-            </Box>
-          </NavCard>
+          <Suspense>
+            <SidebarNav nav={nav} />
+          </Suspense>
         )}
 
-        <Box flex={3}>{children}</Box>
+        <Box flex={3} height="fill" style={{display: 'flex', minHeight: 'auto'}}>
+          {children}
+        </Box>
       </Flex>
     </Card>
+  )
+}
+
+function useNavPath() {
+  // `usePathname` excludes the `/ui` basePath, matching the nav tree hrefs.
+  const pathname = usePathname()
+  return {path: pathname.split('/').filter(Boolean), pathname}
+}
+
+function SidebarNav({nav}: {nav: NavNode}) {
+  const {pathname} = useNavPath()
+
+  return (
+    <NavCard data-testid="article-sidebar-nav" flex={1} overflow="auto">
+      <Box padding={[2, 2, 3, 4]}>
+        <Nav nav={nav} path={pathname} />
+      </Box>
+    </NavCard>
+  )
+}
+
+function BreadcrumbsNav({
+  menuOpen,
+  nav,
+  onToggleMenu,
+}: {
+  menuOpen: boolean
+  nav: NavNode
+  onToggleMenu: (update: (open: boolean) => boolean) => void
+}) {
+  const {path, pathname} = useNavPath()
+
+  return (
+    <BreadcrumbsNavCard
+      data-testid="article-breadcrumbs-nav"
+      data-ui="BreadcrumbsNavCard"
+      paddingX={[2, 2, 3, 4]}
+      paddingY={2}
+      shadow={1}
+    >
+      <Flex align="center" gap={1}>
+        <Box flex={1} padding={3}>
+          <NavBreadcrumbs nav={nav} path={path} />
+        </Box>
+        <Box flex="none">
+          <Button
+            fontSize={1}
+            icon={menuOpen ? CloseIcon : MenuIcon}
+            mode="bleed"
+            onClick={() => onToggleMenu((open) => !open)}
+            padding={3}
+          />
+        </Box>
+      </Flex>
+
+      {menuOpen && (
+        <Box marginTop={2}>
+          <Nav nav={nav} path={pathname} />
+        </Box>
+      )}
+    </BreadcrumbsNavCard>
   )
 }
 

--- a/apps/docs/src/components/Navbar.tsx
+++ b/apps/docs/src/components/Navbar.tsx
@@ -9,23 +9,29 @@ import type {NavNode} from '#lib/nav/types.ts'
 
 import {GitHubMark} from './assets'
 
-export function Navbar({nav}: {nav: NavNode | null}): ReactElement {
+/**
+ * Which top-level entry is highlighted is URL data, so it cannot be part of
+ * the App Shell every link shares. Reading it in a wrapper keeps the shell
+ * with the whole navbar in it and lets only the highlight resolve per URL —
+ * synchronously on a client navigation, streamed on a page load.
+ */
+export function NavbarWithActiveSegment({nav}: {nav: NavNode | null}): ReactElement {
   // `usePathname` excludes the `/ui` basePath, matching the nav tree hrefs
-  const segment = usePathname().split('/').find(Boolean)
+  return <Navbar nav={nav} activeSegment={usePathname().split('/').find(Boolean)} />
+}
 
+export function Navbar({
+  nav,
+  activeSegment,
+}: {
+  nav: NavNode | null
+  activeSegment?: string
+}): ReactElement {
   return (
     <Card flex="none" padding={[2, 2, 3, 4]} style={{lineHeight: 0}}>
       <Flex gap={1}>
         <Box flex="none">
-          <Button
-            as={Link}
-            data-as="a"
-            href="/"
-            mode="bleed"
-            padding={3}
-            prefetch={true}
-            radius={2}
-          >
+          <Button as={Link} data-as="a" href="/" mode="bleed" padding={3} radius={2}>
             <Flex align="center" gap={[3, 3, 4]}>
               <Box flex="none">
                 <Text size={[1, 1, 2]}>
@@ -64,7 +70,7 @@ export function Navbar({nav}: {nav: NavNode | null}): ReactElement {
                   padding={3}
                   prefetch={true}
                   radius={2}
-                  selected={node.segment === segment}
+                  selected={node.segment === activeSegment}
                   style={{opacity: node.hidden ? 0.25 : undefined}}
                   text={node.title}
                 />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completes the Partial Prefetching adoption for `apps/docs`, following the vendored `next-partial-prefetching-adoption` skill. Stacked on #2615.

The flag work was already done — `cacheComponents: true` and `partialPrefetching: true` are both set — so this is the sweep the skill prescribes once a project is adopted: walk every route in `next dev`, resolve the shell insights it reports, and clean up the leftovers from the pre-adoption model.

## What the sweep found

Driving every route and every cross-section navigation (`/ui` → `/ui/docs` → an article → a sibling article → `/ui/arcade` → back, plus `/ui/arcade/frame` and a 404), the dev server reported one insight, **6 times across 2 components**:

```
Error: Route "/[screen]": Next.js encountered URL data `usePathname()`
in a Client Component outside of `<Suspense>`.
  at Navbar (…)          ← pre-existing
  at ArticleLayout (…)   ← from #2615
```

Both read the pathname at the top of the component, which keeps the whole component out of the App Shell that every link shares.

## What changed

- **`Navbar`** is split: the presentational navbar takes `activeSegment` as a prop, and a thin `NavbarWithActiveSegment` wrapper reads `usePathname()`. The `(website)` layout renders the wrapper inside `<Suspense fallback={<Navbar nav={nav} />}>` — the fallback is the real navbar without the highlight, not a skeleton, so the shell carries the whole navbar and only the active-tab highlight resolves per URL.
- **`ArticleLayout`** pushes the pathname read down into the two regions that need it (`SidebarNav` and `BreadcrumbsNav`), each behind its own boundary. The frame and `children` stay outside, so the page never remounts when the nav resolves.
- **`export const prefetch = 'partial'`** is removed from the `[screen]` layout by the first-party `remove-partial-prefetch` codemod: the global flag already covers it.
- **The home link in the navbar** drops `prefetch={true}`. `/` reads no URL data and is fully cached, so the default link already prefetches the whole page.
- **The two URL-data routes** carry a `TODO(runtime-prefetch)` marker naming the links that still ask for a full prefetch, so the decision is explicit rather than implied (see below).

After the fix the same sweep reports **0 insights**.

## Verification

- `pnpm lint`, `pnpm knip`, `pnpm --filter sanity-ui-docs typecheck` and `next build` all pass.
- The `instant()` guard from #2615 still passes on a production build, including its assertion that the article chrome is visible under the lock.
- Cross-section navigations commit the shared chrome under the lock: `/ui` → an article commits the sidebar, and `/ui/arcade` → `/ui/docs` keeps the navbar committed.
- The hover-triggered `router.prefetch('/arcade')` in `CodeExample` still warms `/ui/arcade`.
- Parity: identical titles, sidebar/breadcrumbs presence, nav link counts and status codes across `/ui`, `/ui/docs`, `/ui/arcade`, two articles and a bogus path; the navbar still highlights the right entry on every screen.

**Worth being precise about the benefit**: every behavioural check passes identically with and without these changes. On a client navigation the router already knows the URL, so the client render resolved the pathname synchronously either way. What changes is the server-prerendered shared shell, which no longer excludes the navbar and nav — so the chrome no longer depends on a route being prerendered per path to look complete.

[shared_app_shell_navigation.mp4](https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshared_app_shell_navigation.mp4)

## The one decision left for you

Five links still ask for a full prefetch: the navbar's `Docs`/`Arcade` and the home page's three hero links into `/ui/docs/motivation`. Their destinations read URL data, so a full prefetch there is a runtime prefetch — it resolves the article ahead of the click at the cost of a server render per link. With five links that's cheap, so I left them and marked the routes rather than deciding for you. If you'd rather they used the shared shell like the ~90 sidebar links now do, dropping the prop is a one-line change per link.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

