### PR TITLE
Add no-op expire-tags placeholder for leftover callers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,9 @@ Standard scripts live in the root `package.json` (`lint`, `test`, `build`,
   transpiles it via `transpilePackages` in `apps/docs/next.config.ts`. It is
   deployed via Vercel, not released through Changesets.
 - `apps/docs` is fully static (DS-276): it fetches nothing from Sanity at
-  runtime and needs no environment variables. Every URL is its own `page.tsx`
+  runtime and needs no environment variables. A no-op `POST /ui/api/expire-tags`
+  placeholder remains so leftover callers of the old revalidation endpoint
+  don't 404. Every URL is its own `page.tsx`
   under `apps/docs/src/app/(website)/`, and the nav tree mirrors the route
   file structure — each route folder has a colocated `nav.ts` (title, order,
   display flags) collected with Turbopack's `import.meta.glob` in

--- a/apps/blueprints/docs/README.md
+++ b/apps/blueprints/docs/README.md
@@ -24,9 +24,11 @@ for the agent actions to work.
 The blueprint used to also deploy an `invalidate-sync-tags` function that
 forwarded sync tag invalidation events to the docs deployment's
 `/ui/api/expire-tags` endpoint. The docs app (`apps/docs`) is fully static now
-— it doesn't fetch from Sanity at all — so both the function and the endpoint
-are gone. The `EXPIRE_TAGS_SECRET` env vars (on the deployed function and the
-docs Vercel project) are no longer used and can be deleted.
+— it doesn't fetch from Sanity at all — so the function is gone. The endpoint
+remains as a no-op that returns `{service: 'sanity-ui-docs', tags}` so leftover
+callers don't spike error rates. The `EXPIRE_TAGS_SECRET` env vars (on the
+deployed function and the docs Vercel project) are no longer used and can be
+deleted.
 
 ## Deploys
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -7,7 +7,9 @@ repository (with its full git history). It is linted by the root oxlint config
 formatted by the root oxfmt configuration (`pnpm format` at the repo root).
 
 The site is fully static: it fetches nothing from Sanity at runtime (no
-`@sanity/client`, no Sanity Live) and needs no environment variables.
+`@sanity/client`, no Sanity Live) and needs no environment variables. A no-op
+`POST /ui/api/expire-tags` route remains so leftover callers of the pre-static
+revalidation endpoint still get a 200 JSON response.
 
 ## Content lives in code
 

--- a/apps/docs/src/app/api/expire-tags/route.test.ts
+++ b/apps/docs/src/app/api/expire-tags/route.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'vitest'
+
+import {POST} from './route'
+
+function post(init?: RequestInit & {url?: string}) {
+  const {url = 'https://www.sanity.io/ui/api/expire-tags', ...requestInit} = init ?? {}
+  return POST(new Request(url, {method: 'POST', ...requestInit}))
+}
+
+describe('POST /api/expire-tags', () => {
+  it('echoes tags from a JSON body and does not require a secret', async () => {
+    const response = await post({
+      body: JSON.stringify({secret: 'unused', tags: ['s1:abc', 's1:def']}),
+      headers: {'Content-Type': 'application/json'},
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      service: 'sanity-ui-docs',
+      tags: ['s1:abc', 's1:def'],
+    })
+  })
+
+  it('echoes tags from query params', async () => {
+    const response = await post({
+      url: 'https://www.sanity.io/ui/api/expire-tags?tag=s1:abc&tag=s1:def',
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      service: 'sanity-ui-docs',
+      tags: ['s1:abc', 's1:def'],
+    })
+  })
+
+  it('returns an empty tags list when the body is missing or invalid', async () => {
+    const empty = await post()
+    expect(empty.status).toBe(200)
+    expect(await empty.json()).toEqual({service: 'sanity-ui-docs', tags: []})
+
+    const invalid = await post({
+      body: 'not-json',
+      headers: {'Content-Type': 'application/json'},
+    })
+    expect(invalid.status).toBe(200)
+    expect(await invalid.json()).toEqual({service: 'sanity-ui-docs', tags: []})
+  })
+})

