### PR TITLE
refactor(docs): follow the updated sanity-live-cache-components skill

### DIFF
--- a/.agents/skills/sanity-live-cache-components/SKILL.md
+++ b/.agents/skills/sanity-live-cache-components/SKILL.md
@@ -1,20 +1,49 @@
 ---
 name: sanity-live-cache-components
-description: Integrates Sanity Live with Next.js Cache Components in next-sanity v13+ apps. Sets up sanityFetch, <SanityLive>, Visual Editing, Presentation Tool, draft mode handling, and the three-layer (Page/Dynamic/Cached) component pattern with explicit perspective/stega prop-drilling. Use when configuring or migrating a Next.js app to cacheComponents with Sanity, when adding sanityFetch, when wiring <SanityLive>/<VisualEditing>, or when refactoring components that hardcode perspective/stega.
+description: Integrates Sanity Live with Next.js Cache Components in next-sanity v13+ apps. Sets up sanityFetch, a shared cachedSanity 'use cache' boundary, <SanityLive>, Visual Editing, Presentation Tool, draft mode handling, and the three-layer (Page/Dynamic/Cached) component pattern with explicit perspective/stega prop-drilling. Sequences with the official Next.js skills (next-cache-components-adoption, next-cache-components-optimizer, next-partial-prefetching-adoption, next-dev-loop). Use when configuring or migrating a Next.js app to cacheComponents with Sanity, when adding sanityFetch, when wiring <SanityLive>/<VisualEditing>, or when refactoring components that hardcode perspective/stega.
 ---
 
 # Sanity Live + Cache Components
 
-Wires `next-sanity` into a Next.js 16+ app with `cacheComponents: true`. Data is fetched with `sanityFetch` (which calls `cacheTag`/`cacheLife` internally), and `<SanityLive>` in the root layout revalidates cached content over an EventSource connection to Sanity Content Lake. Visual Editing and Presentation Tool are fully supported when draft mode is enabled.
+Wires `next-sanity` into a Next.js 16+ app with `cacheComponents: true`. Data is fetched with `sanityFetch` through a single shared `'use cache'` boundary (`cachedSanity`), and `<SanityLive>` in the root layout revalidates cached content over an EventSource connection to Sanity Content Lake. Visual Editing and Presentation Tool are fully supported when draft mode is enabled.
 
 Read the relevant guide in `node_modules/next/dist/docs/` (when available) before writing code. If a guide conflicts with this skill, follow this skill.
 
