### PR TITLE
chore: skip v3 and v4 vercel checks

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "exit 0"
+}

--- a/apps/icons/vercel.json
+++ b/apps/icons/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "exit 0"
+}

--- a/apps/storybook/vercel.json
+++ b/apps/storybook/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "exit 0"
+}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR suppresses the Vercel checks in the icons, docs, and Storybook apps. We may eventually want to re-add Storybook but it might also be possible to use Chromatic instead.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the json files are in the right spots.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

No checks should fail on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deployment-only configuration with no runtime or application logic changes.
> 
> **Overview**
> Adds a **`vercel.json`** in **`apps/docs`**, **`apps/icons`**, and **`apps/storybook`** with **`ignoreCommand": "exit 0"`**, so Vercel always treats those projects as “ignored” and does not run their usual build/deploy checks on PRs.
> 
> This matches the goal of turning off v3/v4 Vercel checks for those apps; Storybook might be re-enabled later or replaced with Chromatic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb90464f9e933a3932cbd853708fdfc49c7c7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->