### PR TITLE
fix: flex codemod cross-file styled component support

### DIFF
--- a/.changeset/nice-drinks-dress.md
+++ b/.changeset/nice-drinks-dress.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui-codemod': patch
+---
+
+flex codemod cross-file styled component support

--- a/packages/ui-codemod/src/transforms/latest/box/box.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/box/box.test.ts
@@ -1,13 +1,6 @@
-import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
-import {tmpdir} from 'node:os'
-import {join} from 'node:path'
+import {expect} from 'vitest'
 
-import {afterEach, describe, expect, it} from 'vitest'
-
-const applyTransform = require('jscodeshift/dist/testUtils').applyTransform
-
-import {clearModuleParseCache} from '../../../utils/parseModule'
-import {defineInlineTest} from '../../../utils/testUtils'
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './box'
 
 defineInlineTest(
@@ -246,157 +239,104 @@ defineInlineTest(
   'warns and does not transform attributes if styled Box should be replaced',
 )
 
-const tempDirs: string[] = []
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Box} from '@sanity/ui'
 
-afterEach(() => {
-  clearModuleParseCache()
+    export const RootBox = styled(Box)(({theme}) => ({}))
+  `,
+  `
+    import {RootBox} from './Component.styled'
 
-  for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, {recursive: true, force: true})
-  }
-})
-
-describe('cross-file styled aliases', () => {
-  it('transforms attributes on imported styled Box wrappers', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'ui-codemod-box-crossfile-'))
-
-    tempDirs.push(dir)
-
-    writeFileSync(
-      join(dir, 'Component.styled.tsx'),
-      `
-        import {Box} from '@sanity/ui'
-
-        export const RootBox = styled(Box)(({theme}) => ({}))
-      `,
-    )
-
-    writeFileSync(
-      join(dir, 'Component.tsx'),
-      `
-        import {RootBox} from './Component.styled'
-
-        export function Component() {
-          return <RootBox alignItems="center" />
-        }
-      `,
-    )
-
-    const importerPath = join(dir, 'Component.tsx')
-    const source = readFileSync(importerPath, 'utf8')
-    const output = applyTransform(transform, {}, {source, path: importerPath}, {parser: 'tsx'})
-
+    export function Component() {
+      return <RootBox alignItems="center" />
+    }
+  `,
+  (output) => {
     expect(output).toContain('alignItems: "center"')
     expect(output).not.toContain('<RootBox alignItems="center" />')
-  })
+  },
+  'transforms attributes on imported styled Box wrappers',
+)
 
-  it('adds todo warning when imported styled Box wrapper should be replaced', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'ui-codemod-box-crossfile-todo-'))
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Box} from '@sanity/ui'
 
-    tempDirs.push(dir)
+    export const RootBox = styled(Box)(({theme}) => ({}))
+  `,
+  `
+    import {RootBox} from './Component.styled'
 
-    writeFileSync(
-      join(dir, 'Component.styled.tsx'),
-      `
-        import {Box} from '@sanity/ui'
-
-        export const RootBox = styled(Box)(({theme}) => ({}))
-      `,
-    )
-
-    writeFileSync(
-      join(dir, 'Component.tsx'),
-      `
-        import {RootBox} from './Component.styled'
-
-        export function Component() {
-          return <RootBox display="flex" alignItems="center" />
-        }
-      `,
-    )
-
-    const importerPath = join(dir, 'Component.tsx')
-    const source = readFileSync(importerPath, 'utf8')
-    const output = applyTransform(transform, {}, {source, path: importerPath}, {parser: 'tsx'})
-
+    export function Component() {
+      return <RootBox display="flex" alignItems="center" />
+    }
+  `,
+  (output) => {
     expect(output).toContain('UI-CODEMOD TODO: Please double check styled(Box) migration below')
     expect(output).toContain('<RootBox display="flex" alignItems="center" />')
     expect(output).not.toContain('const RootBox = styled(Box)')
-  })
+  },
+  'adds todo warning when imported styled Box wrapper should be replaced',
+)
 
-  it('does not rewrite unrelated Box from another package', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'ui-codemod-box-crossfile-unrelated-'))
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Box} from '@sanity/ui'
 
-    tempDirs.push(dir)
+    export const RootBox = styled(Box)(({theme}) => ({}))
+  `,
+  `
+    import {Box} from 'another-package'
+    import {RootBox} from './Component.styled'
 
