### PR TITLE
fix(popover): survive rapid open/close toggling and tune content crossfade

### DIFF
--- a/.changeset/popover-rapid-toggle-crossfade.md
+++ b/.changeset/popover-rapid-toggle-crossfade.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+fix(popover): prevent animated popovers from getting stuck with invisible content when rapidly toggled, and start the content fade-in halfway through the card fade instead of after it

--- a/packages/ui/src/core/constants.ts
+++ b/packages/ui/src/core/constants.ts
@@ -1,4 +1,4 @@
-import type {Transition, Variant} from 'motion/react'
+import type {TargetAndTransition, Transition, Variant} from 'motion/react'
 
 /**
  * @internal
@@ -24,9 +24,9 @@ export const POPOVER_MOTION_PROPS: {
     scaleIn: Variant
     scaleOut: Variant
   }
-  children: {
-    hidden: Variant
-    visible: Variant
+  content: {
+    hidden: TargetAndTransition
+    visible: TargetAndTransition
   }
   transition: Transition
 } = {
@@ -41,7 +41,6 @@ export const POPOVER_MOTION_PROPS: {
     visible: {
       opacity: 1,
       transition: {
-        when: 'beforeChildren',
         duration: POPOVER_MOTION_DURATION / 2,
       },
     },
@@ -52,12 +51,27 @@ export const POPOVER_MOTION_PROPS: {
       scale: 0.97,
     },
   },
-  children: {
+  /**
+   * Crossfade targets for the popover content wrapper. These are plain
+   * animation targets (not variants): the content fade is driven directly by
+   * the `open` prop rather than by variant/exit propagation from the card,
+   * so that any open/close/open sequence converges to the correct opacity.
+   * On enter, the content starts fading in halfway through the card fade
+   * (which lasts `POPOVER_MOTION_DURATION / 2`); on exit, it fades out
+   * together with the card.
+   */
+  content: {
     hidden: {
       opacity: 0,
     },
     visible: {
       opacity: 1,
+      transition: {
+        type: 'spring',
+        visualDuration: POPOVER_MOTION_DURATION,
+        bounce: 0.25,
+        delay: POPOVER_MOTION_DURATION / 4,
+      },
     },
   },
   transition: {

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -339,6 +339,7 @@ export function Popover(
         arrowX={arrowX}
         arrowY={arrowY}
         hidden={referenceHidden}
+        open={open}
         overflow={overflow}
         padding={padding}
         placement={placement}

--- a/packages/ui/src/core/primitives/popover/popoverCard.tsx
+++ b/packages/ui/src/core/primitives/popover/popoverCard.tsx
@@ -47,6 +47,7 @@ export function PopoverCard(
     arrowRef: React.Ref<HTMLDivElement>
     arrowX?: number
     arrowY?: number
+    open?: boolean
     originX?: number
     originY?: number
     overflow?: BoxOverflow
@@ -70,6 +71,7 @@ export function PopoverCard(
     arrowX,
     arrowY,
     children,
+    open,
     padding,
     placement,
     originX,
@@ -148,8 +150,23 @@ export function PopoverCard(
         direction="column"
         flex={1}
         overflow={overflow}
-        variants={POPOVER_MOTION_PROPS.children}
         transition={POPOVER_MOTION_PROPS.transition}
+        initial={animate ? POPOVER_MOTION_PROPS.content.hidden : undefined}
+        // The content fade is deliberately driven by `open` as a plain
+        // target instead of participating in the card's variant/exit
+        // propagation. Re-entering while an exit is (or seems) in flight can
+        // leave motion's presence bookkeeping in a state where a variant
+        // child's fade-in is skipped (it waits for a parent-driven animation
+        // that never comes), permanently stuck at opacity 0. A target derived
+        // from `open` is recomputed on every render and always animates from
+        // the current value, so any rapid open/close/open sequence converges.
+        animate={
+          animate
+            ? open
+              ? POPOVER_MOTION_PROPS.content.visible
+              : POPOVER_MOTION_PROPS.content.hidden
+            : undefined
+        }
       >
         <Flex direction="column" flex={1} padding={padding}>
           {children}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Rapidly clicking a popover toggle 3 times (open → close → reopen) could leave an animated `Popover` in a permanently broken state: the popover card ("backdrop") fully visible, but its content stuck at opacity 0.

**Before** (rapid 3× toggle leaves an empty popover shell):

[popover_rapid_click_before_fix.webm](https://cursor.com/agents/bc-2a3adad1-20df-4733-8ecf-643dbe830c13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpopover_rapid_click_before_fix.webm)

**After** (contents render after every sequence, plus the re-tuned crossfade):

[popover_rapid_click_after_fix.webm](https://cursor.com/agents/bc-2a3adad1-20df-4733-8ecf-643dbe830c13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpopover_rapid_click_after_fix.webm)

## Root cause

Confirmed with instrumented runtime traces of `framer-motion@13.1.0` internals:

1. The card's `ExitAnimationFeature` sets an `isExitComplete` flag whenever an exit finishes, and the flag goes stale: on later opens from fully closed, `VisualElement.mount()` erases the presence flip before the feature can observe it, so the flag is never cleared.
2. On a reopen that interrupts a close, the stale flag routes re-entry into motion's `reset()` branch instead of `setActive('exit', false)`. `setActive` cascades to variant children; `reset()` does not — so the content wrapper's `exit.isActive` stayed `true` forever, feeding its opacity into `protectedKeys` on every commit.
3. When the close had happened mid content-fade (e.g. ~150 ms after open), the wrapper's `needsAnimating.opacity` flag was already consumed, so the reopen's orchestrated fade-in was blocked → content stranded at opacity 0 under an opaque card.

Minimal deterministic repro on `main`: one full open/close cycle, then open → close at +150 ms → reopen at +30 ms.

## Fix

The content wrapper no longer participates in the card's variant/exit propagation at all. Its fade is driven directly by the `open` prop as a plain animation target (`animate={open ? visible : hidden}`). An own-prop target is recomputed on every render, is never "inherited", never protected, and always animates from the current value — so any open/close/open sequence at any timing converges by construction. The card keeps its presence/exit role, which is still needed to defer the `<Activity>` hide until the exit animation finishes.

## Crossfade tuning

With `when: 'beforeChildren'` gone, the content fade-in is now scheduled with a plain delay — and retuned: content starts fading in halfway through the card's 100 ms fade (50 ms delay) instead of waiting for it to finish, so open feels snappier while the card is already ≳80 % opaque before content becomes perceptible (no bleed-through of the page behind the backdrop). Fade-out is unchanged: content and card fade out together.

`POPOVER_MOTION_PROPS.card` is also used by `Tooltip`, but the tooltip card has no variant children, so dropping `when: 'beforeChildren'` is a no-op there.

## Verification

- Deterministic Playwright repro (3 clicks at swept gap timings with interaction history on one page, `components-menubutton--animated-popover` story): before the fix it reliably broke (card=1, wrapper=0); after the fix all 40 timing combinations end fully visible.
- `pnpm lint`, `pnpm test` (638 tests), `pnpm test:browser` (245 tests), `pnpm knip`, and `pnpm format --check` (changed files) all pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a3adad1-20df-4733-8ecf-643dbe830c13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a3adad1-20df-4733-8ecf-643dbe830c13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

