### PR TITLE
test(docs): guard instant navigation into the home page

### DIFF
--- a/apps/docs/e2e/helpers.ts
+++ b/apps/docs/e2e/helpers.ts
@@ -77,3 +77,16 @@ export function arcadeScreen(page: Page) {
 export function arcadeFallback(page: Page) {
   return page.getByTestId('arcade-loading')
 }
+
+/** The home page hero. Not rendered on any other screen. */
+export function heroSection(page: Page) {
+  return page.locator('[data-testid="hero-section"]:visible')
+}
+
+/** The visible Sanity UI brand link back to the home page. */
+export function homeLink(page: Page) {
+  return page
+    .locator(`a[href="${HOME_PATH}"]:visible`)
+    .filter({hasText: /^Sanity UI$/})
+    .first()
+}

--- a/apps/docs/e2e/instant-home.e2e.ts
+++ b/apps/docs/e2e/instant-home.e2e.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression guard for instant navigation into the home page. See
+ * `instant-nav.rig.md` — only valid against a production build with the
+ * testing API exposed.
+ *
+ * The home page reads no URL data and every fetch behind it is cached, so its
+ * shell is the whole page: hero, headline and all. Nothing is gated under the
+ * lock, so there is no skeleton to assert — these assertions go red if a
+ * request-time read pushes any of it back to request time. The hero heading is
+ * the LCP element, which is the part that most needs to stay in the shell.
+ *
+ * The suite's protection against a vacuous pass is `instant-nav.e2e.ts`, whose
+ * gated-half assertion fails if the build is missing the testing API.
+ */
+import {instant} from '@next/playwright'
+import {expect, test} from '@playwright/test'
+
+import {articleContent, DOCS_PATH, heroSection, homeLink, HOME_PATH} from './helpers'
+
+test.describe('instant navigation: /ui', () => {
+  test('initial load serves the whole page', async ({page, baseURL}) => {
+    await instant(
+      page,
+      async () => {
+        await page.goto(HOME_PATH)
+        await expect(heroSection(page)).toBeVisible()
+        await expect(page.getByRole('heading', {level: 1})).toBeVisible()
+      },
+      {baseURL},
+    )
+  })
+
+  test('the brand link commits the whole page', async ({page}) => {
+    await page.goto(DOCS_PATH)
+    await expect(articleContent(page)).toBeVisible({timeout: 20000})
+    // The docs page renders no hero, so the assertions below cannot be
+    // satisfied by what was already on screen before the click.
+    await expect(heroSection(page)).toHaveCount(0)
+    const brand = homeLink(page)
+    await expect(brand).toBeVisible({timeout: 20000})
+
+    await instant(page, async () => {
+      await brand.click()
+      await expect(heroSection(page)).toBeVisible()
+      await expect(page.getByRole('heading', {level: 1})).toBeVisible()
+    })
+
+    await expect(page).toHaveURL(new RegExp(`${HOME_PATH}$`))
+  })
+})

--- a/apps/docs/src/components/page/sections/HeroSection.tsx
+++ b/apps/docs/src/components/page/sections/HeroSection.tsx
@@ -54,7 +54,13 @@ export function HeroSection(props: {
   const backgroundImageUrl = backgroundImagePath && `${basePath}${backgroundImagePath}`
 
   return (
-    <Root flex={1} paddingX={[3, 4, 5]} paddingY={[6, 7, 8]} style={{minHeight: 'auto'}}>
+    <Root
+      data-testid="hero-section"
+      flex={1}
+      paddingX={[3, 4, 5]}
+      paddingY={[6, 7, 8]}
+      style={{minHeight: 'auto'}}
+    >
       <BackgroundBox
         display={['none', 'none', 'block']}
         style={{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ran the `next-cache-components-optimizer` loop on `/ui`. Stacked on #2625.

**No code changes were needed — the route is already instant.** This PR ships the regression guard and the one `data-testid` it needs.

## What the loop found

`/ui` reads no URL data and every fetch behind it is cached, so its shell is the whole page. Under the lock, both an initial load and a brand-link click from a docs page commit the hero, the `<h1>`, all seven headings, the call to action, the navbar and the footer. Nothing is deferred and nothing is blank, so there was nothing to push down.

## Making the guard worth shipping

With no fix to revert, a green test proves nothing on its own, so I mutated the route to find out what it actually catches. That took three attempts and the first two are the interesting part:

1. **`await connection()` at the top of the route** — the build *fails* (`Route "/": Next.js encountered uncached or runtime data during prerendering`). This class of regression never reaches the guard, because `next build` rejects it first.
2. **Wrapping every branch in one page-level `<Suspense fallback={null}>`** — the coarse-boundary anti-pattern. Build passes, guard stays green. Not a false negative: `getDynamicFetchOptions()` returns early after `await draftMode()` when draft mode is off, and `draftMode()` alone still prerenders, so the page was never actually dynamic. The mutation didn't regress anything.
3. **`await connection()` inside that boundary** — genuinely request-time, but deferred. **The build passes and all four assertions go red.** That's the gap the guard exists for: a regression `next build` accepts but that empties the shell.

So the guard covers what the build can't: content that still compiles and still renders, but no longer arrives with the shell. It asserts the hero and the `<h1>` — the LCP element, the part that most needs to stay in the shell.

The guard asserts content that's present whenever the page renders, so on its own it would pass with the testing API missing. The suite's protection is the sibling `instant-nav.e2e.ts`, whose gated-half assertion fails if the lock isn't engaging; the spec header records that dependency.

The soft-nav spec starts on `/ui/docs`, which renders no hero, and asserts `toHaveCount(0)` there first — so the post-click assertions can't be satisfied by what was already on screen.

## Result

[home_instant_navigation.mp4](https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_instant_navigation.mp4)

[The home page hero immediately after clicking the Sanity UI brand link](https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_hero_after_brand_click.webp)

Clicking the brand link from a docs article paints the hero immediately, twice in a row in the recording, with no blank frame or loading placeholder.

`pnpm lint`, `pnpm knip`, `pnpm --filter sanity-ui-docs typecheck` and `next build` all pass. Full suite: 17 passed, 1 skipped — the skip is the article sidebar click below the sidebar breakpoint, where the sidebar is collapsed behind the breadcrumbs menu. The phase-B baseline scaffold was deleted; only the locked spec ships.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5f0c0e0-040d-4900-a48c-b423fdd7ac9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