-    writeFileSync(
-      join(dir, 'Component.styled.tsx'),
-      `
-        import {Box} from '@sanity/ui'
-
-        export const RootBox = styled(Box)(({theme}) => ({}))
-      `,
-    )
-
-    writeFileSync(
-      join(dir, 'Component.tsx'),
-      `
-        import {Box} from 'another-package'
-        import {RootBox} from './Component.styled'
-
-        export function Component() {
-          return (
-            <>
-              <RootBox alignItems="center" />
-              <Box display="flex" />
-            </>
-          )
-        }
-      `,
-    )
-
-    const importerPath = join(dir, 'Component.tsx')
-    const source = readFileSync(importerPath, 'utf8')
-    const output = applyTransform(transform, {}, {source, path: importerPath}, {parser: 'tsx'})
-
+    export function Component() {
+      return (
+        <>
+          <RootBox alignItems="center" />
+          <Box display="flex" />
+        </>
+      )
+    }
+  `,
+  (output) => {
     expect(output).toContain('alignItems: "center"')
     expect(output).not.toContain('<RootBox alignItems="center" />')
     expect(output).toContain('<Box display="flex" />')
     expect(output).not.toContain('<Flex')
-  })
+  },
+  'does not rewrite unrelated Box from another package',
+)
 
-  it('transforms styled Box wrappers imported through barrel re-exports', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'ui-codemod-box-crossfile-barrel-'))
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Box} from '@sanity/ui'
 
-    tempDirs.push(dir)
+    export const RootBox = styled(Box)(({theme}) => ({}))
+  `,
+  `
+    import {RootBox} from './index'
 
-    writeFileSync(
-      join(dir, 'Component.styled.tsx'),
-      `
-        import {Box} from '@sanity/ui'
-
-        export const RootBox = styled(Box)(({theme}) => ({}))
-      `,
-    )
-
-    writeFileSync(join(dir, 'index.ts'), `export {RootBox} from './Component.styled'`)
-
-    writeFileSync(
-      join(dir, 'Component.tsx'),
-      `
-        import {RootBox} from './index'
-
-        export function Component() {
-          return <RootBox alignItems="center" />
-        }
-      `,
-    )
-
-    const importerPath = join(dir, 'Component.tsx')
-    const source = readFileSync(importerPath, 'utf8')
-    const output = applyTransform(transform, {}, {source, path: importerPath}, {parser: 'tsx'})
-
+    export function Component() {
+      return <RootBox alignItems="center" />
+    }
+  `,
+  (output) => {
     expect(output).toContain('alignItems: "center"')
     expect(output).not.toContain('<RootBox alignItems="center" />')
-  })
-})
+  },
+  'transforms styled Box wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootBox} from './Component.styled'`,
+    },
+  },
+)

