### PR TITLE
test(docs): guard instant navigation into the docs landing screen

### DIFF
--- a/apps/docs/e2e/helpers.ts
+++ b/apps/docs/e2e/helpers.ts
@@ -16,6 +16,17 @@ export const SIDEBAR_BREAKPOINT = 600
 export const SIBLING_ARTICLE_PATH = '/ui/docs/primitive/button'
 export const ARTICLE_PATH = '/ui/docs/primitive/popover'
 
+export const HOME_PATH = '/ui'
+export const DOCS_PATH = '/ui/docs'
+
+/** The navbar link into the docs screen. */
+export function docsLink(page: Page) {
+  return page
+    .locator(`a[href="${DOCS_PATH}"]:visible`)
+    .filter({hasText: /^Docs$/})
+    .first()
+}
+
 /**
  * A synchronous node of the article chrome: the docs navigation. It comes from
  * the static docs layout, so it belongs to the prefetched route.

--- a/apps/docs/e2e/instant-docs.e2e.ts
+++ b/apps/docs/e2e/instant-docs.e2e.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression guard for instant navigation into the docs landing screen. See
+ * `instant-nav.rig.md` — only valid against a production build with the
+ * testing API exposed.
+ *
+ * Unlike the article guard, nothing on this screen is gated under the lock, so
+ * there is no skeleton to assert: `generateStaticParams` enumerates `screen`
+ * and every read behind it is cached, so the shell for this path carries the
+ * whole page — with or without a full prefetch on the link. These assertions
+ * lock that in; they go red if a request-time read (`cookies()`, `headers()`,
+ * `connection()`, an uncached fetch) or a dropped `generateStaticParams` pushes
+ * the screen back to request time.
+ *
+ * The suite's protection against a vacuous pass is `instant-nav.e2e.ts`, whose
+ * gated-half assertion fails if the build is missing the testing API.
+ */
+import {instant} from '@next/playwright'
+import {expect, test} from '@playwright/test'
+
+import {articleChrome, articleContent, DOCS_PATH, docsLink, HOME_PATH} from './helpers'
+
+test.describe('instant navigation: /ui/docs', () => {
+  test('initial load serves the whole screen', async ({page, baseURL}) => {
+    await instant(
+      page,
+      async () => {
+        await page.goto(DOCS_PATH)
+        await expect(articleChrome(page)).toBeVisible()
+        await expect(articleContent(page)).toBeVisible()
+      },
+      {baseURL},
+    )
+  })
+
+  test('the navbar link commits the whole screen', async ({page}) => {
+    await page.goto(HOME_PATH)
+    // The home page renders no article chrome, so the assertions below cannot
+    // be satisfied by what was already on screen before the click.
+    await expect(articleChrome(page)).toHaveCount(0)
+    const trigger = docsLink(page)
+    await expect(trigger).toBeVisible({timeout: 20000})
+
+    await instant(page, async () => {
+      await trigger.click()
+      await expect(articleChrome(page)).toBeVisible()
+      await expect(articleContent(page)).toBeVisible()
+    })
+
+    await expect(page).toHaveURL(new RegExp(`${DOCS_PATH}$`))
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ran the `next-cache-components-optimizer` loop on `/ui/docs`. Stacked on #2623.

**No code changes were needed — the route is already instant.** This PR ships the regression guard that says so, and nothing else.

## What the loop found

The first locked test I wrote was red, but for the wrong reason: it asserted the article slot would show its loading skeleton under the lock while the body streamed in, mirroring the article guard from #2615. Probing the DOM under the lock showed the opposite — the navbar click commits the URL, the sidebar, *and* the real `<h1>Get started with Sanity UI</h1>`. Nothing on this screen is deferred, so there is no skeleton to assert and nothing to optimize. Per the skill's C-gate, that's a red test to fix rather than a route to refactor.

The reason it's already instant: `generateStaticParams` on the `[screen]` segment enumerates `docs` and `arcade`, and every read behind the screen is cached, so the shell for this concrete path carries the whole page.

## What I checked before trusting that

- **Baseline (unlocked)**: both markers render for the initial load and after a navbar click, at desktop and mobile widths. The home page renders no article chrome, so `toHaveCount(0)` there proves the post-click assertions can't be satisfied by what was already on screen.
- **It isn't the prefetch.** I removed `prefetch={true}` from the navbar links, rebuilt, and the guard stayed green — so the shell, not the runtime prefetch, is what commits this screen. (The prefetch still matters for transport: #2623 measured 126 ms vs 879 ms click-to-content on a throttled connection. It just isn't what makes the navigation instant.)
- **The guard can fail.** Since the natural differential came up green, I mutated the route instead: adding `await connection()` to the page's route component turns all four assertions red across both projects; reverting turns them green again. So the guard genuinely catches the regression class it exists for — a request-time read or a dropped `generateStaticParams` pushing this screen back to request time.
- **Not vacuous**: the guard asserts content that is present whenever the page renders, so on its own it would pass with the testing API missing. The suite's protection is the sibling `instant-nav.e2e.ts`, whose gated-half assertion (`toHaveCount(0)` on the article body) fails if the lock isn't engaging. Both specs run together; the spec header says so.

## Result

[docs_landing_instant_navigation.mp4](https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_landing_instant_navigation.mp4)

[The docs landing page immediately after clicking Docs in the navbar](https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_landing_after_navbar_click.webp)

Clicking `Docs` from the home page paints the sidebar and the article together, with no blank frame or loading placeholder in between, twice in a row in the recording.

`pnpm lint`, `pnpm knip`, `pnpm --filter sanity-ui-docs typecheck` and `next build` all pass. The full e2e suite (both guards, both viewports) is green: 7 passed, 1 skipped — the skip is the article sidebar click below the sidebar's breakpoint, where the sidebar is collapsed behind the breadcrumbs menu. The phase-B baseline scaffold was deleted; only the locked spec ships.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