-This skill assumes familiarity with the `next-cache-components` skill — it covers `'use cache'`, `cacheLife`, `cacheTag`, and the cookies/headers/params rule. The only Sanity-relevant exception: `await draftMode()` is allowed inside `'use cache'` (Next.js bypasses caching when draft mode is enabled — see [the `use cache` reference](https://nextjs.org/docs/app/api-reference/directives/use-cache#draft-mode)).
+This skill assumes familiarity with Cache Components fundamentals — `'use cache'`, `cacheLife`, `cacheTag`, and the cookies/headers/params rule — covered by the [Cache Components guide](https://nextjs.org/docs/app/getting-started/cache-components) (bundled offline under `node_modules/next/dist/docs/`). The only Sanity-relevant exception: `await draftMode()` is allowed inside `'use cache'` (Next.js bypasses caching when draft mode is enabled — see [the `use cache` reference](https://nextjs.org/docs/app/api-reference/directives/use-cache#draft-mode)).
+
+## Where this skill fits
+
+Next.js ships official skills for the framework-generic workflows (see [Setting up your project for AI coding agents](https://nextjs.org/docs/app/guides/ai-agents)). This skill covers only the Sanity surface and defers everything else to them. Install them from the Next.js repository:
+
+```bash
+npx skills add vercel/next.js --skill next-dev-loop
+npx skills add vercel/next.js --skill next-cache-components-adoption
+npx skills add vercel/next.js --skill next-cache-components-optimizer
+npx skills add vercel/next.js --skill next-partial-prefetching-adoption
+```
+
+When their rules apply — blocking-route triage, `<Suspense>` placement, loading-UI reuse, `instant()` regression tests, link prefetch audits — follow them; don't re-derive that guidance from here.
+
+Recommended sequence when migrating an app:
+
+1. **[`next-cache-components-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-adoption)** — enables `cacheComponents: true` and works the app to a passing build, route by route. Tell it to leave the Sanity surface to this skill:
+
+   > Adopt Cache Components in this project using the next-cache-components-adoption Skill. Defer draft mode handling and every `sanityFetch` / `<SanityLive>` call site to the sanity-live-cache-components skill: leave those routes opted out (`export const instant = false`) rather than refactoring the Sanity data fetching.
+
+2. **This skill** — set up `defineLive` and the `live.ts` helpers, refactor `sanityFetch` call sites to source `perspective`/`stega` correctly, wire `<SanityLive>`/`<VisualEditing>` and draft mode, then remove the remaining opt-outs on the deferred Sanity routes. Use the adoption skill's per-route loop and success bar for that removal (dev overlay clean, browser-verified, `next build` passes) — this skill supplies the Sanity-specific fixes, the loop mechanics are the adoption skill's.
+
+3. **Either or both, optional follow-ups:**
+   - [`next-cache-components-optimizer`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-optimizer) — grows a route's static shell and guards it with an `@next/playwright` `instant()` test. Prompt: _"Make the navigation to `/<route>` instant using the next-cache-components-optimizer Skill."_
+   - [`next-partial-prefetching-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-partial-prefetching-adoption) — enables `partialPrefetching` and audits `<Link prefetch={true}>` usage. Prompt: _"Adopt Partial Prefetching in this project using the next-partial-prefetching-adoption Skill."_
+
+   Nothing in this skill blocks either one: the [three-layer pattern](#5-apply-the-three-layer-pattern-to-pages-and-layouts) keeps routes fully prerenderable in the published branch, which is exactly the shell those skills grow and prefetch. Sanity content cached via `cachedSanity` also satisfies the "cached URL-dependent content" requirement for [runtime prefetching](https://nextjs.org/docs/app/guides/runtime-prefetching).
+
+Throughout all of it, verify changes at runtime with [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop) — a passing compile doesn't prove what ended up in the static shell versus streamed.
 
 ## Prerequisites
 
-- Next.js 16.2+ installed in the project (check `package.json` or run `pnpm list next` / `npm ls next` — don't use `pnpm view next version`, that reports the registry's latest, not what's installed).
-- `AGENTS.md` exists, or [follow the guide](https://nextjs.org/docs/app/guides/ai-agents#existing-projects).
+- Next.js 16.3+ installed in the project (check `package.json` or run `pnpm list next` / `npm ls next` — don't use `pnpm view next version`, that reports the registry's latest, not what's installed). `next-sanity` v13 supports Next.js 16, but the official skills this skill sequences with require 16.3+.
+- `AGENTS.md` exists. On Next.js 16.3+, `next dev` auto-generates it (pointing agents at the bundled docs); on older versions [follow the guide](https://nextjs.org/docs/app/guides/ai-agents#existing-projects).
 - These environment variables are set:
   - `NEXT_PUBLIC_SANITY_PROJECT_ID`
   - `NEXT_PUBLIC_SANITY_DATASET`
@@ -25,9 +54,9 @@ This skill assumes familiarity with the `next-cache-components` skill — it cov
 
 | File                                                                 | When to read                                                                                                                   |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [reference/live-helpers.md](reference/live-helpers.md)               | Full `client.ts` / `live.ts`, `sanityFetch*` and `getDynamicFetchOptions` details                                              |
+| [reference/live-helpers.md](reference/live-helpers.md)               | Full `client.ts` / `live.ts`, `cachedSanity`, `sanityFetch*` and `getDynamicFetchOptions` details                              |
 | [reference/three-layer-pattern.md](reference/three-layer-pattern.md) | The Page → Dynamic → Cached pattern for `page.tsx`, including the `searchParams` variant                                       |
-| [reference/layouts.md](reference/layouts.md)                         | Non-blocking data fetching inside `layout.tsx` with a shared `'use cache'` helper                                              |
+| [reference/layouts.md](reference/layouts.md)                         | Non-blocking data fetching inside `layout.tsx`                                                                                 |
 | [reference/dynamic-segments.md](reference/dynamic-segments.md)       | High-performance `[slug]` routes: `loading.tsx` + partial `generateStaticParams`, or non-blocking dynamic `params` in a layout |
 
 ---
@@ -44,9 +73,9 @@ If the app is already using `defineLive`, this skill is a refactor, not a rewrit
 
 - **Don't overwrite `client.ts` or `live.ts`** if they exist. Append missing options. Preserve any existing `token` and `stega.*` settings — see [reference/live-helpers.md](reference/live-helpers.md).
 - **Search the codebase for hardcoded `perspective: 'published'` and `stega: false`** in `sanityFetch` callsites and refactor them to source `perspective`/`stega` via `getDynamicFetchOptions` and the three-layer pattern.
-- **Search for `sanityFetch` calls inside `generateStaticParams`** → swap for `sanityFetchStaticParams`.
-- **Search for `sanityFetch` calls inside `generateMetadata` / `sitemap.ts` / `opengraph-image.tsx` / etc.** → swap for `sanityFetchMetadata`.
-- **Search for `sanityFetch` calls directly inside a `'use server'` function** → split into a separate `'use cache'` helper.
+- **Search for `sanityFetch` calls inside `generateStaticParams`** → swap for `cachedSanityStaticParams`.
+- **Search for `sanityFetch` calls inside `generateMetadata` / `sitemap.ts` / `opengraph-image.tsx` / etc.** → swap for `cachedSanityMetadata`.
+- **Search for `sanityFetch` calls directly inside a `'use server'` function** → swap for `cachedSanity`.
 - **Verify there is exactly one `<SanityLive>` and one `<VisualEditing>` in the tree.** Multiple renders are undefined behavior.
 
 The "Anti-patterns to grep for" section at the bottom of this file lists the search patterns.
@@ -74,7 +103,7 @@ export default nextConfig
 
 ## 3. Configure `defineLive` and export helpers
 
-Create `src/sanity/lib/client.ts` and `src/sanity/lib/live.ts`. The minimal `defineLive` call:
+Create `src/sanity/lib/client.ts` and `src/sanity/lib/live.ts`. The core of `live.ts`:
 
 ```ts
 // src/sanity/lib/live.ts (excerpt)
@@ -84,19 +113,28 @@ export const {SanityLive, sanityFetch} = defineLive({
   browserToken: token,
   strict: true,
 })
+
+// The app's one shared 'use cache' boundary. `sanityFetch` calls
+// `cacheTag`/`cacheLife` internally but doesn't create the boundary —
+// this wrapper provides it once, so callers don't add their own.
+export const cachedSanity: StrictDefinedFetchType = async (options) => {
+  'use cache'
+  return sanityFetch(options)
+}
 ```
 
-Full file contents (including `client.ts`, `getDynamicFetchOptions`, `sanityFetchMetadata`, `sanityFetchStaticParams`) and per-helper guidance: [reference/live-helpers.md](reference/live-helpers.md).
+Full file contents (including `client.ts`, `getDynamicFetchOptions`, `cachedSanityMetadata`, `cachedSanityStaticParams`) and per-helper guidance: [reference/live-helpers.md](reference/live-helpers.md).
 
 The helpers exported from `live.ts`:
 
-| Helper                    | Used in                                                                                        |
-| ------------------------- | ---------------------------------------------------------------------------------------------- |
-| `sanityFetch`             | `'use cache'` components rendered from `page.tsx` / `layout.tsx`                               |
-| `sanityFetchMetadata`     | `generateMetadata`, `generateViewport`, `sitemap.ts`, `robots.ts`, `opengraph-image.tsx`, etc. |
-| `sanityFetchStaticParams` | `generateStaticParams` only                                                                    |
-| `getDynamicFetchOptions`  | Resolving `perspective`/`stega` outside any `'use cache'` boundary                             |
-| `SanityLive`              | Rendered once in a root layout                                                                 |
+| Helper                     | Used in                                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------- |
+| `cachedSanity`             | The default for fetching content anywhere server-side: pages, layouts, components, server actions |
+| `sanityFetch`              | Only inside a component that carries its own `'use cache'` (also caches the rendered JSX)         |
+| `cachedSanityMetadata`     | `generateMetadata`, `generateViewport`, `sitemap.ts`, `robots.ts`, `opengraph-image.tsx`, etc.    |
+| `cachedSanityStaticParams` | `generateStaticParams` only                                                                       |
+| `getDynamicFetchOptions`   | Resolving `perspective`/`stega` outside any `'use cache'` boundary                                |
+| `SanityLive`               | Rendered once in a root layout                                                                    |
 
 ---
 
@@ -142,10 +180,14 @@ Page/Layout (Layer 1: draftMode branch)
   ├── NOT draft mode → <CachedX perspective="published" stega={false} />  (no Suspense)
   └── draft mode → <Suspense fallback={...}>
                       <DynamicX params={params} />  (Layer 2: awaits dynamic APIs)
-                        └── <CachedX perspective={p} stega={s} />  (Layer 3: 'use cache')
+                        └── <CachedX perspective={p} stega={s} />  (Layer 3: fetches via cachedSanity)
 ```
 
-**Critical rule**: Only Layer 3 carries `'use cache'`. The top-level `Page` / `Layout` must **not** have `'use cache'` — it awaits `params`, `searchParams`, or `cookies()` (via `getDynamicFetchOptions`), and those dynamic APIs are forbidden inside `'use cache'`. Layer 3 carrying `'use cache'` is enough for the whole route to prerender into the static shell. Adding `'use cache'` to the top-level function is the most common failure mode — TypeScript and the runtime will both complain.
+**Critical rules**:
+
+- The cache boundary lives in `live.ts` (`cachedSanity`), so route files usually carry no `'use cache'` directive at all. In particular the top-level `Page` / `Layout` must **not** have `'use cache'` — it awaits `params`, `searchParams`, or `cookies()` (via `getDynamicFetchOptions`), and those dynamic APIs are forbidden inside `'use cache'`. Adding `'use cache'` to the top-level function is the most common failure mode — TypeScript and the runtime will both complain.
+- Layer 3 awaiting `cachedSanity` is enough for the whole route to prerender into the static shell — no `<Suspense>` needed in the published branch. `perspective` and `stega` are part of the wrapper's cache key automatically, so published and draft content never share a cache entry.
+- Only Layer 2 (rendered inside `<Suspense>`, draft mode only) touches dynamic APIs.
 
 Pick the right reference for the file you're editing:
 
@@ -156,13 +198,22 @@ Pick the right reference for the file you're editing:
 
 ---
 
+## Verifying the Sanity surface
+
+Use [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop) after each refactor; the loop mechanics and success bar live in the official skills. The Sanity-specific things to confirm:
+
+- Published branch: the route prerenders fully (`◐` or `○` in the build's route table) and content renders without a `<Suspense>` fallback flash.
+- Draft mode: enabling it streams draft content, `<VisualEditing>` overlays appear, and switching perspectives in Presentation Tool changes the rendered content.
+- Live updates: editing published content in the Studio revalidates the route (via `<SanityLive>`) without a rebuild.
+
 ## Anti-patterns to grep for
 
 When auditing an app, search for these and refactor:
 
-- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` call → use the three-layer pattern, source `perspective`/`stega` via `getDynamicFetchOptions`.
-- `sanityFetch(` directly inside a function whose body begins with `'use server'` → split into a separate `'use cache'` helper.
-- `sanityFetch(` inside `generateStaticParams` → swap for `sanityFetchStaticParams`.
-- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `sanityFetchMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` / `cachedSanity` call inside a shared component → use the three-layer pattern, source `perspective`/`stega` via `getDynamicFetchOptions`. (Layer 1's non-draft branch passing literal `perspective="published" stega={false}` props is the pattern, not a violation.)
+- `sanityFetch(` directly inside a function whose body begins with `'use server'` → swap for `cachedSanity` (resolve `perspective`/`stega` via `getDynamicFetchOptions` first).
+- `sanityFetch(` inside `generateStaticParams` → swap for `cachedSanityStaticParams`.
+- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `cachedSanityMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `sanityFetch(` in a component without its own `'use cache'` directive → swap for `cachedSanity` (or add the directive if caching the rendered JSX is intended).
 - `await draftMode()` immediately followed by `await getDynamicFetchOptions()` at the top of a `page.tsx` or `layout.tsx` without a sibling `loading.tsx` → move those dynamic-API calls into a child component wrapped in `<Suspense>` so the static shell can prerender.
 - More than one `<SanityLive>` or `<VisualEditing>` rendered in the tree → consolidate to a single render in the right layout.

--- a/.agents/skills/sanity-live-cache-components/reference/dynamic-segments.md
+++ b/.agents/skills/sanity-live-cache-components/reference/dynamic-segments.md
@@ -34,9 +34,9 @@ export default function Loading() {
 ```tsx
 // src/app/[slug]/page.tsx
 import {
+  cachedSanity,
   getDynamicFetchOptions,
-  sanityFetch,
-  sanityFetchStaticParams,
+  cachedSanityStaticParams,
   type DynamicFetchOptions,
 } from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
@@ -45,7 +45,7 @@ export async function generateStaticParams() {
   const pageSlugsQuery = defineQuery(
     `*[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}`,
   )
-  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
+  const {data} = await cachedSanityStaticParams({query: pageSlugsQuery})
   return data
 }
 
@@ -60,9 +60,8 @@ async function CachedPage({
   perspective,
   stega,
 }: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
-  'use cache'
   const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({
+  const {data} = await cachedSanity({
     query: pageQuery,
     params: {slug},
     perspective,
@@ -79,7 +78,7 @@ A `layout.tsx` can't use `loading.tsx` for fallback UI — [it's one level highe
 ```tsx
 // src/app/(website)/[slug]/layout.tsx
 
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {cachedSanity, getDynamicFetchOptions, type DynamicFetchOptions} from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
 import {Suspense} from 'react'
 
@@ -106,9 +105,8 @@ async function Footer({
   perspective,
   stega,
 }: Awaited<LayoutProps<'/[slug]'>['params']> & DynamicFetchOptions) {
-  'use cache'
   const footerQuery = defineQuery(`*[_type == "footer" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({query: footerQuery, params: {slug}, perspective, stega})
+  const {data} = await cachedSanity({query: footerQuery, params: {slug}, perspective, stega})
   return <footer>{/* use `data` to render stuff */}</footer>
 }
 ```

--- a/.agents/skills/sanity-live-cache-components/reference/layouts.md
+++ b/.agents/skills/sanity-live-cache-components/reference/layouts.md
@@ -1,35 +1,30 @@
 # Non-blocking layout patterns
 
-When `sanityFetch` runs inside a `layout.tsx`, the goal is to keep `children` streaming and keep the static shell as large as possible.
+When Sanity content is fetched inside a `layout.tsx`, the goal is to keep `children` streaming and keep the static shell as large as possible.
 
 ## Contents
 
 - [Rules](#rules)
-- [Pattern: shared `'use cache'` helper per draft/published branch](#pattern-shared-use-cache-helper-per-draftpublished-branch)
+- [Pattern: cached components per draft/published branch](#pattern-cached-components-per-draftpublished-branch)
 - [Anti-pattern: wrapping `children` in a single cached layout](#anti-pattern-wrapping-children-in-a-single-cached-layout)
 - [Simpler example: a single `<Footer>`](#simpler-example-a-single-footer)
 
 ## Rules
 
-- The top-level `layout.tsx` component must not `await` dynamic APIs (other than `draftMode()`) or fetch data. `draftMode()` is the lone exception because Next.js bypasses caching when it's enabled and a `draftMode()`-only top-level component still prerenders into the static shell. Anything else (`cookies()`, `headers()`, `await params`, `await searchParams`, `sanityFetch`) reduces the static shell or slows draft-mode streaming.
+- The top-level `layout.tsx` component must not `await` dynamic APIs (other than `draftMode()`) or fetch data. `draftMode()` is the lone exception because Next.js bypasses caching when it's enabled and a `draftMode()`-only top-level component still prerenders into the static shell. Anything else (`cookies()`, `headers()`, `await params`, `await searchParams`, data fetching) reduces the static shell or slows draft-mode streaming.
 - Push [dynamic API calls](https://nextjs.org/docs/app/guides/streaming#push-dynamic-access-down) down to the leaf that needs them.
-- Extract shared data fetching into a reusable async `'use cache'` helper so two components that need the same data don't both wait independently.
+- Two components fetching the same query don't need a shared helper to avoid duplicate requests: `cachedSanity` keys its cache on the fetch options, so identical calls resolve from one cache entry.
 
-## Pattern: shared `'use cache'` helper per draft/published branch
+## Pattern: cached components per draft/published branch
 
 ```tsx
 // src/app/(website)/layout.tsx
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {cachedSanity, getDynamicFetchOptions, type DynamicFetchOptions} from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
 import {draftMode} from 'next/headers'
 import {Suspense} from 'react'
 
-async function fetchSettings({perspective, stega}: DynamicFetchOptions) {
-  'use cache'
-  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
-  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
-  return data
-}
+const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
 
 export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
   const {isEnabled: isDraftMode} = await draftMode()
@@ -59,8 +54,8 @@ async function DynamicNavbar() {
   return <CachedNavbar perspective={perspective} stega={stega} />
 }
 async function CachedNavbar({perspective, stega}: DynamicFetchOptions) {
-  'use cache'
-  const data = await fetchSettings({perspective, stega})
+  // Same options as CachedFooter → same cache entry, fetched once
+  const {data} = await cachedSanity({query: settingsQuery, perspective, stega})
   return <Navbar data={data} />
 }
 
@@ -69,8 +64,7 @@ async function DynamicFooter() {
   return <CachedFooter perspective={perspective} stega={stega} />
 }
 async function CachedFooter({perspective, stega}: DynamicFetchOptions) {
-  'use cache'
-  const data = await fetchSettings({perspective, stega})
+  const {data} = await cachedSanity({query: settingsQuery, perspective, stega})
   return <Footer data={data} />
 }
 ```
@@ -101,9 +95,8 @@ async function CachedWebsiteLayout({
   perspective,
   stega,
 }: {children: ReactNode} & DynamicFetchOptions) {
-  'use cache'
   const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
-  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+  const {data} = await cachedSanity({query: settingsQuery, perspective, stega})
 
   return (
     <>
@@ -121,7 +114,7 @@ Useful as a sanity check when adapting the pattern to a layout with only one dat
 
 ```tsx
 // src/app/(website)/layout.tsx
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {cachedSanity, getDynamicFetchOptions, type DynamicFetchOptions} from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
 import {draftMode} from 'next/headers'
 import {Suspense} from 'react'
@@ -146,9 +139,8 @@ async function DynamicFooter() {
   return <Footer perspective={perspective} stega={stega} />
 }
 async function Footer({perspective, stega}: DynamicFetchOptions) {
-  'use cache'
   const footerQuery = defineQuery(`*[_type == "footer"][0]`)
-  const {data} = await sanityFetch({query: footerQuery, perspective, stega})
+  const {data} = await cachedSanity({query: footerQuery, perspective, stega})
   return <footer>{/* use `data` to render stuff */}</footer>
 }
 function FooterFallback() {
@@ -160,4 +152,4 @@ function FooterFallback() {
 }
 ```
 
-The non-draft `<Footer perspective="published" stega={false} />` is part of the static shell, so the whole layout is cached and revalidates only when content used by `sanityFetch` changes. In draft mode the layout still renders immediately from its static shell while `<DynamicFooter>` streams in.
+The non-draft `<Footer perspective="published" stega={false} />` is part of the static shell, so the whole layout is cached and revalidates only when content used by the fetch changes. In draft mode the layout still renders immediately from its static shell while `<DynamicFooter>` streams in.

--- a/.agents/skills/sanity-live-cache-components/reference/live-helpers.md
+++ b/.agents/skills/sanity-live-cache-components/reference/live-helpers.md
@@ -4,10 +4,11 @@
 
 - [`client.ts`](#clientts)
 - [`live.ts`](#livets)
+- [`cachedSanity`](#cachedsanity)
 - [`sanityFetch`](#sanityfetch)
-- [`sanityFetchMetadata`](#sanityfetchmetadata)
+- [`cachedSanityMetadata`](#cachedsanitymetadata)
 - [`getDynamicFetchOptions`](#getdynamicfetchoptions)
-- [`sanityFetchStaticParams`](#sanityfetchstaticparams)
+- [`cachedSanityStaticParams`](#cachedsanitystaticparams)
 - [Anti-patterns to grep for](#anti-patterns-to-grep-for)
 
 ## `client.ts`
@@ -46,7 +47,12 @@ Create `src/sanity/lib/live.ts` alongside `client.ts`. If it already exists, app
 ```ts
 // src/sanity/lib/live.ts
 import {type QueryParams} from 'next-sanity'
-import {defineLive, resolvePerspectiveFromCookies, type LivePerspective} from 'next-sanity/live'
+import {
+  defineLive,
+  resolvePerspectiveFromCookies,
+  type LivePerspective,
+  type StrictDefinedFetchType,
+} from 'next-sanity/live'
 import {cookies, draftMode} from 'next/headers'
 import {client} from './client'
 
@@ -61,6 +67,14 @@ export const {SanityLive, sanityFetch} = defineLive({
   browserToken: token,
   strict: true,
 })
+
+// The app's one shared 'use cache' boundary. `sanityFetch` calls
+// `cacheTag`/`cacheLife` internally but doesn't create the boundary —
+// this wrapper provides it once, so callers don't add their own.
+export const cachedSanity: StrictDefinedFetchType = async (options) => {
+  'use cache'
+  return sanityFetch(options)
+}
 
 export interface DynamicFetchOptions {
   perspective: LivePerspective
@@ -78,20 +92,19 @@ export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
 }
 
 // For usage within `generateStaticParams`
-export async function sanityFetchStaticParams<const QueryString extends string>({
+export async function cachedSanityStaticParams<const QueryString extends string>({
   query,
   params = {},
 }: {
   query: QueryString
   params?: QueryParams
 }) {
-  'use cache'
-  const {data} = await sanityFetch({query, params, perspective: 'published', stega: false})
+  const {data} = await cachedSanity({query, params, perspective: 'published', stega: false})
   return {data}
 }
 
 // For usage within `generateMetadata` and `generateViewport`
-export async function sanityFetchMetadata<const QueryString extends string>({
+export async function cachedSanityMetadata<const QueryString extends string>({
   query,
   params = {},
   perspective,
@@ -100,32 +113,32 @@ export async function sanityFetchMetadata<const QueryString extends string>({
   params?: QueryParams
   perspective: LivePerspective
 }) {
-  'use cache'
-  const {data} = await sanityFetch({query, params, perspective, stega: false})
+  const {data} = await cachedSanity({query, params, perspective, stega: false})
   return {data}
 }
 ```
 
-## `sanityFetch`
+## `cachedSanity`
 
-For fetching data in React Server Components that have a `'use cache'` directive and are rendered (directly or transitively) from a `page.tsx` or `layout.tsx`.
+The default way to fetch Sanity content anywhere server-side: React Server Components, layouts, server actions, and route handlers. It is `sanityFetch` wrapped in the app's single shared `'use cache'` boundary, so callers don't declare `'use cache'` themselves.
 
-- `perspective` switches between published, drafts, and specific Sanity Content Releases.
-- `stega: true` (combined with `stega.studioUrl` in `createClient` and `<VisualEditing>` in the root layout) renders click-to-edit overlays.
-- `getDynamicFetchOptions` resolves `perspective` from the `sanity-preview-perspective` cookie, which `<VisualEditing>` manages when the app is rendered inside Presentation Tool's preview iframe.
+Why it works:
 
-The async function that calls `sanityFetch` must carry `'use cache'` or `'use cache: remote'`, and must take `perspective` and `stega` as props. Never hardcode them.
+- `perspective`, `stega`, `query`, and `params` are all serializable arguments, so they become part of the cache key automatically — published and draft content never share a cache entry, and identical fetches from different components deduplicate into one entry.
+- `sanityFetch` calls `cacheTag()` (with Content Lake sync tags) and `cacheLife()` inside the wrapper's cache scope, so `<SanityLive>` revalidation targets each entry precisely.
+- When draft mode is enabled, Next.js bypasses `'use cache'`, so draft content stays fresh per request without extra handling.
+
+The component calling it must still take `perspective` and `stega` as props (or resolve them via `getDynamicFetchOptions` outside the static shell). Never hardcode them in shared components.
 
 Pattern:
 
 ```tsx
-import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {cachedSanity, type DynamicFetchOptions} from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
 
 async function CachedComponent({slug, perspective, stega}: {slug: string} & DynamicFetchOptions) {
-  'use cache'
   const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({query: pageQuery, params: {slug}, perspective, stega})
+  const {data} = await cachedSanity({query: pageQuery, params: {slug}, perspective, stega})
 }
 ```
 
@@ -133,8 +146,7 @@ Anti-pattern (hardcoded options break Visual Editing and content-release preview
 
 ```tsx
 async function CachedComponent({slug}: {slug: string}) {
-  'use cache'
-  const {data} = await sanityFetch({
+  const {data} = await cachedSanity({
     query: pageQuery,
     params: {slug},
     perspective: 'published', // hardcoded
@@ -143,52 +155,69 @@ async function CachedComponent({slug}: {slug: string}) {
 }
 ```
 
-### `sanityFetch` inside server actions
+### Inside server actions
 
-`'use server'` boundaries cannot accept `perspective`/`stega` as props (server action inputs are untrusted). Resolve them inside the `'use server'` function and forward them to a separate `'use cache'` boundary:
+`'use server'` boundaries cannot accept `perspective`/`stega` as inputs (server action inputs are untrusted). Resolve them inside the `'use server'` function and forward them to `cachedSanity`:
 
 ```tsx
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {cachedSanity, getDynamicFetchOptions} from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
 
-async function fetchMore({page, perspective, stega}: {page: string} & DynamicFetchOptions) {
-  'use cache'
-  const pagesQuery = defineQuery(`*[_type == "page"][0...$page]`)
-  const {data} = await sanityFetch({query: pagesQuery, params: {page}, perspective, stega})
-  return data
-}
 async function renderMore({page}: {page: string}) {
   'use server'
   const {perspective, stega} = await getDynamicFetchOptions()
-  const data = await fetchMore({page, perspective, stega})
+  const pagesQuery = defineQuery(`*[_type == "page"][0...$page]`)
+  const {data} = await cachedSanity({query: pagesQuery, params: {page}, perspective, stega})
 }
 ```
 
 Anti-patterns:
 
-- Hardcoding `perspective`/`stega` in the `'use cache'` helper.
-- Calling `sanityFetch` directly inside `'use server'` — it bypasses caching entirely.
+- Hardcoding `perspective`/`stega` inside the action.
+- Calling the bare `sanityFetch` inside `'use server'` — it has no cache boundary there.
 
-### `sanityFetch` inside `route.ts`
+### Inside `route.ts`
 
-Hardcode `stega: false` and resolve only `perspective`. Route handlers don't render a DOM next to `<VisualEditing>`, so stega encoding only inflates the payload (and can cause downstream errors).
+Use `cachedSanity` with `stega: false` hardcoded, and resolve only `perspective`. Route handlers don't render a DOM next to `<VisualEditing>`, so stega encoding only inflates the payload (and can cause downstream errors).
 
-## `sanityFetchMetadata`
+## `sanityFetch`
+
+The bare fetcher returned by `defineLive`. It calls `cacheTag`/`cacheLife` internally, which **requires** a surrounding `'use cache'` scope — so the only place to call it directly is inside a component (or function) that carries its own `'use cache'` directive:
+
+```tsx
+import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function CachedPage({slug, perspective, stega}: {slug: string} & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({query: pageQuery, params: {slug}, perspective, stega})
+  return <article>{/* expensive rendering, cached alongside the data */}</article>
+}
+```
+
+Reach for this instead of `cachedSanity` only when caching the rendered JSX (not just the data) is worth an extra boundary — e.g. an expensive Portable Text render tree. The same rules apply: take `perspective` and `stega` as props, never hardcode them.
+
+- `perspective` switches between published, drafts, and specific Sanity Content Releases.
+- `stega: true` (combined with `stega.studioUrl` in `createClient` and `<VisualEditing>` in the root layout) renders click-to-edit overlays.
+- `getDynamicFetchOptions` resolves `perspective` from the `sanity-preview-perspective` cookie, which `<VisualEditing>` manages when the app is rendered inside Presentation Tool's preview iframe.
+
+## `cachedSanityMetadata`
 
 For fetching data inside `generateMetadata`, `generateSitemaps`, `generateViewport`, `generateImageMetadata`, and the file-based metadata routes (`icon.tsx`, `apple-icon.tsx`, `manifest.ts`, `opengraph-image.tsx`, `twitter-image.tsx`, `robots.ts`, `sitemap.ts`).
 
-It's `sanityFetch` without `stega` (never wanted in these contexts) and without requiring `'use cache'` at the callsite — the helper already provides it.
+It's `cachedSanity` with `stega` pinned to `false` (never wanted in these contexts).
 
 Presentation Tool can open an app in a standalone preview window, so the correct content release must still be reflected in `<title>` and friends. Always resolve `perspective`:
 
 ```ts
-import {getDynamicFetchOptions, sanityFetchMetadata} from '@/sanity/lib/live'
+import {getDynamicFetchOptions, cachedSanityMetadata} from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
 
 export async function generateMetadata({params}: PageProps<'/[slug]'>) {
   const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
   const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetchMetadata({query: pageQuery, params: {slug}, perspective})
+  const {data} = await cachedSanityMetadata({query: pageQuery, params: {slug}, perspective})
 }
 ```
 
@@ -202,19 +231,20 @@ Avoid calling `getDynamicFetchOptions` in the top-level body of a `layout.tsx` o
 
 When Cache Components are enabled, `<Suspense>` boundaries determine the static shell. For fully prerendered routes, render the Suspense tree only when in draft mode — see [three-layer-pattern.md](three-layer-pattern.md).
 
-## `sanityFetchStaticParams`
+## `cachedSanityStaticParams`
 
 Used inside `generateStaticParams`. `stega` is never wanted (the data feeds route params), and `perspective` cookies aren't available at build time anyway, so both are hardcoded.
 
-- Never call `sanityFetch` inside `generateStaticParams` — always use `sanityFetchStaticParams`.
-- Never call `sanityFetchStaticParams` outside `generateStaticParams`.
+- Never call `sanityFetch` or `cachedSanity` directly inside `generateStaticParams` — always use `cachedSanityStaticParams` (which fetches through `cachedSanity` internally).
+- Never call `cachedSanityStaticParams` outside `generateStaticParams`.
 
 ## Anti-patterns to grep for
 
 When migrating an existing app, these are the strings to search for and refactor:
 
-- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` call → replace with `perspective` and `stega` props sourced from `getDynamicFetchOptions` via the three-layer pattern.
-- `sanityFetch(` directly inside a function whose body starts with `'use server'` → split into a separate `'use cache'` helper and forward `perspective`/`stega` as props.
-- `sanityFetch(` inside `generateStaticParams` → swap for `sanityFetchStaticParams`.
-- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `sanityFetchMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` / `cachedSanity` call inside a shared component → replace with `perspective` and `stega` props sourced from `getDynamicFetchOptions` via the three-layer pattern.
+- `sanityFetch(` directly inside a function whose body starts with `'use server'` → swap for `cachedSanity` and resolve `perspective`/`stega` via `getDynamicFetchOptions` inside the action.
+- `sanityFetch(` in a component without its own `'use cache'` directive → swap for `cachedSanity` (or add the directive if caching the rendered JSX is intended).
+- `sanityFetch(` inside `generateStaticParams` → swap for `cachedSanityStaticParams`.
+- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `cachedSanityMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
 - `await draftMode()` immediately followed by `await getDynamicFetchOptions()` at the top of a `page.tsx` or `layout.tsx` without a sibling `loading.tsx` → move the dynamic-API calls into a child component wrapped in `<Suspense>` so the static shell can prerender.

--- a/.agents/skills/sanity-live-cache-components/reference/three-layer-pattern.md
+++ b/.agents/skills/sanity-live-cache-components/reference/three-layer-pattern.md
@@ -27,14 +27,14 @@ The examples below use `/[slug]/page.tsx`, which needs:
 
 ```tsx
 // src/app/[slug]/page.tsx
-import {sanityFetchStaticParams} from '@/sanity/lib/live'
+import {cachedSanityStaticParams} from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
 
 export async function generateStaticParams() {
   const pageSlugsQuery = defineQuery(
     `*[_type == "page" && defined(slug.current)]{"slug": slug.current}`,
   )
-  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
+  const {data} = await cachedSanityStaticParams({query: pageSlugsQuery})
   return data
 }
 ```
@@ -69,12 +69,12 @@ export default async function Page({params}: PageProps<'/[slug]'>) {
 
 Notes:
 
-- `Page` does **not** have a `'use cache'` directive. `draftMode()` is allowed inside `'use cache'`, but `Page` also `awaits` `params` (and may call `getDynamicFetchOptions()`, which reads `cookies()`), and those dynamic APIs are not allowed inside `'use cache'`. It's enough for `<CachedPage>` (Layer 3) to carry `'use cache'` for `Page` to be prerendered as part of the static shell.
-- Requires `generateStaticParams` if `params` is used as input to `sanityFetch`.
+- `Page` does **not** have a `'use cache'` directive. `draftMode()` is allowed inside `'use cache'`, but `Page` also `awaits` `params` (and may call `getDynamicFetchOptions()`, which reads `cookies()`), and those dynamic APIs are not allowed inside `'use cache'`. `<CachedPage>` (Layer 3) fetching through `cachedSanity` is enough for `Page` to be prerendered as part of the static shell.
+- Requires `generateStaticParams` if `params` is used as input to the fetch.
 - Not in draft mode → no `<Suspense>` boundary, maximizes the static shell.
 - In draft mode → `<DynamicPage />` inside `<Suspense>` will suspend twice:
   1. when `<DynamicPage>` awaits `getDynamicFetchOptions()`
-  2. when `<CachedPage />` awaits `sanityFetch` with the resolved `perspective`/`stega`
+  2. when `<CachedPage />` awaits `cachedSanity` with the resolved `perspective`/`stega`
 
   A good fallback skeleton that doesn't cause layout shift is highly recommended.
 
@@ -97,11 +97,11 @@ async function DynamicPage({params}: Pick<PageProps<'/[slug]'>, 'params'>) {
 
 ## Layer 3: Cached component
 
-Has `'use cache'` and only receives plain, serializable props:
+Receives only plain, serializable props and fetches through `cachedSanity` — the shared `'use cache'` boundary in `live.ts` — so it needs no directive of its own:
 
 ```tsx
 // src/app/[slug]/page.tsx (continued)
-import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {cachedSanity, type DynamicFetchOptions} from '@/sanity/lib/live'
 import {defineQuery} from 'next-sanity'
 
 async function CachedPage({
@@ -109,9 +109,8 @@ async function CachedPage({
   perspective,
   stega,
 }: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
-  'use cache'
   const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({
+  const {data} = await cachedSanity({
     query: pageQuery,
     params: {slug},
     perspective,
@@ -121,9 +120,11 @@ async function CachedPage({
 }
 ```
 
+Variant: if the component's rendering itself is expensive (e.g. a large Portable Text tree) and worth caching alongside the data, give the component its own `'use cache'` directive and call the bare `sanityFetch` instead — see [live-helpers.md](live-helpers.md#sanityfetch). The props contract is identical.
+
 ## `searchParams` and other dynamic APIs
 
-If `searchParams` or other dynamic APIs are inputs to `sanityFetch` (or `params` is used without `generateStaticParams` or a `loading.tsx`), always render the `<Suspense>` tree and **stop branching on `draftMode`**. See [the streaming guide](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense) for picking between `loading.tsx` and `<Suspense>`.
+If `searchParams` or other dynamic APIs are inputs to the fetch (or `params` is used without `generateStaticParams` or a `loading.tsx`), always render the `<Suspense>` tree and **stop branching on `draftMode`**. See [the streaming guide](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense) for picking between `loading.tsx` and `<Suspense>`.
 
 ```tsx
 // src/app/[slug]/page.tsx (continued)

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -29,7 +29,7 @@
       "source": "sanity-io/next-sanity",
       "sourceType": "github",
       "skillPath": "skills/sanity-live-cache-components/SKILL.md",
-      "computedHash": "354498f97fd57877d48f4cfe6e8838de610995a6d53bef0cee3fe5b5ef9fad7e"
+      "computedHash": "6ca6b6034d8f297b6984794480686a1b67badf8e7b157b8634751d4f4d263894"
     },
     "stories": {
       "source": "storybookjs/mcp",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the vendored `sanity-live-cache-components` skill, audits `apps/docs` against it, and settles the runtime-prefetch question left open by #2616. Stacked on #2616.

## The skill update

`skills update sanity-live-cache-components` pulled a substantial revision. The material change is a **single shared `'use cache'` boundary** exported from `live.ts` as `cachedSanity`, with route files carrying no `'use cache'` of their own by default. The metadata and static-params helpers were renamed to match (`sanityFetchMetadata` → `cachedSanityMetadata`, `sanityFetchStaticParams` → `cachedSanityStaticParams`) and now route through it. The skill also gained a "Where this skill fits" section sequencing it with the four official Next.js skills, and `reference/layouts.md` gained an explicit **"Anti-pattern: wrapping `children` in a single cached layout"**.

## Audit result

Three deviations, all fixed:

1. **No shared boundary.** `live.ts` had no `cachedSanity`; every call site declared its own `'use cache'`. Added it (typed as `typeof sanityFetch` — the skill's `StrictDefinedFetchType` isn't exported by `next-sanity@13.3.1`), and rebuilt the two helpers on top of it so they no longer carry their own boundary.
2. **`(website)/layout.tsx` wrapped `children` in a cached component.** This is the named anti-pattern: the page waits on the layout's Sanity fetch instead of streaming independently. Now only the banner and navbar are cached; `children` and the (data-free) footer sit outside, with the `Flex` frame in the layout itself.
3. **`[screen]/layout.tsx` did the same.** The nav fetch is now started but not awaited — the layout hands the promise to the client `ArticleLayout`, which unwraps it with `use()` inside the boundaries that already render the nav. `children` no longer waits on it.

Deliberately left as-is, because the skill sanctions it: the three page components keep their own `'use cache'` with the bare `sanityFetch`, since they cache the rendered Portable Text / PageBuilder tree rather than just data. Each now says so in a one-line comment.

Verified as already conforming: the three-layer Page/Dynamic/Cached pattern with explicit `perspective`/`stega` props, `generateMetadata` resolving `perspective` rather than hardcoding `published`, `generateStaticParams` using the dedicated helper, exactly one `<SanityLive includeDrafts>` and one `<VisualEditing>` (both in a layout, and the Vite-built studio doesn't share that layout), `cacheComponents` + `cacheLife: {default: sanity}` in the config, and no `sanityFetch` inside `'use server'` functions or route handlers.

## The runtime-prefetch decision

#2616 left two `TODO(runtime-prefetch)` markers for the five links that still ask for a full prefetch: the navbar's `Docs`/`Arcade` and the home page's three hero links. Measured on a production build over a throttled connection (400 kbps, 300 ms RTT), median of three runs:

| Navigation | Full prefetch | App Shell only |
| --- | --- | --- |
| Navbar `Docs` → docs body visible | **126 ms** | 879 ms |
| Hero link → article body visible | **273 ms** | 877 ms |
| Prefetch requests on a home-page view | 8 | 5 |

Three things decided it:

- **The App Shell provides no instant floor for these navigations.** Under `instant()`, a navbar click commits nothing — no URL change, no loading shell — *with and without* the full prefetch. A screen change can't be covered by the shared shell, so the runtime prefetch is the only thing making these fast.
- **The cost is bounded by unique destinations, not links.** Five links resolve to three URLs (the three hero links dedupe), so a home-page view issues three extra prefetches. Every destination is prerendered and `'use cache'`d with the Sanity profile, so each prefetch is a cache read, not a render — which is what the guide's "each visible link can wake a server" warning is about.
- **The ~90 sidebar links are the case the guide warns about**, and they already use the default; that asymmetry is now deliberate and documented rather than accidental.

So the five links keep `prefetch={true}`, and the markers are replaced by comments recording why.

## Verification

- `pnpm lint`, `pnpm knip`, `pnpm --filter sanity-ui-docs typecheck` and `next build` all pass; all 68 routes still prerender as `◐`.
- Driving every route and cross-section navigation in `next dev` reports **0 prerender insights**, same as before the refactor.
- The `instant()` guard from #2615 still passes on a production build.
- Parity: identical titles, sidebar/breadcrumbs presence, nav link counts, footer and status codes across `/ui`, `/ui/docs`, `/ui/arcade`, two articles and a bogus path.
- **Draft mode verified end-to-end**, since both restructured layouts have a draft branch. With draft mode enabled, `/ui`, `/ui/docs`, `/ui/docs/primitive/popover` and `/ui/arcade` all render their chrome, sidebar and article, and the headings come back stega-encoded — so Visual Editing overlays resolve. Note this needs a token with draft access: the `SANITY_API_READ_TOKEN` in the agent VM returns `Unauthorized - Session not found` for the drafts perspective, identically before and after this change, so it's an environment limitation rather than a regression.

## Open follow-up

The same measurement suggests a third option for the sidebar: keep the default `<Link>` prefetch and upgrade to a full prefetch on hover (the guide's [hover-triggered prefetch](https://nextjs.org/docs/app/guides/prefetching#hover-triggered-prefetch)). That would buy the ~750 ms saving on the link the reader actually goes to, at one prefetch per hovered link instead of ninety. Not in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