--- a/packages/ui-codemod/src/transforms/latest/flex/flex.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/flex/flex.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './flex'
 
 defineInlineTest(
@@ -77,4 +79,79 @@ defineInlineTest(
     }} />
   `,
   'moves grid props to style and updates mapped values',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Flex} from '@sanity/ui'
+
+    export const RootFlex = styled(Flex)(({theme}) => ({}))
+  `,
+  `
+    import {RootFlex} from './Component.styled'
+
+    export function Component() {
+      return <RootFlex align="center" />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootFlex alignItems="center" />')
+  },
+  'transforms attributes on imported styled Flex wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Flex} from '@sanity/ui'
+
+    export const RootFlex = styled(Flex)(({theme}) => ({}))
+  `,
+  `
+    import {Flex} from 'another-package'
+    import {RootFlex} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootFlex align="center" />
+          <Flex direction="column" />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootFlex alignItems="center" />')
+    expect(output).toContain('<Flex direction="column" />')
+  },
+  'does not transform attributes on unrelated Flex from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Flex} from '@sanity/ui'
+
+    export const RootFlex = styled(Flex)(({theme}) => ({}))
+  `,
+  `
+    import {RootFlex} from './index'
+
+    export function Component() {
+      return <RootFlex align="center" />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootFlex alignItems="center" />')
+  },
+  'transforms styled Box wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootFlex} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/flex/flex.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/flex/flex.test.ts
@@ -148,7 +148,7 @@ defineCrossFileTest(
   (output) => {
     expect(output).toContain('<RootFlex alignItems="center" />')
   },
-  'transforms styled Box wrappers imported through barrel re-exports',
+  'transforms styled Flex wrappers imported through barrel re-exports',
   {
     extraFiles: {
       'index.ts': `export {RootFlex} from './Component.styled'`,

--- a/packages/ui-codemod/src/transforms/latest/flex/flex.ts
+++ b/packages/ui-codemod/src/transforms/latest/flex/flex.ts
@@ -2,10 +2,12 @@ import {type API, type FileInfo} from 'jscodeshift'
 
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {FLEX_MODS} from './flex.mods'
 
 const TODO_WARNING = 'Please double check the Flex migration below'
@@ -20,8 +22,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Flex', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Flex',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Flex', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Flex', localNames, options, styledAliases)) {
       return
     }
 
@@ -29,14 +39,24 @@ export default function transform(
       markChanged()
     }
 
-    root
-      .find(j.JSXOpeningElement, {
-        name: {type: 'JSXIdentifier', name: 'Flex'},
+    root.find(j.JSXOpeningElement).forEach((path) => {
+      const name = path.node.name
+
+      if (name.type !== 'JSXIdentifier' || !localNames.has(name.name)) {
+        return
+      }
+
+      if (transformAttributes(j, path, FLEX_MODS, TODO_WARNING)) {
+        markChanged()
+      }
+    })
+
+    if (
+      transformStyledComponents(j, root, styledAliases, () => true, {
+        callback: (path) => transformAttributes(j, path, FLEX_MODS, TODO_WARNING),
       })
-      .forEach((path) => {
-        if (transformAttributes(j, path, FLEX_MODS, TODO_WARNING)) {
-          markChanged()
-        }
-      })
+    ) {
+      markChanged()
+    }
   })
 }

--- a/packages/ui-codemod/src/utils/testUtils.ts
+++ b/packages/ui-codemod/src/utils/testUtils.ts
@@ -1,5 +1,11 @@
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
 import {type FileInfo, type Options, type Transform} from 'jscodeshift'
 import {expect, it} from 'vitest'
+
+import {clearModuleParseCache} from './parseModule'
 
 const applyTransform = require('jscodeshift/dist/testUtils').applyTransform
 
@@ -51,4 +57,43 @@ function runInlineTest(
 
   expectation(output)
   return output
+}
+
+export function defineCrossFileTest(
+  module: Transform,
+  options: Options,
+  styledInput: string,
+  importerInput: string,
+  assert: (output: string) => void,
+  testName?: string,
+  crossFileOptions?: {
+    extraFiles?: Record<string, string>
+  },
+) {
+  it(testName || 'transforms cross-file styled component correctly', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ui-codemod-crossfile-'))
+
+    try {
+      writeFileSync(join(dir, 'Component.styled.tsx'), styledInput.trim())
+      writeFileSync(join(dir, 'Component.tsx'), importerInput.trim())
+
+      for (const [filePath, source] of Object.entries(crossFileOptions?.extraFiles ?? {})) {
+        writeFileSync(join(dir, filePath), source.trim())
+      }
+
+      const importerPath = join(dir, 'Component.tsx')
+      const source = readFileSync(importerPath, 'utf8')
+      const output = await applyTransform(
+        module,
+        options,
+        {source, path: importerPath},
+        {parser: 'tsx'},
+      )
+
+      assert(typeof output === 'string' ? output : '')
+    } finally {
+      clearModuleParseCache()
+      rmSync(dir, {recursive: true, force: true})
+    }
+  })
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR updates the Flex codemod to handle cross-file styled component transformations. This is something that will need to be done to all codemods (except Box which is already done) but I wanted to do one file before making changes across the board.

It also create a new test util for cross-file updates and swaps that out in the Box tests too.
 
### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Since it's codemod code, it's mostly making sure the logic here makes sense.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I added tests for the Flex codemod and, once this is published, will run against Studio before updating the rest of the codemods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to `@sanity/ui-codemod` transform and test utilities; behavior change is limited to migration output for Flex/styled imports, with automated cross-file tests.
> 
> **Overview**
> The **Flex** codemod now applies prop migrations (`align` → `alignItems`, grid props to `style`, etc.) on JSX that uses **styled `Flex` wrappers defined in other files**, including aliases reached through barrel re-exports. It follows the same **`getStyledComponentAliases` / `transformStyledComponents`** pattern as Box, and JSX matching is driven by resolved local/styled names instead of only the `Flex` tag.
> 
> Tests add **`defineCrossFileTest`** in `testUtils` (temp dir, styled + importer files, optional `extraFiles`, parse cache cleanup). **Box** cross-file cases are migrated off hand-rolled `mkdtemp`/`applyTransform` setup to that helper; **Flex** gets new cross-file coverage (styled wrapper, unrelated package `Flex`, barrel imports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 654d46e36602c9982d1f96fff788301314315325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->