### PR TITLE
fix(ui): unset max-width on inline typography SVGs

### DIFF
--- a/.changeset/svg-inline-max-width.md
+++ b/.changeset/svg-inline-max-width.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Unset `max-width` on inline SVGs in `Text`, `Label`, `Heading`, and `Code` so CSS resets that set `max-width: 100%` no longer squash icons.

--- a/packages/ui/src/core/primitives/code/styles.ts
+++ b/packages/ui/src/core/primitives/code/styles.ts
@@ -69,6 +69,8 @@ export function codeBaseStyle(): ReturnType<typeof css> {
       /* Certain popular CSS libraries changes the defaults for SVG display */
       /* Make sure SVGs are rendered as inline elements */
       display: inline;
+      /* ...and aren't squeezed by resets that set max-width: 100% */
+      max-width: unset;
     }
 
     & [data-sanity-icon] {

--- a/packages/ui/src/core/primitives/heading/styles.ts
+++ b/packages/ui/src/core/primitives/heading/styles.ts
@@ -59,6 +59,8 @@ export function headingBaseStyle(props: HeadingStyleProps & ThemeProps): ReturnT
       /* Certain popular CSS libraries changes the defaults for SVG display */
       /* Make sure SVGs are rendered as inline elements */
       display: inline;
+      /* ...and aren't squeezed by resets that set max-width: 100% */
+      max-width: unset;
     }
 
     & [data-sanity-icon] {

--- a/packages/ui/src/core/primitives/label/styles.ts
+++ b/packages/ui/src/core/primitives/label/styles.ts
@@ -40,6 +40,8 @@ export function labelBaseStyle(
       /* Certain popular CSS libraries changes the defaults for SVG display */
       /* Make sure SVGs are rendered as inline elements */
       display: inline;
+      /* ...and aren't squeezed by resets that set max-width: 100% */
+      max-width: unset;
     }
 
     & [data-sanity-icon] {

--- a/packages/ui/src/core/primitives/svgInlineReset.test.ts
+++ b/packages/ui/src/core/primitives/svgInlineReset.test.ts
@@ -1,0 +1,34 @@
+/** @vitest-environment node */
+
+import {describe, expect, it} from 'vitest'
+
+import {buildTheme} from '../../theme/build/buildTheme'
+import {getScopedTheme} from '../../theme/getScopedTheme'
+import {codeBaseStyle} from './code/styles'
+import {headingBaseStyle} from './heading/styles'
+import {labelBaseStyle} from './label/styles'
+import {textBaseStyle} from './text/styles'
+
+const theme = getScopedTheme(buildTheme(), 'light', 'default')
+
+function flattenCss(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return value.map(flattenCss).join('')
+  return ''
+}
+
+describe('typography SVG reset', () => {
+  it('unsets max-width wherever SVG display is forced to inline', () => {
+    const snippets = [
+      flattenCss(textBaseStyle({theme, $muted: false})),
+      flattenCss(labelBaseStyle({theme, $muted: false})),
+      flattenCss(headingBaseStyle({$accent: false, $muted: false, theme})),
+      flattenCss(codeBaseStyle()),
+    ]
+
+    for (const css of snippets) {
+      expect(css).toContain('display: inline')
+      expect(css).toContain('max-width: unset')
+    }
+  })
+})

--- a/packages/ui/src/core/primitives/text/styles.ts
+++ b/packages/ui/src/core/primitives/text/styles.ts
@@ -64,6 +64,8 @@ export function textBaseStyle(
       /* Certain popular CSS libraries changes the defaults for SVG display */
       /* Make sure SVGs are rendered as inline elements */
       display: inline;
+      /* ...and aren't squeezed by resets that set max-width: 100% */
+      max-width: unset;
     }
 
     & [data-sanity-icon] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Text`, `Label`, `Heading`, and `Code` already force nested SVGs to `display: inline` so CSS resets (Tailwind Preflight, Josh Comeau’s reset, etc.) don’t turn icons into block boxes.

Those same resets often also set `max-width: 100%` on `svg`. Inside shrink-to-fit UI — notably `@sanity/visual-editing` overlay pills like “Home page” — that percentage resolves against an indefinite containing block, so the icon collapses into a thin sliver instead of staying `1em × 1em`.

## Change

Wherever we set `display: inline` on those typography SVGs, also set `max-width: unset` so icons keep their intrinsic size.

A unit test asserts all four style helpers emit both declarations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d57ae529-8425-46f7-9651-36c722fd13a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d57ae529-8425-46f7-9651-36c722fd13a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

