### PR TITLE
fix(popover): drop the separate content fade, animate like Tooltip

### DIFF
--- a/.changeset/popover-tooltip-style-animation.md
+++ b/.changeset/popover-tooltip-style-animation.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+fix(popover): animate popovers with the same simplicity as tooltips — only the card fades and scales, the content is no longer animated separately, so it can never get stuck invisible (SAPP-4314)

--- a/packages/ui/src/core/constants.ts
+++ b/packages/ui/src/core/constants.ts
@@ -1,4 +1,4 @@
-import type {TargetAndTransition, Transition, Variant} from 'motion/react'
+import type {Transition, Variant} from 'motion/react'
 
 /**
  * @internal
@@ -24,10 +24,6 @@ export const POPOVER_MOTION_PROPS: {
     scaleIn: Variant
     scaleOut: Variant
   }
-  content: {
-    hidden: TargetAndTransition
-    visible: TargetAndTransition
-  }
   transition: Transition
 } = {
   card: {
@@ -49,29 +45,6 @@ export const POPOVER_MOTION_PROPS: {
     },
     scaleOut: {
       scale: 0.97,
-    },
-  },
-  /**
-   * Crossfade targets for the popover content wrapper. These are plain
-   * animation targets (not variants): the content fade is driven directly by
-   * the `open` prop rather than by variant/exit propagation from the card,
-   * so that any open/close/open sequence converges to the correct opacity.
-   * On enter, the content starts fading in halfway through the card fade
-   * (which lasts `POPOVER_MOTION_DURATION / 2`); on exit, it fades out
-   * together with the card.
-   */
-  content: {
-    hidden: {
-      opacity: 0,
-    },
-    visible: {
-      opacity: 1,
-      transition: {
-        type: 'spring',
-        visualDuration: POPOVER_MOTION_DURATION,
-        bounce: 0.25,
-        delay: POPOVER_MOTION_DURATION / 4,
-      },
     },
   },
   transition: {

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -339,7 +339,6 @@ export function Popover(
         arrowX={arrowX}
         arrowY={arrowY}
         hidden={referenceHidden}
-        open={open}
         overflow={overflow}
         padding={padding}
         placement={placement}

--- a/packages/ui/src/core/primitives/popover/popoverCard.tsx
+++ b/packages/ui/src/core/primitives/popover/popoverCard.tsx
@@ -31,10 +31,6 @@ const MotionCard = styled(motion.create(Card))`
   will-change: transform;
 `
 
-const MotionFlex = styled(motion.create(Flex))`
-  will-change: opacity;
-`
-
 /**
  * @internal
  */
@@ -47,7 +43,6 @@ export function PopoverCard(
     arrowRef: React.Ref<HTMLDivElement>
     arrowX?: number
     arrowY?: number
-    open?: boolean
     originX?: number
     originY?: number
     overflow?: BoxOverflow
@@ -71,7 +66,6 @@ export function PopoverCard(
     arrowX,
     arrowY,
     children,
-    open,
     padding,
     placement,
     originX,
@@ -145,33 +139,11 @@ export function PopoverCard(
       animate={animate ? ['visible', 'scaleIn'] : undefined}
       exit={animate ? ['hidden', 'scaleOut'] : undefined}
     >
-      <MotionFlex
-        data-ui="Popover__wrapper"
-        direction="column"
-        flex={1}
-        overflow={overflow}
-        transition={POPOVER_MOTION_PROPS.transition}
-        initial={animate ? POPOVER_MOTION_PROPS.content.hidden : undefined}
-        // The content fade is deliberately driven by `open` as a plain
-        // target instead of participating in the card's variant/exit
-        // propagation. Re-entering while an exit is (or seems) in flight can
-        // leave motion's presence bookkeeping in a state where a variant
-        // child's fade-in is skipped (it waits for a parent-driven animation
-        // that never comes), permanently stuck at opacity 0. A target derived
-        // from `open` is recomputed on every render and always animates from
-        // the current value, so any rapid open/close/open sequence converges.
-        animate={
-          animate
-            ? open
-              ? POPOVER_MOTION_PROPS.content.visible
-              : POPOVER_MOTION_PROPS.content.hidden
-            : undefined
-        }
-      >
+      <Flex data-ui="Popover__wrapper" direction="column" flex={1} overflow={overflow}>
         <Flex direction="column" flex={1} padding={padding}>
           {children}
         </Flex>
-      </MotionFlex>
+      </Flex>
 
       {arrow && (
         <Arrow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SAPP-4314

## Problem

Even after [#2730](https://github.com/sanity-io/ui/pull/2730), animated popovers still intermittently render with `Popover__wrapper` stuck at opacity 0 — the card visible but empty, or nothing at all — in both development and production Studio builds ([SAPP-4314](https://linear.app/sanity/issue/SAPP-4314/popovers-intermittently-render-nothing), observed on the comments input popover and document group inventory).

## Fix

Stop animating the popover content separately altogether. `Popover` now animates exactly like `Tooltip`: only the card fades and scales (shared `POPOVER_MOTION_PROPS.card` variants), and the content is rendered in a plain `Flex`. With no second animated layer there is no wrapper opacity to get stuck — the content's visibility can never disagree with the card's.

- `popoverCard.tsx`: `Popover__wrapper` is now a plain `Flex` (kept for layout/overflow and its `data-ui` hook), no motion props.
- `constants.ts`: the `content` crossfade targets are gone; the shared `card` variants and `transition` (also used by `Tooltip`) are unchanged.
- `popover.tsx`: drops the now-unneeded `open` prop pass-through to `PopoverCard`.

Net: −59/+8 lines.

## Verification

- The deterministic repro for the original stuck state (one full open/close cycle, then open → close at +150 ms → reopen at +30 ms, `components-menubutton--animated-popover` story) passes 5/5 runs: card and wrapper at computed opacity 1, menu items visible.
- The 40-combination rapid-toggle timing sweep (with interaction history on one page) ends fully visible in every case.
- `pnpm lint`, `pnpm test` (638 tests), and `pnpm knip` pass. (Storybook browser tests running, will confirm.)

Demo video to follow.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9987185f-233c-47f1-9032-50f40531d51a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9987185f-233c-47f1-9032-50f40531d51a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

