### PR TITLE
fix: reduce specificity of reset element selectors

### DIFF
--- a/.changeset/fresh-impalas-fly.md
+++ b/.changeset/fresh-impalas-fly.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui': patch
+---
+
+fix: reduce specificity of element selectors in CSS reset to 0,0,0

--- a/packages/ui/src/css/global/reset.css
+++ b/packages/ui/src/css/global/reset.css
@@ -17,46 +17,48 @@
 }
 
 /* Prevent adjustments of font size after orientation changes in iOS. */
-html {
+:where(html) {
   -webkit-text-size-adjust: 100%;
 }
 
-body {
+:where(body) {
   background: light-dark(var(--white), var(--black));
   font-family: var(--sans);
   -webkit-font-smoothing: antialiased;
 }
 
 /* Display multimedia as block by default */
-audio,
-canvas,
-embed,
-iframe,
-img,
-object,
-picture,
-video {
+:where(
+  audio,
+  canvas,
+  embed,
+  iframe,
+  img,
+  object,
+  picture,
+  video
+){
   display: block;
   max-width: 100%;
 }
-img,
-picture,
-video {
+:where(img, picture, video) {
   block-size: auto;
 }
 
 /* Inherit typography in form controls */
-button,
-input,
-select,
-textarea {
+:where(
+  button,
+  input,
+  select,
+  textarea
+) {
   font: inherit;
   line-height: inherit;
   color: inherit;
 }
 
 /* Remove excess space for table borders */
-table {
+:where(table) {
   border-collapse: collapse;
   border-spacing: 0;
 }


### PR DESCRIPTION
### Description

Reduces the specificity of CSS resets for element selectors by moving them into `:where()` selector lists. This drops the specificity of each rule to `0,0,0`, so they can now easily be overridden by user styles while still resetting user agent defaults.

Note: this won't fix instances like those reported recently by Rupert on Media Library, since he was referring to styles attached to wildcard selectors, which are already 0 specificity (and because in his case, the styles being overridden were in a layer initialized before the UI5 styles).

### What to review

Did I type `:where(…)` properly and move the right selectors in? ;)

### Testing

I ran through a number of components in our Storybook to ensure the expected resets are still kicking in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS specificity tweak in the global reset with no logic changes; Storybook spot-checks per author, with minor risk of unexpected styling if something relied on reset winning over single-class overrides.
> 
> **Overview**
> **Global CSS reset** in `@sanity/ui` now wraps type/element selectors (`html`, `body`, media elements, form controls, `table`) in **`:where()`**, so those rules sit at **0,0,0 specificity** instead of matching as plain element selectors.
> 
> Reset behavior is unchanged; **consumer and app styles can override these defaults more easily** without fighting higher-specificity resets. Universal `*`, `:root`, and `prefers-reduced-motion` rules are left as-is.
> 
> Patch release noted in changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f58286b1d843c35ab040c212ab58c23a147beec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->