### PR TITLE
fix: swap columnGap and rowGap in codemods

### DIFF
--- a/.changeset/many-towns-grab.md
+++ b/.changeset/many-towns-grab.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui-codemod': patch
+---
+
+fix: swap columnGap and rowGap mods

--- a/packages/ui-codemod/src/constants/latest/layout-mods.ts
+++ b/packages/ui-codemod/src/constants/latest/layout-mods.ts
@@ -143,11 +143,11 @@ export const LAYOUT_MODS: AttributeMods = {
   },
   gapX: {
     type: 'rename-only',
-    name: 'rowGap',
+    name: 'columnGap',
   },
   gapY: {
     type: 'rename-only',
-    name: 'columnGap',
+    name: 'rowGap',
   },
   gridColumn: {
     type: 'mapped-only',

--- a/packages/ui-codemod/src/transforms/latest/card/card.mods.ts
+++ b/packages/ui-codemod/src/transforms/latest/card/card.mods.ts
@@ -163,7 +163,7 @@ export const CARD_MODS: AttributeMods = {
   },
   gapX: {
     type: 'style-mapped',
-    style: 'rowGap',
+    style: 'columnGap',
     mapping: {
       0: 'var(--space-0)',
       1: 'var(--space-1)',
@@ -179,7 +179,7 @@ export const CARD_MODS: AttributeMods = {
   },
   gapY: {
     type: 'style-mapped',
-    style: 'columnGap',
+    style: 'rowGap',
     mapping: {
       0: 'var(--space-0)',
       1: 'var(--space-1)',


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Currently, the codemods rename `gapX` to `rowGap` and `gapY` to `columnGap`. These should be swapped since `gapX` is the space between columns and `gapY` is the space between rows. This PR fixes that.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the new names look correct.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small mapping fix in codemod config only; improves migration output with no runtime library behavior change.
> 
> **Overview**
> Corrects **`@sanity/ui-codemod`** migrations that mapped **`gapX`** and **`gapY`** to the wrong CSS gap properties.
> 
> **`gapX`** now targets **`columnGap`** (horizontal spacing between columns) and **`gapY`** targets **`rowGap`** (vertical spacing between rows), in both shared layout rename mods (`layout-mods.ts`) and Card style-mapped mods (`card.mods.ts`). A patch changeset is included for the package release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce87e5f5360fb4f42a62ec742f216bba9ce5885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->