### PR TITLE
fix: update display css to exclude hidden

### DIFF
--- a/.changeset/solid-wolves-wish.md
+++ b/.changeset/solid-wolves-wish.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui': patch
+---
+
+exclude hidden attribute in display css

--- a/packages/ui/postcss-breakpoints.test.ts
+++ b/packages/ui/postcss-breakpoints.test.ts
@@ -47,3 +47,42 @@ it('generates responsive css', async () => {
 
   await run(input, output)
 })
+
+it('inserts the breakpoint suffix before pseudo selectors', async () => {
+  const input = `@breakpoints {
+  .sui-display-block:not([hidden]) {
+    display: block;
+  }
+}`
+
+  const output = `.sui-display-block:not([hidden]) {
+  display: block;
+}
+@media (min-width: 360px) {
+  .sui-display-block-bp-1:not([hidden]) {
+    display: block;
+  }
+}
+@media (min-width: 600px) {
+  .sui-display-block-bp-2:not([hidden]) {
+    display: block;
+  }
+}
+@media (min-width: 900px) {
+  .sui-display-block-bp-3:not([hidden]) {
+    display: block;
+  }
+}
+@media (min-width: 1200px) {
+  .sui-display-block-bp-4:not([hidden]) {
+    display: block;
+  }
+}
+@media (min-width: 1800px) {
+  .sui-display-block-bp-5:not([hidden]) {
+    display: block;
+  }
+}`
+
+  await run(input, output)
+})

--- a/packages/ui/postcss-breakpoints.ts
+++ b/packages/ui/postcss-breakpoints.ts
@@ -1,5 +1,6 @@
 import type {PluginCreator, Rule} from 'postcss'
 import postcss from 'postcss'
+import selectorParser from 'postcss-selector-parser'
 import type {ContainerWithChildren} from 'postcss/lib/container'
 
 export const BREAKPOINTS = ['360px', '600px', '900px', '1200px', '1800px'] as const
@@ -16,10 +17,18 @@ function getIsDynamicCssPath(fromPath: string | undefined) {
   return fromPath.replace(/\\/g, '/').includes('/classes/dynamic/')
 }
 
+function suffixSelector(selector: string, suffix: string) {
+  return selectorParser((selectors) => {
+    selectors.walkClasses((classNode) => {
+      classNode.value = `${classNode.value}${suffix}`
+    })
+  }).processSync(selector)
+}
+
 function getClone(rule: Rule, suffix: string) {
   const clone = rule.clone()
 
-  clone.selector = `${clone.selector}${suffix}`
+  clone.selector = suffixSelector(clone.selector, suffix)
   clone.raws.before = `\n${'  '}`
   clone.raws.after = `\n${'  '}`
 

--- a/packages/ui/src/css/classes/generic/display.css
+++ b/packages/ui/src/css/classes/generic/display.css
@@ -1,10 +1,10 @@
 @breakpoints {
-  .sui-display-block { display: block; }
-  .sui-display-inline-block { display: inline-block; }
-  .sui-display-inline { display: inline; }
-  .sui-display-flex { display: flex; }
-  .sui-display-inline-flex { display: inline-flex; }
-  .sui-display-grid { display: grid; }
-  .sui-display-inline-grid { display: inline-grid; }
-  .sui-display-none { display: none; }
+  .sui-display-block:not([hidden]) { display: block; }
+  .sui-display-inline-block:not([hidden]) { display: inline-block; }
+  .sui-display-inline:not([hidden]) { display: inline; }
+  .sui-display-flex:not([hidden]) { display: flex; }
+  .sui-display-inline-flex:not([hidden]) { display: inline-flex; }
+  .sui-display-grid:not([hidden]) { display: grid; }
+  .sui-display-inline-grid:not([hidden]) { display: inline-grid; }
+  .sui-display-none:not([hidden]) { display: none; }
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds `:not([hidden])` to our display styling to avoid stepping on the browser's native handling for the `hidden` attribute. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Does this CSS make sense?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

In Storybook, adding `hidden` attribute to a Box hides the box.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS utility and build-plugin selector fix with a new test; no auth, data, or API surface changes.
> 
> **Overview**
> Display utilities now use `:not([hidden])` so `display` rules do not override the browser’s native `hidden` behavior (e.g. a `Box` with `hidden` stays hidden in Storybook).
> 
> The **postcss-breakpoints** plugin no longer appends `-bp-N` to the whole selector string; it suffixes **class names only** via `postcss-selector-parser`, so compound selectors like `.sui-display-block:not([hidden])` become `.sui-display-block-bp-1:not([hidden])` instead of invalid `.sui-display-block:not([hidden])-bp-1`. A Vitest case covers that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2da596e4692249812dbe3ffff4eae4f64455dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->