### PR TITLE
build(ui): generate the styles.css export with vanillaExtract nodeCompat

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,11 +38,14 @@
     "./theme": "./src/exports/theme.ts",
     "./toast": "./src/exports/toast.ts",
     "./tooltip": "./src/exports/tooltip.ts",
-    "./package.json": "./package.json",
     "./styles.css": {
-      "types": "./src/exports/styles.ts",
-      "default": "./dist/styles.css"
-    }
+      "types": "./dist/styles-css.d.ts",
+      "browser": "./dist/styles.css",
+      "style": "./dist/styles.css",
+      "node": "./dist/styles-css.js",
+      "default": "./dist/styles-css.js"
+    },
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "exports": {
@@ -55,11 +58,14 @@
       "./theme": "./dist/theme.js",
       "./toast": "./dist/toast.js",
       "./tooltip": "./dist/tooltip.js",
-      "./package.json": "./package.json",
       "./styles.css": {
-        "types": "./dist/styles.d.ts",
-        "default": "./dist/styles.css"
-      }
+        "types": "./dist/styles-css.d.ts",
+        "browser": "./dist/styles.css",
+        "style": "./dist/styles.css",
+        "node": "./dist/styles-css.js",
+        "default": "./dist/styles-css.js"
+      },
+      "./package.json": "./package.json"
     }
   },
   "scripts": {

--- a/packages/ui/src/exports/styles.ts
+++ b/packages/ui/src/exports/styles.ts
@@ -1,4 +1,0 @@
-// Type-only entry point for `@sanity/ui/styles.css`.
-const styles: void = undefined
-
-export default styles

--- a/packages/ui/tsdown.config.mts
+++ b/packages/ui/tsdown.config.mts
@@ -16,27 +16,24 @@ const config: UserConfig = await defineConfig({
   entry: {
     '*': './src/exports/*.{ts,tsx}',
   },
-  // `src/exports/styles.ts` emits the declaration for the CSS export, but its
-  // JavaScript output is not a separate public `@sanity/ui/styles` entry point.
-  exports: {
-    exclude: ['styles'],
-    customExports: (packageExports, {isPublish}) => ({
-      ...packageExports,
-      './styles.css': {
-        types: isPublish ? './dist/styles.d.ts' : './src/exports/styles.ts',
-        default: './dist/styles.css',
-      },
-    }),
-  },
   tsconfig: 'tsconfig.dist.json',
   styledComponents: true,
   reactCompiler: {target: '19'},
   // Extract vanilla-extract `.css.ts` styles into dist/styles.css. Unlike the
-  // default (`inject: {nodeCompat: true}`, which self-imports
-  // `@sanity/ui/bundle.css` from every entry), `inject: false` leaves loading
-  // the stylesheet to the consumer: `import '@sanity/ui/styles.css'` — the
-  // same file name and consumer contract as the vanilla-extract based
-  // successor of this library, to minimize churn when upgrading later.
+  // default (`inject: true`, which self-imports `@sanity/ui/styles.css` from
+  // every entry), `inject: false` leaves loading the stylesheet to the
+  // consumer: `import '@sanity/ui/styles.css'` — the same file name and
+  // consumer contract as the vanilla-extract based successor of this library,
+  // to minimize churn when upgrading later.
+  //
+  // `exports: {nodeCompat: true}` (the default, spelled out because it carries
+  // the whole consumer contract while `inject` is off) publishes the
+  // stylesheet as the `./styles.css` subpath through a conditional export: the
+  // `browser`/`style` conditions resolve to `dist/styles.css`, while
+  // `node`/`default` resolve to a generated no-op `dist/styles-css.js` shim
+  // (with `dist/styles-css.d.ts` for `types`). Runtimes that cannot load CSS —
+  // plain `node`, SSR test runners, RSC bundlers — therefore import a valid
+  // module instead of throwing on the stylesheet.
   //
   // `minify: false` keeps the output readable so CSS diffs between published
   // versions are easy to eval. The lightningcss pass still runs with the
@@ -46,7 +43,12 @@ const config: UserConfig = await defineConfig({
   // (e.g. an authored `overflow: hidden` fallback before `overflow: clip`
   // ships as just `overflow: clip` — fine, since `overflow: clip` is
   // Baseline).
-  vanillaExtract: {fileName: 'styles.css', inject: false, minify: false},
+  vanillaExtract: {
+    fileName: 'styles.css',
+    inject: false,
+    exports: {nodeCompat: true},
+    minify: false,
+  },
 })
 
 export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ catalogs:
       specifier: ^0.24.0
       version: 0.24.0
     '@sanity/vanilla-extract-vite-plugin':
-      specifier: ^0.2.8
+      specifier: ^0.2.11
       version: 0.2.11
     '@types/node':
       specifier: ^24.13.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   '@sanity/client': ^7.26.2
   '@sanity/functions': ^1.6.0
   '@sanity/tsdown-config': ^0.24.0
-  '@sanity/vanilla-extract-vite-plugin': ^0.2.8
+  '@sanity/vanilla-extract-vite-plugin': ^0.2.11
   '@types/node': ^24.13.3
   '@types/react': ^19.2.18
   '@types/react-dom': ^19.2.4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Replaces the hand-written `@sanity/ui/styles.css` shim with the one `@sanity/vanilla-extract-tsdown-plugin` generates through `vanillaExtract.exports.nodeCompat`.

- Deletes `packages/ui/src/exports/styles.ts` (the type-only entry point that only existed to give the CSS export a `types` target).
- Drops the `exports.exclude: ['styles']` / `exports.customExports` wiring from `packages/ui/tsdown.config.mts`.
- Spells out `vanillaExtract.exports = {nodeCompat: true}` next to the existing `inject: false`, since that option now carries the whole consumer contract.
- Commits the regenerated `packages/ui/package.json` export map.
- Bumps the `@sanity/vanilla-extract-vite-plugin` catalog range to `^0.2.11`.

## Why

`@sanity/ui/styles.css` used to be published as a plain `"./styles.css": {"types": ..., "default": "./dist/styles.css"}` export. That resolves to a stylesheet under every condition, so any runtime that cannot load CSS — plain `node`, SSR test runners, RSC bundlers — throws `ERR_UNKNOWN_FILE_EXTENSION` on the import that the 4.0 migration guide tells everyone to add.

`nodeCompat` makes the export conditional instead: `browser`/`style` point at `dist/styles.css`, `node`/`default` point at a generated no-op `dist/styles-css.js`, and `types` points at `dist/styles-css.d.ts`.

```jsonc
"./styles.css": {
  "types": "./dist/styles-css.d.ts",
  "browser": "./dist/styles.css",
  "style": "./dist/styles.css",
  "node": "./dist/styles-css.js",
  "default": "./dist/styles-css.js"
}
```

## Dependency bumps

`@sanity/tsdown-config` (`0.24.0`), `tsdown` (`0.22.14`), `@sanity/vanilla-extract-vite-plugin` (`0.2.11`), and `@vanilla-extract/css` (`1.21.2`) were already resolved to the newest published releases in `pnpm-lock.yaml`, so no upgrade was needed to reach the `exports.nodeCompat` option — `@sanity/tsdown-config@0.24.0` already defaults `vanillaExtract.exports` to `{nodeCompat: true}`. Only the `@sanity/vanilla-extract-vite-plugin` catalog range was stale relative to the lockfile, and it is bumped here.

A side effect worth calling out: because the installed toolchain already defaulted to `nodeCompat`, the plugin's `customExports` wrapper was already overriding the hand-written one on every build. The committed `packages/ui/package.json` had drifted from what `pnpm build` produces; this PR commits the regenerated map.

## Verification

Packed the tarball and resolved the subpath from a real Node consumer, with the old export shape patched back in for the before case:

```
--- old export shape (plain ./dist/styles.css) in node ---
ERR_UNKNOWN_FILE_EXTENSION: Unknown file extension ".css" for .../@sanity/ui/dist/styles.css

--- new export shape in node ---
resolve (node): file:///.../@sanity/ui/dist/styles-css.js
esm import: OK
require.resolve: /.../@sanity/ui/dist/styles-css.js
cjs require: OK
```

Bundler-facing resolution is unchanged:

```
--- with --conditions=browser (what a bundler sees) ---
resolved: file:///.../@sanity/ui/dist/styles.css
```

`import '@sanity/ui/styles.css'` type-checks under `moduleResolution` `bundler`, `node16` and `nodenext`; `publint` reports no issues and `attw` rates the `styles.css` subpath the same as every other subpath. `pnpm build` and `pnpm lint` pass, and `dist/styles.css` is byte-identical to the previous build.

No changeset: the `@sanity/ui/styles.css` export is introduced by the unreleased 4.0 major (`.changeset/ui-4.md`), so this only changes how that not-yet-published export is shaped.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-111f22fe-d8da-45af-8e66-903650db70e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-111f22fe-d8da-45af-8e66-903650db70e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

