### PR TITLE
fix: handle display array in box codemod

### DIFF
--- a/packages/ui-codemod/src/transforms/latest/box/box.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/box/box.test.ts
@@ -182,6 +182,18 @@ defineInlineTest(
   transform,
   {},
   `
+  <Box display={['none', 'flex']} />
+  `,
+  `
+  <Flex display={['none', 'flex']} />
+  `,
+  'replaces Box with Flex when display is an array with flex',
+)
+
+defineInlineTest(
+  transform,
+  {},
+  `
   import {Box} from '@sanity/ui'
 
   function Example() {

--- a/packages/ui-codemod/src/transforms/latest/box/box.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/box/box.test.ts
@@ -182,10 +182,10 @@ defineInlineTest(
   transform,
   {},
   `
-  <Box display={['none', 'flex']} />
+  <Box display={['none', undefined, null, 'flex']} />
   `,
   `
-  <Flex display={['none', 'flex']} />
+  <Flex display={['none', undefined, null, 'flex']} />
   `,
   'replaces Box with Flex when display is an array with flex',
 )

--- a/packages/ui-codemod/src/transforms/latest/box/box.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/box/box.test.ts
@@ -194,6 +194,26 @@ defineInlineTest(
   transform,
   {},
   `
+  <>
+    <Box display={['block', undefined, null, 'flex']} />
+    {/* This forces a change to avoid the transform return null */}
+    <Box display="flex" />
+  </>
+  `,
+  `
+  <>
+    <Box display={['block', undefined, null, 'flex']} />
+    {/* This forces a change to avoid the transform return null */}
+    <Flex display="flex" />
+  </>
+  `,
+  'does not replace Box with Flex when display is a mixed array',
+)
+
+defineInlineTest(
+  transform,
+  {},
+  `
   import {Box} from '@sanity/ui'
 
   function Example() {

--- a/packages/ui-codemod/src/transforms/latest/box/box.ts
+++ b/packages/ui-codemod/src/transforms/latest/box/box.ts
@@ -35,15 +35,17 @@ export default function transform(
       return
     }
 
-    const replaceWithFlex = (attrs: (JSXAttribute | JSXSpreadAttribute)[]) => {
-      const display = getStaticAttributeExpression(j, attrs, 'display')
-      return display === 'flex' || display == 'inline-flex'
+    const matchesDisplayValue = (attrs: (JSXAttribute | JSXSpreadAttribute)[], suffix: string) => {
+      const display = getStaticAttributeExpression(j, attrs, 'display') || []
+      const values = Array.isArray(display) ? display : [display]
+      return values.some((value) => typeof value === 'string' && value.endsWith(suffix))
     }
 
-    const replaceWithGrid = (attrs: (JSXAttribute | JSXSpreadAttribute)[]) => {
-      const display = getStaticAttributeExpression(j, attrs, 'display')
-      return display === 'grid' || display == 'inline-grid'
-    }
+    const replaceWithFlex = (attrs: (JSXAttribute | JSXSpreadAttribute)[]) =>
+      matchesDisplayValue(attrs, 'flex')
+
+    const replaceWithGrid = (attrs: (JSXAttribute | JSXSpreadAttribute)[]) =>
+      matchesDisplayValue(attrs, 'grid')
 
     if (transformImport(j, root, 'Box', fromPackage, toPackage)) {
       markChanged()

--- a/packages/ui-codemod/src/transforms/latest/box/box.ts
+++ b/packages/ui-codemod/src/transforms/latest/box/box.ts
@@ -35,17 +35,34 @@ export default function transform(
       return
     }
 
-    const matchesDisplayValue = (attrs: (JSXAttribute | JSXSpreadAttribute)[], suffix: string) => {
+    const matchesDisplayValue = (
+      attrs: (JSXAttribute | JSXSpreadAttribute)[],
+      suffix: string,
+      exclude: string[],
+    ) => {
       const display = getStaticAttributeExpression(j, attrs, 'display') || []
       const values = Array.isArray(display) ? display : [display]
+      let matchesExclude
+
+      for (const excluded of exclude) {
+        if (values.some((value) => typeof value === 'string' && value.endsWith(excluded))) {
+          matchesExclude = true
+          break
+        }
+      }
+
+      if (matchesExclude) {
+        return false
+      }
+
       return values.some((value) => typeof value === 'string' && value.endsWith(suffix))
     }
 
     const replaceWithFlex = (attrs: (JSXAttribute | JSXSpreadAttribute)[]) =>
-      matchesDisplayValue(attrs, 'flex')
+      matchesDisplayValue(attrs, 'flex', ['block', 'inline', 'grid'])
 
     const replaceWithGrid = (attrs: (JSXAttribute | JSXSpreadAttribute)[]) =>
-      matchesDisplayValue(attrs, 'grid')
+      matchesDisplayValue(attrs, 'grid', ['block', 'inline', 'flex'])
 
     if (transformImport(j, root, 'Box', fromPackage, toPackage)) {
       markChanged()

--- a/packages/ui-codemod/src/types/AnyExpression.ts
+++ b/packages/ui-codemod/src/types/AnyExpression.ts
@@ -2,7 +2,6 @@ import type {Expression} from 'jscodeshift'
 
 export interface AnyExpression extends Expression {
   type: string
-  name?: string
   value?: unknown
   elements?: unknown
   quasis?: unknown

--- a/packages/ui-codemod/src/types/AnyExpression.ts
+++ b/packages/ui-codemod/src/types/AnyExpression.ts
@@ -2,6 +2,7 @@ import type {Expression} from 'jscodeshift'
 
 export interface AnyExpression extends Expression {
   type: string
+  name?: string
   value?: unknown
   elements?: unknown
   quasis?: unknown

--- a/packages/ui-codemod/src/utils/getStaticAttributeExpression.ts
+++ b/packages/ui-codemod/src/utils/getStaticAttributeExpression.ts
@@ -6,7 +6,7 @@ import {getAttributeExpression} from './getAttributeExpression'
 
 export type CompositePrimitive = string | number | boolean
 
-export type StaticAttributeValue = CompositePrimitive | (CompositePrimitive | null)[]
+export type StaticAttributeValue = CompositePrimitive | (CompositePrimitive | null | undefined)[]
 
 function getStaticPrimitive(expr: AnyExpression): CompositePrimitive | undefined {
   if (
@@ -53,7 +53,7 @@ export function getStaticAttributeExpression(
   }
 
   const elements = expr.elements as (AnyExpression | null)[]
-  const values: (CompositePrimitive | null)[] = []
+  const values: (CompositePrimitive | null | undefined)[] = []
 
   for (const element of elements) {
     if (element === null || element.type === 'NullLiteral') {
@@ -67,6 +67,11 @@ export function getStaticAttributeExpression(
 
     if (element.type === 'Literal' && element.value === null) {
       values.push(null)
+      continue
+    }
+
+    if (element.type === 'Identifier' && element.name === 'undefined') {
+      values.push(undefined)
       continue
     }
 

--- a/packages/ui-codemod/src/utils/getStaticAttributeExpression.ts
+++ b/packages/ui-codemod/src/utils/getStaticAttributeExpression.ts
@@ -52,7 +52,7 @@ export function getStaticAttributeExpression(
     return null
   }
 
-  const elements = expr.elements as (AnyExpression | null)[]
+  const elements = expr.elements as ((AnyExpression & {name?: string}) | null)[]
   const values: (CompositePrimitive | null | undefined)[] = []
 
   for (const element of elements) {

--- a/packages/ui-codemod/src/utils/getStaticAttributeExpression.ts
+++ b/packages/ui-codemod/src/utils/getStaticAttributeExpression.ts
@@ -1,15 +1,35 @@
 import type {API, JSXAttribute, JSXSpreadAttribute} from 'jscodeshift'
 
+import type {AnyExpression} from '../types/AnyExpression'
 import {getAttribute} from './getAttribute'
 import {getAttributeExpression} from './getAttributeExpression'
 
 export type CompositePrimitive = string | number | boolean
 
+export type StaticAttributeValue = CompositePrimitive | (CompositePrimitive | null)[]
+
+function getStaticPrimitive(expr: AnyExpression): CompositePrimitive | undefined {
+  if (
+    expr.type === 'StringLiteral' ||
+    expr.type === 'NumericLiteral' ||
+    expr.type === 'BooleanLiteral' ||
+    expr.type === 'Literal'
+  ) {
+    const {value} = expr
+
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      return value
+    }
+  }
+
+  return undefined
+}
+
 export function getStaticAttributeExpression(
   j: API['jscodeshift'],
   attrs: (JSXAttribute | JSXSpreadAttribute)[],
   name: string,
-): CompositePrimitive | null {
+): StaticAttributeValue | null {
   const attr = getAttribute(attrs, name)
 
   if (!attr) {
@@ -22,14 +42,42 @@ export function getStaticAttributeExpression(
     return null
   }
 
-  if (
-    expr.type === 'StringLiteral' ||
-    expr.type === 'NumericLiteral' ||
-    expr.type === 'BooleanLiteral' ||
-    expr.type === 'Literal'
-  ) {
-    return expr.value as string | number | boolean
+  const primitive = getStaticPrimitive(expr as AnyExpression)
+
+  if (primitive !== undefined) {
+    return primitive
   }
 
-  return null
+  if (expr.type !== 'ArrayExpression') {
+    return null
+  }
+
+  const elements = expr.elements as (AnyExpression | null)[]
+  const values: (CompositePrimitive | null)[] = []
+
+  for (const element of elements) {
+    if (element === null || element.type === 'NullLiteral') {
+      values.push(null)
+      continue
+    }
+
+    if (element.type === 'SpreadElement') {
+      return null
+    }
+
+    if (element.type === 'Literal' && element.value === null) {
+      values.push(null)
+      continue
+    }
+
+    const elementValue = getStaticPrimitive(element)
+
+    if (elementValue === undefined) {
+      return null
+    }
+
+    values.push(elementValue)
+  }
+
+  return values
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR updates the Box codemod to check for `flex` and `grid` display values in responsive arrays in addition to strings. It doesn't handle mixed arrays (arrays with `block` and `flex` for example) but there aren't currently any instances of those in studio and they would be caught during typechecking. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

I would focus on whether the logic in `box.ts` and the test make sense. The `getStaticAttributeExpression` file contains more agent aided jscodeshift code.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to ui-codemod transform utilities and tests; no runtime app behavior, though other codemods using `getStaticAttributeExpression` could see array values where they previously got `null`.
> 
> **Overview**
> The **Box** codemod can now treat responsive `display` props written as static arrays (e.g. `['none', undefined, null, 'flex']`) the same as a plain `'flex'` / `'grid'` string when deciding to rewrite to **Flex** or **Grid**.
> 
> **`getStaticAttributeExpression`** is extended to return parsed static array literals (strings/numbers/booleans, `null`, and identifier `undefined`), not only single primitives; spreads or non-static elements still yield `null`.
> 
> Replacement logic in **`box.ts`** is centralized in **`matchesDisplayValue`**, which normalizes scalar vs array values, requires a matching `flex`/`grid` suffix, and **skips** the rewrite when the array mixes incompatible display families (e.g. `block` and `flex` in the same array). New inline tests cover the happy path and the mixed-array guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65652a2c9d8784013f64571accb71cc62aab87d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->