### PR TITLE
fix: box/flex/grid default min-width and min-height

### DIFF
--- a/.changeset/curly-trams-feel.md
+++ b/.changeset/curly-trams-feel.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui': patch
+---
+
+add default min-height and min-width to box/flex/grid

--- a/packages/ui/src/components/box/Box.tsx
+++ b/packages/ui/src/components/box/Box.tsx
@@ -10,9 +10,14 @@ const boxClassName = suffixClassName('sui-Box')
 /** @public */
 export function Box<T extends ElementType = 'div'>({
   display = 'block',
+  minHeight = '0',
+  minWidth = '0',
   ...props
 }: BoxProps<T> & Omit<ComponentPropsWithRef<T>, keyof BoxProps<T>>) {
-  const {as, children, className, style, ...rest} = getProps({display, ...props}, boxProps)
+  const {as, children, className, style, ...rest} = getProps(
+    {display, minHeight, minWidth, ...props},
+    boxProps,
+  )
   const Component = as || 'div'
 
   return (

--- a/packages/ui/src/components/flex/Flex.tsx
+++ b/packages/ui/src/components/flex/Flex.tsx
@@ -10,9 +10,14 @@ const flexClassName = suffixClassName('sui-Flex')
 /** @public */
 export function Flex<T extends ElementType = 'div'>({
   display = 'flex',
+  minHeight = '0',
+  minWidth = '0',
   ...props
 }: FlexProps<T> & Omit<ComponentPropsWithRef<T>, keyof FlexProps<T>>) {
-  const {as, children, className, style, ...rest} = getProps({display, ...props}, flexProps)
+  const {as, children, className, style, ...rest} = getProps(
+    {display, minHeight, minWidth, ...props},
+    flexProps,
+  )
   const Component = as || 'div'
 
   return (

--- a/packages/ui/src/components/grid/Grid.tsx
+++ b/packages/ui/src/components/grid/Grid.tsx
@@ -10,9 +10,14 @@ const gridClassName = suffixClassName('sui-Grid')
 /** @public */
 export function Grid<T extends ElementType = 'div'>({
   display = 'grid',
+  minHeight = '0',
+  minWidth = '0',
   ...props
 }: GridProps<T> & Omit<ComponentPropsWithRef<T>, keyof GridProps<T>>) {
-  const {as, children, className, style, ...rest} = getProps({display, ...props}, gridProps)
+  const {as, children, className, style, ...rest} = getProps(
+    {display, minHeight, minWidth, ...props},
+    gridProps,
+  )
   const Component = as || 'div'
 
   return (


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds default `min-height: 0` and `min-width: 0` to the Box, Flex, and Grid components to match v3 and v4.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the default props make sense on those components.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I checked that the components had `min-height` and `min-width` styling set by default and that I could still override it by setting the props.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small default-style change on layout primitives; overrides remain possible, with possible minor visual/layout shifts where defaults were relied on implicitly.
> 
> **Overview**
> **`Box`**, **`Flex`**, and **`Grid`** now default **`minHeight`** and **`minWidth`** to **`'0'`**, wired through **`getProps`** so the layout props apply the same way as other sizing defaults. This restores behavior from **v3/v4** and helps nested flex/grid layouts shrink and scroll instead of overflowing when min sizes would otherwise stay at **`auto`**.
> 
> Consumers can still override both props explicitly. The change is released as a **patch** on **`@sanity/ui`** via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad37974282cc2adc9f269d3aace5a20c690cd0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->