### PR TITLE
fix: remove overflow:hidden on untruncated typography components

### DIFF
--- a/.changeset/twenty-chefs-sleep.md
+++ b/.changeset/twenty-chefs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui': patch
+---
+
+fix: remove hidden overflow on untruncated typography components

--- a/apps/storybook/src/stories/Text.stories.tsx
+++ b/apps/storybook/src/stories/Text.stories.tsx
@@ -81,6 +81,28 @@ export const Tones: Story = {
   },
 }
 
+export const Trim: Story = {
+  render: (props) => {
+    return (
+      <>
+        <Text trim {...props}>
+          Trimmed text
+        </Text>
+        <Text trim {...props}>
+          More trimmed text
+        </Text>
+      </>
+    )
+  },
+  play: async ({canvas}) => {
+    await expect((await canvas.findByText(/Trimmed text/)).classList).toContain('sui-text-trim')
+
+    await expect(
+      (await canvas.findByText(/Lorem ipsum dolor sit amet/)).parentElement?.classList,
+    ).toContain('sui-text-trim')
+  },
+}
+
 export const TrimTruncate: Story = {
   name: 'Trim & Truncate',
   render: (props) => {
@@ -118,6 +140,33 @@ export const TrimTruncateOneLine: Story = {
     await expect((await canvas.findByText(/Lorem ipsum dolor sit amet/)).classList).toContain(
       'sui-text-overflow',
     )
+
+    await expect(
+      (await canvas.findByText(/Lorem ipsum dolor sit amet/)).parentElement?.classList,
+    ).toContain('sui-text-trim')
+  },
+}
+
+export const Truncate: Story = {
+  render: (props) => {
+    return (
+      <>
+        <Text truncate={1} {...props}>
+          One line truncation lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+          nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Text>
+        <br />
+        <Text truncate={3} {...props}>
+          Multiline truncation lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+          nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Text>
+      </>
+    )
+  },
+  play: async ({canvas}) => {
+    await expect((await canvas.findByText(/Trimmed text/)).classList).toContain('sui-text-trim')
 
     await expect(
       (await canvas.findByText(/Lorem ipsum dolor sit amet/)).parentElement?.classList,

--- a/apps/storybook/src/stories/Text.stories.tsx
+++ b/apps/storybook/src/stories/Text.stories.tsx
@@ -96,10 +96,6 @@ export const Trim: Story = {
   },
   play: async ({canvas}) => {
     await expect((await canvas.findByText(/Trimmed text/)).classList).toContain('sui-text-trim')
-
-    await expect(
-      (await canvas.findByText(/Lorem ipsum dolor sit amet/)).parentElement?.classList,
-    ).toContain('sui-text-trim')
   },
 }
 
@@ -166,10 +162,12 @@ export const Truncate: Story = {
     )
   },
   play: async ({canvas}) => {
-    await expect((await canvas.findByText(/Trimmed text/)).classList).toContain('sui-text-trim')
+    await expect((await canvas.findByText(/One line truncation/)).classList).toContain(
+      'sui-text-overflow',
+    )
 
-    await expect(
-      (await canvas.findByText(/Lorem ipsum dolor sit amet/)).parentElement?.classList,
-    ).toContain('sui-text-trim')
+    await expect((await canvas.findByText(/Multiline truncation/)).classList).toContain(
+      'sui-line-clamp',
+    )
   },
 }

--- a/packages/ui/src/components/eyebrow/Eyebrow.tsx
+++ b/packages/ui/src/components/eyebrow/Eyebrow.tsx
@@ -41,7 +41,7 @@ export function Eyebrow<T extends ElementType = 'span'>({
 
   return (
     <Component
-      className={clsx(eyebrowClassName, className)}
+      className={clsx(eyebrowClassName, props.truncate && 'sui-overflow-hidden', className)}
       style={style}
       data-ui="Eyebrow"
       {...rest}

--- a/packages/ui/src/components/eyebrow/Eyebrow.tsx
+++ b/packages/ui/src/components/eyebrow/Eyebrow.tsx
@@ -41,7 +41,7 @@ export function Eyebrow<T extends ElementType = 'span'>({
 
   return (
     <Component
-      className={clsx(eyebrowClassName, 'sui-overflow-hidden', className)}
+      className={clsx(eyebrowClassName, className)}
       style={style}
       data-ui="Eyebrow"
       {...rest}

--- a/packages/ui/src/components/heading/Heading.tsx
+++ b/packages/ui/src/components/heading/Heading.tsx
@@ -41,7 +41,7 @@ export function Heading<T extends ElementType = 'h2'>({
 
   return (
     <Component
-      className={clsx(headingClassName, 'sui-overflow-hidden', className)}
+      className={clsx(headingClassName, className)}
       style={style}
       data-ui="Heading"
       {...rest}

--- a/packages/ui/src/components/heading/Heading.tsx
+++ b/packages/ui/src/components/heading/Heading.tsx
@@ -41,7 +41,7 @@ export function Heading<T extends ElementType = 'h2'>({
 
   return (
     <Component
-      className={clsx(headingClassName, className)}
+      className={clsx(headingClassName, props.truncate && 'sui-overflow-hidden', className)}
       style={style}
       data-ui="Heading"
       {...rest}

--- a/packages/ui/src/components/text/Text.tsx
+++ b/packages/ui/src/components/text/Text.tsx
@@ -39,12 +39,7 @@ export function Text<T extends ElementType = 'span'>({
   }
 
   return (
-    <Component
-      className={clsx(textClassName, 'sui-overflow-hidden', className)}
-      style={style}
-      data-ui="Text"
-      {...rest}
-    >
+    <Component className={clsx(textClassName, className)} style={style} data-ui="Text" {...rest}>
       {children}
     </Component>
   )

--- a/packages/ui/src/components/text/Text.tsx
+++ b/packages/ui/src/components/text/Text.tsx
@@ -39,7 +39,12 @@ export function Text<T extends ElementType = 'span'>({
   }
 
   return (
-    <Component className={clsx(textClassName, className)} style={style} data-ui="Text" {...rest}>
+    <Component
+      className={clsx(textClassName, props.truncate && 'sui-overflow-hidden', className)}
+      style={style}
+      data-ui="Text"
+      {...rest}
+    >
       {children}
     </Component>
   )


### PR DESCRIPTION
### Description

`overflow: hidden` styles were accidentally added unconditionally to untruncated text components in a previous PR. This PR updates those instances to only hide overflow when the truncate prop is used.

### What to review

Did I do a good delete? 😄 

### Testing

- Ensured no more instances of the `'sui-overflow-hidden, className'` pattern were found in the codebase
- Added stories for standalone `trim` and `truncate` usage for Text
- Verified fix in component stories


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional className change in typography with no auth, data, or API impact; behavior improves for the common non-truncate case.
> 
> **Overview**
> Fixes a regression where **`Text`**, **`Heading`**, and **`Eyebrow`** always applied `sui-overflow-hidden` on their default render path, which could clip content when `truncate` was not used.
> 
> **`sui-overflow-hidden`** is now applied only when the **`truncate`** prop is truthy on that path; the trim+truncate inner-span behavior is unchanged. Storybook gains **`Trim`** and **`Truncate`** stories with play assertions for trim and overflow/line-clamp classes, and a patch changeset for `@sanity/ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faacd1fc3e6e641b1c130b75f834ed9563a32ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->