--- a/apps/docs/src/app/api/expire-tags/route.test.ts
+++ b/apps/docs/src/app/api/expire-tags/route.test.ts
@@ -7,7 +7,7 @@ function post(init?: RequestInit & {url?: string}) {
   return POST(new Request(url, {method: 'POST', ...requestInit}))
 }
 
-describe('POST /api/expire-tags', () => {
+describe('/api/expire-tags', () => {
   it('echoes tags from a JSON body and does not require a secret', async () => {
     const response = await post({
       body: JSON.stringify({secret: 'unused', tags: ['s1:abc', 's1:def']}),

--- a/apps/docs/src/app/api/expire-tags/route.test.ts
+++ b/apps/docs/src/app/api/expire-tags/route.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {POST} from './route'
+import {GET, POST} from './route'
 
 function post(init?: RequestInit & {url?: string}) {
   const {url = 'https://www.sanity.io/ui/api/expire-tags', ...requestInit} = init ?? {}
@@ -44,5 +44,14 @@ describe('POST /api/expire-tags', () => {
     })
     expect(invalid.status).toBe(200)
     expect(await invalid.json()).toEqual({service: 'sanity-ui-docs', tags: []})
+  })
+
+  it('also 200s GET so redirected POSTs do not 405', async () => {
+    const response = await GET(
+      new Request('https://www.sanity.io/ui/api/expire-tags?tag=s1:abc', {method: 'GET'}),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({service: 'sanity-ui-docs', tags: ['s1:abc']})
   })
 })

--- a/apps/docs/src/app/api/expire-tags/route.ts
+++ b/apps/docs/src/app/api/expire-tags/route.ts
@@ -1,0 +1,28 @@
+/**
+ * No-op placeholder for leftover callers of the pre-DS-276 revalidation
+ * endpoint. The docs app is fully static now, so there is nothing to expire —
+ * we still 200 so deployed callers don't spike error rates.
+ */
+export async function POST(request: Request) {
+  const url = new URL(request.url)
+  let tags = url.searchParams.getAll('tag')
+
+  if (tags.length === 0) {
+    try {
+      const body: unknown = await request.json()
+      if (
+        body &&
+        typeof body === 'object' &&
+        'tags' in body &&
+        Array.isArray(body.tags) &&
+        body.tags.every((tag) => typeof tag === 'string')
+      ) {
+        tags = body.tags
+      }
+    } catch {
+      // no valid JSON body
+    }
+  }
+
+  return Response.json({service: 'sanity-ui-docs', tags})
+}

--- a/apps/docs/src/app/api/expire-tags/route.ts
+++ b/apps/docs/src/app/api/expire-tags/route.ts
@@ -26,3 +26,6 @@ export async function POST(request: Request) {
 
   return Response.json({service: 'sanity-ui-docs', tags})
 }
+
+// Apex 301s would downgrade POST to GET; still 200 so those don't count as errors.
+export const GET = POST


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#2704 made `apps/docs` fully static and removed `POST /ui/api/expire-tags`. Anything still calling that URL (for example a not-yet-undeployed `invalidate-sync-tags` function) would 404 and show up in error rates.

## What

Restore `apps/docs/src/app/api/expire-tags/route.ts` as a no-op:

- Always returns `200` with `{service: 'sanity-ui-docs', tags}`
- Echoes `tags` from the JSON body or `?tag=` query params
- Does not require `EXPIRE_TAGS_SECRET` and does not call `revalidateTag`
- `GET` is aliased to the same handler so apex 301s that downgrade POST to GET also 200

Docs in `apps/docs`, `apps/blueprints/docs`, and `AGENTS.md` now describe the placeholder instead of saying the endpoint is gone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c0ce7b2-4261-4495-8827-540f37da455b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c0ce7b2-4261-4495-8827-540f37da455b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

