### PR TITLE
fix: scale typography icons under Safari page zoom

### DIFF
--- a/.changeset/sapp-933-safari-icon-zoom.md
+++ b/.changeset/sapp-933-safari-icon-zoom.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Stop setting `font-size` on descendant icons so Safari page zoom can scale them (WebKit 199236 / SAPP-933). Theme `iconSize` is applied as rem `width`/`height` only while the SVG still has the default `1em` presentation attributes, so consumer `width`/`height` props and `@sanity/logos` height-only shells keep working.

--- a/.changeset/sapp-933-safari-icon-zoom.md
+++ b/.changeset/sapp-933-safari-icon-zoom.md
@@ -1,5 +1,6 @@
 ---
+"@sanity/icons": patch
 "@sanity/ui": patch
 ---
 
-Stop setting `font-size` on descendant icons so Safari page zoom can scale them (WebKit 199236 / SAPP-933). Theme `iconSize` is applied as rem `width`/`height` only while the SVG still has the default `1em` presentation attributes, so consumer `width`/`height` props and `@sanity/logos` height-only shells keep working.
+Emit `@sanity/icons` glyphs with `height="1em"` only (the `@sanity/logos` shell that already scales in Safari) and stop setting `font-size` on descendant SVGs in `@sanity/ui` `responsiveFont()` so Cmd+/- page zoom can scale them (WebKit 199236 / SAPP-933).

--- a/packages/icons/scripts/generate.ts
+++ b/packages/icons/scripts/generate.ts
@@ -90,8 +90,13 @@ async function readIcon(filePath: string) {
     ' xmlns="http://www.w3.org/2000/svg" {...props} ref={ref}',
   )
 
-  code = code.replace(/width="25"/g, `width="1em"`)
-  code = code.replace(/height="25"/g, `height="1em"`)
+  // WebKit 199236: width+height 1em plus font-size on the SVG does not
+  // scale with Safari Cmd+/-. Match the @sanity/logos shell that does
+  // scale (SanityMonogram / SanityLogo): height="1em" only. Square
+  // viewBoxes keep the used width. SVGR `icon: true` already emits 1em
+  // on both axes; strip width whether it is still 25 or already 1em.
+  code = code.replace(/\s*width="(?:25|1em)"/g, '')
+  code = code.replace(/height="25"/g, 'height="1em"')
 
   code = code.replace(/stroke-width=/g, `strokeWidth=`)
   code = code.replace(/stroke-linecap=/g, `strokeLinecap=`)

--- a/packages/icons/src/exports/AccessDenied.tsx
+++ b/packages/icons/src/exports/AccessDenied.tsx
@@ -11,7 +11,6 @@ export const AccessDeniedIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="access-denied"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Activity.tsx
+++ b/packages/icons/src/exports/Activity.tsx
@@ -11,7 +11,6 @@ export const ActivityIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="activity"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Add.tsx
+++ b/packages/icons/src/exports/Add.tsx
@@ -11,7 +11,6 @@ export const AddIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="add"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/AddCircle.tsx
+++ b/packages/icons/src/exports/AddCircle.tsx
@@ -11,7 +11,6 @@ export const AddCircleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="add-circle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/AddComment.tsx
+++ b/packages/icons/src/exports/AddComment.tsx
@@ -11,7 +11,6 @@ export const AddCommentIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="add-comment"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/AddDocument.tsx
+++ b/packages/icons/src/exports/AddDocument.tsx
@@ -11,7 +11,6 @@ export const AddDocumentIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="add-document"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/AddUser.tsx
+++ b/packages/icons/src/exports/AddUser.tsx
@@ -11,7 +11,6 @@ export const AddUserIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="add-user"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Api.tsx
+++ b/packages/icons/src/exports/Api.tsx
@@ -11,7 +11,6 @@ export const ApiIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="api"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Archive.tsx
+++ b/packages/icons/src/exports/Archive.tsx
@@ -11,7 +11,6 @@ export const ArchiveIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="archive"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ArrowDown.tsx
+++ b/packages/icons/src/exports/ArrowDown.tsx
@@ -11,7 +11,6 @@ export const ArrowDownIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="arrow-down"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ArrowLeft.tsx
+++ b/packages/icons/src/exports/ArrowLeft.tsx
@@ -11,7 +11,6 @@ export const ArrowLeftIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="arrow-left"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ArrowRight.tsx
+++ b/packages/icons/src/exports/ArrowRight.tsx
@@ -11,7 +11,6 @@ export const ArrowRightIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="arrow-right"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ArrowTopRight.tsx
+++ b/packages/icons/src/exports/ArrowTopRight.tsx
@@ -11,7 +11,6 @@ export const ArrowTopRightIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="arrow-top-right"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ArrowUp.tsx
+++ b/packages/icons/src/exports/ArrowUp.tsx
@@ -11,7 +11,6 @@ export const ArrowUpIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="arrow-up"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Asterisk.tsx
+++ b/packages/icons/src/exports/Asterisk.tsx
@@ -11,7 +11,6 @@ export const AsteriskIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="asterisk"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/BarChart.tsx
+++ b/packages/icons/src/exports/BarChart.tsx
@@ -11,7 +11,6 @@ export const BarChartIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bar-chart"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Basket.tsx
+++ b/packages/icons/src/exports/Basket.tsx
@@ -11,7 +11,6 @@ export const BasketIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="basket"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Bell.tsx
+++ b/packages/icons/src/exports/Bell.tsx
@@ -11,7 +11,6 @@ export const BellIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bell"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Bill.tsx
+++ b/packages/icons/src/exports/Bill.tsx
@@ -11,7 +11,6 @@ export const BillIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bill"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/BinaryDocument.tsx
+++ b/packages/icons/src/exports/BinaryDocument.tsx
@@ -11,7 +11,6 @@ export const BinaryDocumentIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="binary-document"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/BlockContent.tsx
+++ b/packages/icons/src/exports/BlockContent.tsx
@@ -11,7 +11,6 @@ export const BlockContentIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="block-content"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/BlockElement.tsx
+++ b/packages/icons/src/exports/BlockElement.tsx
@@ -11,7 +11,6 @@ export const BlockElementIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="block-element"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Blockquote.tsx
+++ b/packages/icons/src/exports/Blockquote.tsx
@@ -11,7 +11,6 @@ export const BlockquoteIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="blockquote"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Bold.tsx
+++ b/packages/icons/src/exports/Bold.tsx
@@ -11,7 +11,6 @@ export const BoldIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bold"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Bolt.tsx
+++ b/packages/icons/src/exports/Bolt.tsx
@@ -11,7 +11,6 @@ export const BoltIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bolt"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Book.tsx
+++ b/packages/icons/src/exports/Book.tsx
@@ -11,7 +11,6 @@ export const BookIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="book"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Bookmark.tsx
+++ b/packages/icons/src/exports/Bookmark.tsx
@@ -11,7 +11,6 @@ export const BookmarkIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bookmark"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/BookmarkFilled.tsx
+++ b/packages/icons/src/exports/BookmarkFilled.tsx
@@ -11,7 +11,6 @@ export const BookmarkFilledIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bookmark-filled"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Bottle.tsx
+++ b/packages/icons/src/exports/Bottle.tsx
@@ -11,7 +11,6 @@ export const BottleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bottle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Bug.tsx
+++ b/packages/icons/src/exports/Bug.tsx
@@ -11,7 +11,6 @@ export const BugIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bug"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/BulbFilled.tsx
+++ b/packages/icons/src/exports/BulbFilled.tsx
@@ -11,7 +11,6 @@ export const BulbFilledIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bulb-filled"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/BulbOutline.tsx
+++ b/packages/icons/src/exports/BulbOutline.tsx
@@ -11,7 +11,6 @@ export const BulbOutlineIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="bulb-outline"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Calendar.tsx
+++ b/packages/icons/src/exports/Calendar.tsx
@@ -11,7 +11,6 @@ export const CalendarIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="calendar"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Case.tsx
+++ b/packages/icons/src/exports/Case.tsx
@@ -11,7 +11,6 @@ export const CaseIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="case"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ChartUpward.tsx
+++ b/packages/icons/src/exports/ChartUpward.tsx
@@ -11,7 +11,6 @@ export const ChartUpwardIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="chart-upward"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Checkmark.tsx
+++ b/packages/icons/src/exports/Checkmark.tsx
@@ -11,7 +11,6 @@ export const CheckmarkIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="checkmark"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/CheckmarkCircle.tsx
+++ b/packages/icons/src/exports/CheckmarkCircle.tsx
@@ -11,7 +11,6 @@ export const CheckmarkCircleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="checkmark-circle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ChevronDown.tsx
+++ b/packages/icons/src/exports/ChevronDown.tsx
@@ -11,7 +11,6 @@ export const ChevronDownIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="chevron-down"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ChevronLeft.tsx
+++ b/packages/icons/src/exports/ChevronLeft.tsx
@@ -11,7 +11,6 @@ export const ChevronLeftIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="chevron-left"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ChevronRight.tsx
+++ b/packages/icons/src/exports/ChevronRight.tsx
@@ -11,7 +11,6 @@ export const ChevronRightIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="chevron-right"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ChevronUp.tsx
+++ b/packages/icons/src/exports/ChevronUp.tsx
@@ -11,7 +11,6 @@ export const ChevronUpIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="chevron-up"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Circle.tsx
+++ b/packages/icons/src/exports/Circle.tsx
@@ -11,7 +11,6 @@ export const CircleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="circle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Clipboard.tsx
+++ b/packages/icons/src/exports/Clipboard.tsx
@@ -11,7 +11,6 @@ export const ClipboardIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="clipboard"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ClipboardImage.tsx
+++ b/packages/icons/src/exports/ClipboardImage.tsx
@@ -11,7 +11,6 @@ export const ClipboardImageIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="clipboard-image"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Clock.tsx
+++ b/packages/icons/src/exports/Clock.tsx
@@ -11,7 +11,6 @@ export const ClockIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="clock"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Close.tsx
+++ b/packages/icons/src/exports/Close.tsx
@@ -11,7 +11,6 @@ export const CloseIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="close"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/CloseCircle.tsx
+++ b/packages/icons/src/exports/CloseCircle.tsx
@@ -11,7 +11,6 @@ export const CloseCircleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="close-circle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Code.tsx
+++ b/packages/icons/src/exports/Code.tsx
@@ -11,7 +11,6 @@ export const CodeIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="code"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/CodeBlock.tsx
+++ b/packages/icons/src/exports/CodeBlock.tsx
@@ -11,7 +11,6 @@ export const CodeBlockIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="code-block"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Cog.tsx
+++ b/packages/icons/src/exports/Cog.tsx
@@ -11,7 +11,6 @@ export const CogIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="cog"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Collapse.tsx
+++ b/packages/icons/src/exports/Collapse.tsx
@@ -11,7 +11,6 @@ export const CollapseIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="collapse"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ColorWheel.tsx
+++ b/packages/icons/src/exports/ColorWheel.tsx
@@ -11,7 +11,6 @@ export const ColorWheelIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="color-wheel"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Comment.tsx
+++ b/packages/icons/src/exports/Comment.tsx
@@ -11,7 +11,6 @@ export const CommentIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="comment"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Component.tsx
+++ b/packages/icons/src/exports/Component.tsx
@@ -11,7 +11,6 @@ export const ComponentIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="component"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Compose.tsx
+++ b/packages/icons/src/exports/Compose.tsx
@@ -11,7 +11,6 @@ export const ComposeIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="compose"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ComposeSparkles.tsx
+++ b/packages/icons/src/exports/ComposeSparkles.tsx
@@ -11,7 +11,6 @@ export const ComposeSparklesIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="compose-sparkles"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Confetti.tsx
+++ b/packages/icons/src/exports/Confetti.tsx
@@ -11,7 +11,6 @@ export const ConfettiIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="confetti"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Controls.tsx
+++ b/packages/icons/src/exports/Controls.tsx
@@ -11,7 +11,6 @@ export const ControlsIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="controls"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Copy.tsx
+++ b/packages/icons/src/exports/Copy.tsx
@@ -11,7 +11,6 @@ export const CopyIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="copy"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/CreditCard.tsx
+++ b/packages/icons/src/exports/CreditCard.tsx
@@ -11,7 +11,6 @@ export const CreditCardIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="credit-card"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Crop.tsx
+++ b/packages/icons/src/exports/Crop.tsx
@@ -11,7 +11,6 @@ export const CropIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="crop"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Cube.tsx
+++ b/packages/icons/src/exports/Cube.tsx
@@ -11,7 +11,6 @@ export const CubeIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="cube"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Dashboard.tsx
+++ b/packages/icons/src/exports/Dashboard.tsx
@@ -11,7 +11,6 @@ export const DashboardIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="dashboard"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Database.tsx
+++ b/packages/icons/src/exports/Database.tsx
@@ -11,7 +11,6 @@ export const DatabaseIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="database"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Desktop.tsx
+++ b/packages/icons/src/exports/Desktop.tsx
@@ -11,7 +11,6 @@ export const DesktopIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="desktop"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Diamond.tsx
+++ b/packages/icons/src/exports/Diamond.tsx
@@ -11,7 +11,6 @@ export const DiamondIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="diamond"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Document.tsx
+++ b/packages/icons/src/exports/Document.tsx
@@ -11,7 +11,6 @@ export const DocumentIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="document"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DocumentPdf.tsx
+++ b/packages/icons/src/exports/DocumentPdf.tsx
@@ -11,7 +11,6 @@ export const DocumentPdfIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="document-pdf"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DocumentRemove.tsx
+++ b/packages/icons/src/exports/DocumentRemove.tsx
@@ -11,7 +11,6 @@ export const DocumentRemoveIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="document-remove"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DocumentSheet.tsx
+++ b/packages/icons/src/exports/DocumentSheet.tsx
@@ -11,7 +11,6 @@ export const DocumentSheetIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="document-sheet"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DocumentText.tsx
+++ b/packages/icons/src/exports/DocumentText.tsx
@@ -11,7 +11,6 @@ export const DocumentTextIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="document-text"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DocumentVideo.tsx
+++ b/packages/icons/src/exports/DocumentVideo.tsx
@@ -11,7 +11,6 @@ export const DocumentVideoIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="document-video"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DocumentWord.tsx
+++ b/packages/icons/src/exports/DocumentWord.tsx
@@ -11,7 +11,6 @@ export const DocumentWordIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="document-word"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DocumentZip.tsx
+++ b/packages/icons/src/exports/DocumentZip.tsx
@@ -11,7 +11,6 @@ export const DocumentZipIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="document-zip"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Documents.tsx
+++ b/packages/icons/src/exports/Documents.tsx
@@ -11,7 +11,6 @@ export const DocumentsIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="documents"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Dot.tsx
+++ b/packages/icons/src/exports/Dot.tsx
@@ -11,7 +11,6 @@ export const DotIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="dot"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DoubleChevronDown.tsx
+++ b/packages/icons/src/exports/DoubleChevronDown.tsx
@@ -11,7 +11,6 @@ export const DoubleChevronDownIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="double-chevron-down"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DoubleChevronLeft.tsx
+++ b/packages/icons/src/exports/DoubleChevronLeft.tsx
@@ -11,7 +11,6 @@ export const DoubleChevronLeftIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="double-chevron-left"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DoubleChevronRight.tsx
+++ b/packages/icons/src/exports/DoubleChevronRight.tsx
@@ -11,7 +11,6 @@ export const DoubleChevronRightIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="double-chevron-right"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DoubleChevronUp.tsx
+++ b/packages/icons/src/exports/DoubleChevronUp.tsx
@@ -11,7 +11,6 @@ export const DoubleChevronUpIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="double-chevron-up"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DoubleQuote.tsx
+++ b/packages/icons/src/exports/DoubleQuote.tsx
@@ -11,7 +11,6 @@ export const DoubleQuoteIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="double-quote"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Download.tsx
+++ b/packages/icons/src/exports/Download.tsx
@@ -11,7 +11,6 @@ export const DownloadIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="download"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/DragHandle.tsx
+++ b/packages/icons/src/exports/DragHandle.tsx
@@ -11,7 +11,6 @@ export const DragHandleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="drag-handle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Drop.tsx
+++ b/packages/icons/src/exports/Drop.tsx
@@ -11,7 +11,6 @@ export const DropIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="drop"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/EarthAmericas.tsx
+++ b/packages/icons/src/exports/EarthAmericas.tsx
@@ -11,7 +11,6 @@ export const EarthAmericasIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="earth-americas"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/EarthGlobe.tsx
+++ b/packages/icons/src/exports/EarthGlobe.tsx
@@ -11,7 +11,6 @@ export const EarthGlobeIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="earth-globe"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Edit.tsx
+++ b/packages/icons/src/exports/Edit.tsx
@@ -11,7 +11,6 @@ export const EditIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="edit"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/EllipsisHorizontal.tsx
+++ b/packages/icons/src/exports/EllipsisHorizontal.tsx
@@ -11,7 +11,6 @@ export const EllipsisHorizontalIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="ellipsis-horizontal"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/EllipsisVertical.tsx
+++ b/packages/icons/src/exports/EllipsisVertical.tsx
@@ -11,7 +11,6 @@ export const EllipsisVerticalIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="ellipsis-vertical"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Empty.tsx
+++ b/packages/icons/src/exports/Empty.tsx
@@ -11,7 +11,6 @@ export const EmptyIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="empty"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Enter.tsx
+++ b/packages/icons/src/exports/Enter.tsx
@@ -11,7 +11,6 @@ export const EnterIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="enter"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/EnterRight.tsx
+++ b/packages/icons/src/exports/EnterRight.tsx
@@ -11,7 +11,6 @@ export const EnterRightIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="enter-right"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Envelope.tsx
+++ b/packages/icons/src/exports/Envelope.tsx
@@ -11,7 +11,6 @@ export const EnvelopeIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="envelope"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Equal.tsx
+++ b/packages/icons/src/exports/Equal.tsx
@@ -11,7 +11,6 @@ export const EqualIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="equal"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ErrorFilled.tsx
+++ b/packages/icons/src/exports/ErrorFilled.tsx
@@ -11,7 +11,6 @@ export const ErrorFilledIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="error-filled"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ErrorOutline.tsx
+++ b/packages/icons/src/exports/ErrorOutline.tsx
@@ -11,7 +11,6 @@ export const ErrorOutlineIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="error-outline"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ErrorScreen.tsx
+++ b/packages/icons/src/exports/ErrorScreen.tsx
@@ -11,7 +11,6 @@ export const ErrorScreenIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="error-screen"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Expand.tsx
+++ b/packages/icons/src/exports/Expand.tsx
@@ -11,7 +11,6 @@ export const ExpandIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="expand"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/EyeClosed.tsx
+++ b/packages/icons/src/exports/EyeClosed.tsx
@@ -11,7 +11,6 @@ export const EyeClosedIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="eye-closed"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/EyeOpen.tsx
+++ b/packages/icons/src/exports/EyeOpen.tsx
@@ -11,7 +11,6 @@ export const EyeOpenIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="eye-open"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/FaceHappy.tsx
+++ b/packages/icons/src/exports/FaceHappy.tsx
@@ -11,7 +11,6 @@ export const FaceHappyIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="face-happy"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/FaceIndifferent.tsx
+++ b/packages/icons/src/exports/FaceIndifferent.tsx
@@ -11,7 +11,6 @@ export const FaceIndifferentIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="face-indifferent"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/FaceSad.tsx
+++ b/packages/icons/src/exports/FaceSad.tsx
@@ -11,7 +11,6 @@ export const FaceSadIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="face-sad"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Feedback.tsx
+++ b/packages/icons/src/exports/Feedback.tsx
@@ -11,7 +11,6 @@ export const FeedbackIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="feedback"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Filter.tsx
+++ b/packages/icons/src/exports/Filter.tsx
@@ -11,7 +11,6 @@ export const FilterIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="filter"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Folder.tsx
+++ b/packages/icons/src/exports/Folder.tsx
@@ -11,7 +11,6 @@ export const FolderIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="folder"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Generate.tsx
+++ b/packages/icons/src/exports/Generate.tsx
@@ -11,7 +11,6 @@ export const GenerateIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="generate"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Github.tsx
+++ b/packages/icons/src/exports/Github.tsx
@@ -11,7 +11,6 @@ export const GithubIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="github"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Groq.tsx
+++ b/packages/icons/src/exports/Groq.tsx
@@ -11,7 +11,6 @@ export const GroqIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="groq"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Hash.tsx
+++ b/packages/icons/src/exports/Hash.tsx
@@ -11,7 +11,6 @@ export const HashIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="hash"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Heart.tsx
+++ b/packages/icons/src/exports/Heart.tsx
@@ -11,7 +11,6 @@ export const HeartIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="heart"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/HeartFilled.tsx
+++ b/packages/icons/src/exports/HeartFilled.tsx
@@ -11,7 +11,6 @@ export const HeartFilledIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="heart-filled"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/HelpCircle.tsx
+++ b/packages/icons/src/exports/HelpCircle.tsx
@@ -11,7 +11,6 @@ export const HelpCircleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="help-circle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Highlight.tsx
+++ b/packages/icons/src/exports/Highlight.tsx
@@ -11,7 +11,6 @@ export const HighlightIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="highlight"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Home.tsx
+++ b/packages/icons/src/exports/Home.tsx
@@ -11,7 +11,6 @@ export const HomeIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="home"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/IceCream.tsx
+++ b/packages/icons/src/exports/IceCream.tsx
@@ -11,7 +11,6 @@ export const IceCreamIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="ice-cream"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Image.tsx
+++ b/packages/icons/src/exports/Image.tsx
@@ -11,7 +11,6 @@ export const ImageIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="image"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ImageRemove.tsx
+++ b/packages/icons/src/exports/ImageRemove.tsx
@@ -11,7 +11,6 @@ export const ImageRemoveIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="image-remove"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Images.tsx
+++ b/packages/icons/src/exports/Images.tsx
@@ -11,7 +11,6 @@ export const ImagesIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="images"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Inbox.tsx
+++ b/packages/icons/src/exports/Inbox.tsx
@@ -11,7 +11,6 @@ export const InboxIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="inbox"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/InfoFilled.tsx
+++ b/packages/icons/src/exports/InfoFilled.tsx
@@ -11,7 +11,6 @@ export const InfoFilledIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="info-filled"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/InfoOutline.tsx
+++ b/packages/icons/src/exports/InfoOutline.tsx
@@ -11,7 +11,6 @@ export const InfoOutlineIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="info-outline"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Inline.tsx
+++ b/packages/icons/src/exports/Inline.tsx
@@ -11,7 +11,6 @@ export const InlineIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="inline"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/InlineElement.tsx
+++ b/packages/icons/src/exports/InlineElement.tsx
@@ -11,7 +11,6 @@ export const InlineElementIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="inline-element"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/InsertAbove.tsx
+++ b/packages/icons/src/exports/InsertAbove.tsx
@@ -11,7 +11,6 @@ export const InsertAboveIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="insert-above"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/InsertBelow.tsx
+++ b/packages/icons/src/exports/InsertBelow.tsx
@@ -11,7 +11,6 @@ export const InsertBelowIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="insert-below"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Italic.tsx
+++ b/packages/icons/src/exports/Italic.tsx
@@ -11,7 +11,6 @@ export const ItalicIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="italic"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Joystick.tsx
+++ b/packages/icons/src/exports/Joystick.tsx
@@ -11,7 +11,6 @@ export const JoystickIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="joystick"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Json.tsx
+++ b/packages/icons/src/exports/Json.tsx
@@ -11,7 +11,6 @@ export const JsonIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="json"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Launch.tsx
+++ b/packages/icons/src/exports/Launch.tsx
@@ -11,7 +11,6 @@ export const LaunchIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="launch"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Leave.tsx
+++ b/packages/icons/src/exports/Leave.tsx
@@ -11,7 +11,6 @@ export const LeaveIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="leave"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Lemon.tsx
+++ b/packages/icons/src/exports/Lemon.tsx
@@ -11,7 +11,6 @@ export const LemonIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="lemon"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Link.tsx
+++ b/packages/icons/src/exports/Link.tsx
@@ -11,7 +11,6 @@ export const LinkIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="link"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/LinkRemoved.tsx
+++ b/packages/icons/src/exports/LinkRemoved.tsx
@@ -11,7 +11,6 @@ export const LinkRemovedIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="link-removed"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Linkedin.tsx
+++ b/packages/icons/src/exports/Linkedin.tsx
@@ -11,7 +11,6 @@ export const LinkedinIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="linkedin"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/List.tsx
+++ b/packages/icons/src/exports/List.tsx
@@ -11,7 +11,6 @@ export const ListIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="list"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Lock.tsx
+++ b/packages/icons/src/exports/Lock.tsx
@@ -11,7 +11,6 @@ export const LockIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="lock"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/LogoJs.tsx
+++ b/packages/icons/src/exports/LogoJs.tsx
@@ -11,7 +11,6 @@ export const LogoJsIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="logo-js"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/LogoTs.tsx
+++ b/packages/icons/src/exports/LogoTs.tsx
@@ -11,7 +11,6 @@ export const LogoTsIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="logo-ts"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Marker.tsx
+++ b/packages/icons/src/exports/Marker.tsx
@@ -11,7 +11,6 @@ export const MarkerIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="marker"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/MarkerRemoved.tsx
+++ b/packages/icons/src/exports/MarkerRemoved.tsx
@@ -11,7 +11,6 @@ export const MarkerRemovedIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="marker-removed"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/MasterDetail.tsx
+++ b/packages/icons/src/exports/MasterDetail.tsx
@@ -11,7 +11,6 @@ export const MasterDetailIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="master-detail"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Menu.tsx
+++ b/packages/icons/src/exports/Menu.tsx
@@ -11,7 +11,6 @@ export const MenuIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="menu"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Microphone.tsx
+++ b/packages/icons/src/exports/Microphone.tsx
@@ -11,7 +11,6 @@ export const MicrophoneIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="microphone"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/MicrophoneSlash.tsx
+++ b/packages/icons/src/exports/MicrophoneSlash.tsx
@@ -11,7 +11,6 @@ export const MicrophoneSlashIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="microphone-slash"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/MobileDevice.tsx
+++ b/packages/icons/src/exports/MobileDevice.tsx
@@ -11,7 +11,6 @@ export const MobileDeviceIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="mobile-device"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Moon.tsx
+++ b/packages/icons/src/exports/Moon.tsx
@@ -11,7 +11,6 @@ export const MoonIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="moon"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Number.tsx
+++ b/packages/icons/src/exports/Number.tsx
@@ -11,7 +11,6 @@ export const NumberIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="number"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/OkHand.tsx
+++ b/packages/icons/src/exports/OkHand.tsx
@@ -11,7 +11,6 @@ export const OkHandIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="ok-hand"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Olist.tsx
+++ b/packages/icons/src/exports/Olist.tsx
@@ -11,7 +11,6 @@ export const OlistIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="olist"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Overage.tsx
+++ b/packages/icons/src/exports/Overage.tsx
@@ -11,7 +11,6 @@ export const OverageIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="overage"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Package.tsx
+++ b/packages/icons/src/exports/Package.tsx
@@ -11,7 +11,6 @@ export const PackageIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="package"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/PanelLeft.tsx
+++ b/packages/icons/src/exports/PanelLeft.tsx
@@ -11,7 +11,6 @@ export const PanelLeftIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="panel-left"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/PanelRight.tsx
+++ b/packages/icons/src/exports/PanelRight.tsx
@@ -11,7 +11,6 @@ export const PanelRightIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="panel-right"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Pause.tsx
+++ b/packages/icons/src/exports/Pause.tsx
@@ -11,7 +11,6 @@ export const PauseIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="pause"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Pin.tsx
+++ b/packages/icons/src/exports/Pin.tsx
@@ -11,7 +11,6 @@ export const PinIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="pin"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/PinFilled.tsx
+++ b/packages/icons/src/exports/PinFilled.tsx
@@ -11,7 +11,6 @@ export const PinFilledIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="pin-filled"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/PinRemoved.tsx
+++ b/packages/icons/src/exports/PinRemoved.tsx
@@ -11,7 +11,6 @@ export const PinRemovedIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="pin-removed"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Play.tsx
+++ b/packages/icons/src/exports/Play.tsx
@@ -11,7 +11,6 @@ export const PlayIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="play"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Plug.tsx
+++ b/packages/icons/src/exports/Plug.tsx
@@ -11,7 +11,6 @@ export const PlugIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="plug"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Presentation.tsx
+++ b/packages/icons/src/exports/Presentation.tsx
@@ -11,7 +11,6 @@ export const PresentationIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="presentation"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Progress50.tsx
+++ b/packages/icons/src/exports/Progress50.tsx
@@ -11,7 +11,6 @@ export const Progress50Icon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="progress-50"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Progress75.tsx
+++ b/packages/icons/src/exports/Progress75.tsx
@@ -11,7 +11,6 @@ export const Progress75Icon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="progress-75"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Projects.tsx
+++ b/packages/icons/src/exports/Projects.tsx
@@ -11,7 +11,6 @@ export const ProjectsIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="projects"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Publish.tsx
+++ b/packages/icons/src/exports/Publish.tsx
@@ -11,7 +11,6 @@ export const PublishIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="publish"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ReadOnly.tsx
+++ b/packages/icons/src/exports/ReadOnly.tsx
@@ -11,7 +11,6 @@ export const ReadOnlyIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="read-only"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Redo.tsx
+++ b/packages/icons/src/exports/Redo.tsx
@@ -11,7 +11,6 @@ export const RedoIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="redo"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Refresh.tsx
+++ b/packages/icons/src/exports/Refresh.tsx
@@ -11,7 +11,6 @@ export const RefreshIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="refresh"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Remove.tsx
+++ b/packages/icons/src/exports/Remove.tsx
@@ -11,7 +11,6 @@ export const RemoveIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="remove"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/RemoveCircle.tsx
+++ b/packages/icons/src/exports/RemoveCircle.tsx
@@ -11,7 +11,6 @@ export const RemoveCircleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="remove-circle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Reset.tsx
+++ b/packages/icons/src/exports/Reset.tsx
@@ -11,7 +11,6 @@ export const ResetIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="reset"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Restore.tsx
+++ b/packages/icons/src/exports/Restore.tsx
@@ -11,7 +11,6 @@ export const RestoreIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="restore"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Retrieve.tsx
+++ b/packages/icons/src/exports/Retrieve.tsx
@@ -11,7 +11,6 @@ export const RetrieveIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="retrieve"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Retry.tsx
+++ b/packages/icons/src/exports/Retry.tsx
@@ -11,7 +11,6 @@ export const RetryIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="retry"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Revert.tsx
+++ b/packages/icons/src/exports/Revert.tsx
@@ -11,7 +11,6 @@ export const RevertIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="revert"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Robot.tsx
+++ b/packages/icons/src/exports/Robot.tsx
@@ -11,7 +11,6 @@ export const RobotIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="robot"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Rocket.tsx
+++ b/packages/icons/src/exports/Rocket.tsx
@@ -11,7 +11,6 @@ export const RocketIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="rocket"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Schema.tsx
+++ b/packages/icons/src/exports/Schema.tsx
@@ -11,7 +11,6 @@ export const SchemaIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="schema"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Search.tsx
+++ b/packages/icons/src/exports/Search.tsx
@@ -11,7 +11,6 @@ export const SearchIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="search"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Select.tsx
+++ b/packages/icons/src/exports/Select.tsx
@@ -11,7 +11,6 @@ export const SelectIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="select"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Share.tsx
+++ b/packages/icons/src/exports/Share.tsx
@@ -11,7 +11,6 @@ export const ShareIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="share"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Sort.tsx
+++ b/packages/icons/src/exports/Sort.tsx
@@ -11,7 +11,6 @@ export const SortIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="sort"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Sparkle.tsx
+++ b/packages/icons/src/exports/Sparkle.tsx
@@ -11,7 +11,6 @@ export const SparkleIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="sparkle"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Sparkles.tsx
+++ b/packages/icons/src/exports/Sparkles.tsx
@@ -11,7 +11,6 @@ export const SparklesIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="sparkles"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Spinner.tsx
+++ b/packages/icons/src/exports/Spinner.tsx
@@ -11,7 +11,6 @@ export const SpinnerIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="spinner"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/SplitHorizontal.tsx
+++ b/packages/icons/src/exports/SplitHorizontal.tsx
@@ -11,7 +11,6 @@ export const SplitHorizontalIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="split-horizontal"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/SplitVertical.tsx
+++ b/packages/icons/src/exports/SplitVertical.tsx
@@ -11,7 +11,6 @@ export const SplitVerticalIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="split-vertical"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Square.tsx
+++ b/packages/icons/src/exports/Square.tsx
@@ -11,7 +11,6 @@ export const SquareIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="square"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Stack.tsx
+++ b/packages/icons/src/exports/Stack.tsx
@@ -11,7 +11,6 @@ export const StackIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="stack"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/StackCompact.tsx
+++ b/packages/icons/src/exports/StackCompact.tsx
@@ -11,7 +11,6 @@ export const StackCompactIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="stack-compact"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Star.tsx
+++ b/packages/icons/src/exports/Star.tsx
@@ -11,7 +11,6 @@ export const StarIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="star"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/StarFilled.tsx
+++ b/packages/icons/src/exports/StarFilled.tsx
@@ -11,7 +11,6 @@ export const StarFilledIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="star-filled"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Stop.tsx
+++ b/packages/icons/src/exports/Stop.tsx
@@ -11,7 +11,6 @@ export const StopIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="stop"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Strikethrough.tsx
+++ b/packages/icons/src/exports/Strikethrough.tsx
@@ -11,7 +11,6 @@ export const StrikethroughIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="strikethrough"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/String.tsx
+++ b/packages/icons/src/exports/String.tsx
@@ -11,7 +11,6 @@ export const StringIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="string"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Sun.tsx
+++ b/packages/icons/src/exports/Sun.tsx
@@ -11,7 +11,6 @@ export const SunIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="sun"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Sync.tsx
+++ b/packages/icons/src/exports/Sync.tsx
@@ -11,7 +11,6 @@ export const SyncIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="sync"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/TabletDevice.tsx
+++ b/packages/icons/src/exports/TabletDevice.tsx
@@ -11,7 +11,6 @@ export const TabletDeviceIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="tablet-device"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Tag.tsx
+++ b/packages/icons/src/exports/Tag.tsx
@@ -11,7 +11,6 @@ export const TagIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="tag"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Tags.tsx
+++ b/packages/icons/src/exports/Tags.tsx
@@ -11,7 +11,6 @@ export const TagsIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="tags"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Target.tsx
+++ b/packages/icons/src/exports/Target.tsx
@@ -11,7 +11,6 @@ export const TargetIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="target"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Task.tsx
+++ b/packages/icons/src/exports/Task.tsx
@@ -11,7 +11,6 @@ export const TaskIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="task"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Terminal.tsx
+++ b/packages/icons/src/exports/Terminal.tsx
@@ -11,7 +11,6 @@ export const TerminalIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="terminal"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Text.tsx
+++ b/packages/icons/src/exports/Text.tsx
@@ -11,7 +11,6 @@ export const TextIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="text"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ThLarge.tsx
+++ b/packages/icons/src/exports/ThLarge.tsx
@@ -11,7 +11,6 @@ export const ThLargeIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="th-large"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ThList.tsx
+++ b/packages/icons/src/exports/ThList.tsx
@@ -11,7 +11,6 @@ export const ThListIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="th-list"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ThumbsDown.tsx
+++ b/packages/icons/src/exports/ThumbsDown.tsx
@@ -11,7 +11,6 @@ export const ThumbsDownIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="thumbs-down"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ThumbsUp.tsx
+++ b/packages/icons/src/exports/ThumbsUp.tsx
@@ -11,7 +11,6 @@ export const ThumbsUpIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="thumbs-up"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Tiers.tsx
+++ b/packages/icons/src/exports/Tiers.tsx
@@ -11,7 +11,6 @@ export const TiersIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="tiers"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Timeline.tsx
+++ b/packages/icons/src/exports/Timeline.tsx
@@ -11,7 +11,6 @@ export const TimelineIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="timeline"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/ToggleArrowRight.tsx
+++ b/packages/icons/src/exports/ToggleArrowRight.tsx
@@ -11,7 +11,6 @@ export const ToggleArrowRightIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="toggle-arrow-right"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Token.tsx
+++ b/packages/icons/src/exports/Token.tsx
@@ -11,7 +11,6 @@ export const TokenIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="token"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Transfer.tsx
+++ b/packages/icons/src/exports/Transfer.tsx
@@ -11,7 +11,6 @@ export const TransferIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="transfer"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Translate.tsx
+++ b/packages/icons/src/exports/Translate.tsx
@@ -11,7 +11,6 @@ export const TranslateIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="translate"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Trash.tsx
+++ b/packages/icons/src/exports/Trash.tsx
@@ -11,7 +11,6 @@ export const TrashIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="trash"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/TrendUpward.tsx
+++ b/packages/icons/src/exports/TrendUpward.tsx
@@ -11,7 +11,6 @@ export const TrendUpwardIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="trend-upward"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/TriangleOutline.tsx
+++ b/packages/icons/src/exports/TriangleOutline.tsx
@@ -11,7 +11,6 @@ export const TriangleOutlineIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="triangle-outline"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Trolley.tsx
+++ b/packages/icons/src/exports/Trolley.tsx
@@ -11,7 +11,6 @@ export const TrolleyIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="trolley"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Truncate.tsx
+++ b/packages/icons/src/exports/Truncate.tsx
@@ -11,7 +11,6 @@ export const TruncateIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="truncate"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Twitter.tsx
+++ b/packages/icons/src/exports/Twitter.tsx
@@ -11,7 +11,6 @@ export const TwitterIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="twitter"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Ulist.tsx
+++ b/packages/icons/src/exports/Ulist.tsx
@@ -11,7 +11,6 @@ export const UlistIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="ulist"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Unarchive.tsx
+++ b/packages/icons/src/exports/Unarchive.tsx
@@ -11,7 +11,6 @@ export const UnarchiveIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="unarchive"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Underline.tsx
+++ b/packages/icons/src/exports/Underline.tsx
@@ -11,7 +11,6 @@ export const UnderlineIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="underline"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Undo.tsx
+++ b/packages/icons/src/exports/Undo.tsx
@@ -11,7 +11,6 @@ export const UndoIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="undo"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Unknown.tsx
+++ b/packages/icons/src/exports/Unknown.tsx
@@ -11,7 +11,6 @@ export const UnknownIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="unknown"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Unlink.tsx
+++ b/packages/icons/src/exports/Unlink.tsx
@@ -11,7 +11,6 @@ export const UnlinkIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="unlink"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Unlock.tsx
+++ b/packages/icons/src/exports/Unlock.tsx
@@ -11,7 +11,6 @@ export const UnlockIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="unlock"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Unpublish.tsx
+++ b/packages/icons/src/exports/Unpublish.tsx
@@ -11,7 +11,6 @@ export const UnpublishIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="unpublish"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Upload.tsx
+++ b/packages/icons/src/exports/Upload.tsx
@@ -11,7 +11,6 @@ export const UploadIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="upload"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/User.tsx
+++ b/packages/icons/src/exports/User.tsx
@@ -11,7 +11,6 @@ export const UserIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="user"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Users.tsx
+++ b/packages/icons/src/exports/Users.tsx
@@ -11,7 +11,6 @@ export const UsersIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="users"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Versions.tsx
+++ b/packages/icons/src/exports/Versions.tsx
@@ -11,7 +11,6 @@ export const VersionsIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="versions"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Video.tsx
+++ b/packages/icons/src/exports/Video.tsx
@@ -11,7 +11,6 @@ export const VideoIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="video"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/WarningFilled.tsx
+++ b/packages/icons/src/exports/WarningFilled.tsx
@@ -11,7 +11,6 @@ export const WarningFilledIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="warning-filled"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/WarningOutline.tsx
+++ b/packages/icons/src/exports/WarningOutline.tsx
@@ -11,7 +11,6 @@ export const WarningOutlineIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="warning-outline"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/exports/Wrench.tsx
+++ b/packages/icons/src/exports/Wrench.tsx
@@ -11,7 +11,6 @@ export const WrenchIcon: ForwardRefExoticComponent<
   return (
     <svg
       data-sanity-icon="wrench"
-      width="1em"
       height="1em"
       viewBox="0 0 25 25"
       fill="none"

--- a/packages/icons/src/icon.test.tsx
+++ b/packages/icons/src/icon.test.tsx
@@ -21,7 +21,7 @@ test(
     // just has no drawing content yet, like an `<img>` before its `src` has arrived.
     const fallback = container.querySelector('svg[data-sanity-icon="rocket"]')
     expect(fallback).toBeInTheDocument()
-    expect(fallback).toHaveAttribute('width', '1em')
+    expect(fallback).not.toHaveAttribute('width')
     expect(fallback).toHaveAttribute('height', '1em')
     expect(fallback).toHaveAttribute('viewBox', '0 0 25 25')
     expect(fallback).toHaveAttribute('fill', 'none')
@@ -33,7 +33,7 @@ test(
     }, LOAD_TIMEOUT)
 
     const icon = container.querySelector('svg[data-sanity-icon="rocket"]')
-    expect(icon).toHaveAttribute('width', '1em')
+    expect(icon).not.toHaveAttribute('width')
     expect(icon).toHaveAttribute('height', '1em')
     expect(icon).toHaveAttribute('viewBox', '0 0 25 25')
     expect(icon).toHaveAttribute('fill', 'none')

--- a/packages/icons/src/icon.tsx
+++ b/packages/icons/src/icon.tsx
@@ -23,10 +23,11 @@ export interface IconProps {
  * icon – each one is shown with a copyable import snippet.
  *
  * While the icon chunk loads, a fallback svg with the exact same shell as every generated
- * icon (`data-sanity-icon`, `width`/`height` of `1em`, the shared `viewBox`, and the spread
- * props) is rendered, so the icon slot reserves its final size and responds to the same
- * styling from the first paint – the way an `<img>` with intrinsic dimensions behaves while
- * its `src` is still downloading.
+ * icon (`data-sanity-icon`, `height` of `1em`, no default `width`, the shared `viewBox`, and
+ * the spread props) is rendered, so the icon slot reserves its final size and responds to
+ * the same styling from the first paint – the way an `<img>` with intrinsic dimensions
+ * behaves while its `src` is still downloading. Height-only matches `@sanity/logos` so
+ * Safari Cmd+/- can scale the box (WebKit 199236 / SAPP-933).
  *
  * @public
  */
@@ -45,7 +46,6 @@ export const Icon: ForwardRefExoticComponent<
       fallback={
         <svg
           data-sanity-icon={symbol}
-          width="1em"
           height="1em"
           viewBox="0 0 25 25"
           fill="none"

--- a/packages/ui/src/core/styles/font/responsiveFont.test.ts
+++ b/packages/ui/src/core/styles/font/responsiveFont.test.ts
@@ -6,6 +6,7 @@ import {buildTheme} from '../../../theme/build/buildTheme'
 import {getScopedTheme} from '../../../theme/getScopedTheme'
 import {CSSObject} from '../../../theme/system/css'
 import {ThemeFontKey, ThemeFontSize} from '../../../theme/system/font'
+import {Theme} from '../../../theme/system/theme'
 import {getTheme_v2} from '../../../theme/versioning/getTheme_v2'
 import {rem} from '../helpers'
 import {responsiveFont} from './responsiveFont'
@@ -15,14 +16,39 @@ const fonts = getTheme_v2(theme).font
 
 const FONT_KEYS: ThemeFontKey[] = ['code', 'heading', 'label', 'text']
 
+const ICON_SELECTORS = [
+  '& svg:not([data-sanity-icon])',
+  '& svg:not([data-sanity-icon])[width="1em"]',
+  '& svg:not([data-sanity-icon])[height="1em"]',
+  '& [data-sanity-icon]',
+  '& [data-sanity-icon][width="1em"]',
+  '& [data-sanity-icon][height="1em"]',
+] as const
+
 function sizeStyle(fontKey: ThemeFontKey, sizeIndex: number): CSSObject {
   return responsiveFont(fontKey, {$size: [sizeIndex], theme})[1]
 }
 
-function iconRules(style: CSSObject): CSSObject[] {
-  return Object.entries(style)
-    .filter(([key]) => key.includes('[data-sanity-icon]') || key.includes('svg:not'))
-    .map(([, value]) => value as CSSObject)
+function themeWithTextIconSize(iconSize: number): Theme {
+  const v2 = getTheme_v2(theme)
+  const sizes = v2.font.text.sizes.slice()
+  sizes[2] = Object.assign({}, sizes[2], {iconSize})
+
+  return {
+    sanity: {
+      ...theme.sanity,
+      v2: {
+        ...v2,
+        font: {
+          ...v2.font,
+          text: {
+            ...v2.font.text,
+            sizes,
+          },
+        },
+      },
+    },
+  }
 }
 
 function iconBox(size: ThemeFontSize) {
@@ -46,9 +72,9 @@ describe('responsiveFont icon sizing', () => {
     )
 
     for (const style of styles) {
-      for (const rule of iconRules(style)) {
-        expect(rule).not.toHaveProperty('fontSize')
-        expect(JSON.stringify(rule)).not.toMatch(/font-size/i)
+      for (const selector of ICON_SELECTORS) {
+        expect(style[selector]).not.toHaveProperty('fontSize')
+        expect(JSON.stringify(style[selector])).not.toMatch(/font-size/i)
       }
     }
   })
@@ -71,25 +97,7 @@ describe('responsiveFont icon sizing', () => {
   })
 
   it('reads iconSize from the theme instead of baking in default tokens', () => {
-    const customTheme = {
-      sanity: {
-        ...theme.sanity,
-        v2: {
-          ...theme.sanity.v2,
-          font: {
-            ...fonts,
-            text: {
-              ...fonts.text,
-              sizes: fonts.text.sizes.map((size, index) =>
-                index === 2 ? {...size, iconSize: 99} : size,
-              ),
-            },
-          },
-        },
-      },
-    }
-
-    const style = responsiveFont('text', {$size: [2], theme: customTheme})[1]
+    const style = responsiveFont('text', {$size: [2], theme: themeWithTextIconSize(99)})[1]
 
     expect(style['& [data-sanity-icon][width="1em"]']).toEqual({width: rem(99)})
     expect(style['& [data-sanity-icon][height="1em"]']).toEqual({height: rem(99)})
@@ -100,9 +108,11 @@ describe('responsiveFont icon sizing', () => {
   it('keeps the rem icon box on responsive breakpoints', () => {
     const styles = responsiveFont('text', {$size: [1, 2], theme})
     const expected = iconBox(fonts.text.sizes[2])
-    const mediaStyle = Object.values(styles[2])[0] as CSSObject
+    const mediaKey = Object.keys(styles[2])[0]
 
-    expect(mediaStyle['& [data-sanity-icon][height="1em"]']).toEqual({height: expected.iconSize})
-    expect(iconRules(mediaStyle).every((rule) => !('fontSize' in rule))).toBe(true)
+    expect(styles[2][mediaKey]).toMatchObject({
+      '& [data-sanity-icon][height="1em"]': {height: expected.iconSize},
+    })
+    expect(JSON.stringify(styles[2][mediaKey])).not.toMatch(/font-size/i)
   })
 })

--- a/packages/ui/src/core/styles/font/responsiveFont.test.ts
+++ b/packages/ui/src/core/styles/font/responsiveFont.test.ts
@@ -1,0 +1,108 @@
+/** @vitest-environment node */
+
+import {describe, expect, it} from 'vitest'
+
+import {buildTheme} from '../../../theme/build/buildTheme'
+import {getScopedTheme} from '../../../theme/getScopedTheme'
+import {CSSObject} from '../../../theme/system/css'
+import {ThemeFontKey, ThemeFontSize} from '../../../theme/system/font'
+import {getTheme_v2} from '../../../theme/versioning/getTheme_v2'
+import {rem} from '../helpers'
+import {responsiveFont} from './responsiveFont'
+
+const theme = getScopedTheme(buildTheme(), 'light', 'default')
+const fonts = getTheme_v2(theme).font
+
+const FONT_KEYS: ThemeFontKey[] = ['code', 'heading', 'label', 'text']
+
+function sizeStyle(fontKey: ThemeFontKey, sizeIndex: number): CSSObject {
+  return responsiveFont(fontKey, {$size: [sizeIndex], theme})[1]
+}
+
+function iconRules(style: CSSObject): CSSObject[] {
+  return Object.entries(style)
+    .filter(([key]) => key.includes('[data-sanity-icon]') || key.includes('svg:not'))
+    .map(([, value]) => value as CSSObject)
+}
+
+function iconBox(size: ThemeFontSize) {
+  const {ascenderHeight, descenderHeight, fontSize, iconSize, lineHeight} = size
+  const capHeight = lineHeight - (ascenderHeight + descenderHeight)
+  const customIconSize = Math.floor((fontSize * 1.125) / 2) * 2 + 1
+
+  return {
+    customIconOffset: rem((capHeight - customIconSize) / 2),
+    customIconSize: rem(customIconSize),
+    fontSize: rem(fontSize),
+    iconOffset: rem((capHeight - iconSize) / 2),
+    iconSize: rem(iconSize),
+  }
+}
+
+describe('responsiveFont icon sizing', () => {
+  it('does not set font-size on descendant SVG icon selectors', () => {
+    const styles = FONT_KEYS.flatMap((fontKey) =>
+      fonts[fontKey].sizes.map((_, sizeIndex) => sizeStyle(fontKey, sizeIndex)),
+    )
+
+    for (const style of styles) {
+      for (const rule of iconRules(style)) {
+        expect(rule).not.toHaveProperty('fontSize')
+        expect(JSON.stringify(rule)).not.toMatch(/font-size/i)
+      }
+    }
+  })
+
+  it('sizes default 1em axes with rem and leaves the unguarded selectors as margin only', () => {
+    const style = sizeStyle('text', 2)
+    const expected = iconBox(fonts.text.sizes[2])
+
+    expect(style.fontSize).toBe(expected.fontSize)
+    expect(style['& svg:not([data-sanity-icon])']).toEqual({margin: expected.customIconOffset})
+    expect(style['& svg:not([data-sanity-icon])[width="1em"]']).toEqual({
+      width: expected.customIconSize,
+    })
+    expect(style['& svg:not([data-sanity-icon])[height="1em"]']).toEqual({
+      height: expected.customIconSize,
+    })
+    expect(style['& [data-sanity-icon]']).toEqual({margin: expected.iconOffset})
+    expect(style['& [data-sanity-icon][width="1em"]']).toEqual({width: expected.iconSize})
+    expect(style['& [data-sanity-icon][height="1em"]']).toEqual({height: expected.iconSize})
+  })
+
+  it('reads iconSize from the theme instead of baking in default tokens', () => {
+    const customTheme = {
+      sanity: {
+        ...theme.sanity,
+        v2: {
+          ...theme.sanity.v2,
+          font: {
+            ...fonts,
+            text: {
+              ...fonts.text,
+              sizes: fonts.text.sizes.map((size, index) =>
+                index === 2 ? {...size, iconSize: 99} : size,
+              ),
+            },
+          },
+        },
+      },
+    }
+
+    const style = responsiveFont('text', {$size: [2], theme: customTheme})[1]
+
+    expect(style['& [data-sanity-icon][width="1em"]']).toEqual({width: rem(99)})
+    expect(style['& [data-sanity-icon][height="1em"]']).toEqual({height: rem(99)})
+    expect(style['& [data-sanity-icon]']).not.toHaveProperty('width')
+    expect(style['& [data-sanity-icon]']).not.toHaveProperty('height')
+  })
+
+  it('keeps the rem icon box on responsive breakpoints', () => {
+    const styles = responsiveFont('text', {$size: [1, 2], theme})
+    const expected = iconBox(fonts.text.sizes[2])
+    const mediaStyle = Object.values(styles[2])[0] as CSSObject
+
+    expect(mediaStyle['& [data-sanity-icon][height="1em"]']).toEqual({height: expected.iconSize})
+    expect(iconRules(mediaStyle).every((rule) => !('fontSize' in rule))).toBe(true)
+  })
+})

--- a/packages/ui/src/core/styles/font/responsiveFont.ts
+++ b/packages/ui/src/core/styles/font/responsiveFont.ts
@@ -88,14 +88,31 @@ function fontSize(size: ThemeFontSize): CSSObject {
       marginBottom: '-1px',
     },
 
+    // WebKit 199236: font-size on an SVG means page zoom does not scale 1em
+    // width/height. Size default 1em axes with rem instead. Do not restore
+    // fontSize on these selectors (SAPP-933).
     '& svg:not([data-sanity-icon])': {
-      fontSize: `calc(${customIconSize} / 16 * 1rem)`,
       margin: rem(customIconOffset),
     },
 
+    '& svg:not([data-sanity-icon])[width="1em"]': {
+      width: rem(customIconSize),
+    },
+
+    '& svg:not([data-sanity-icon])[height="1em"]': {
+      height: rem(customIconSize),
+    },
+
     '& [data-sanity-icon]': {
-      fontSize: `calc(${iconSize} / 16 * 1rem)`,
       margin: rem(iconOffset),
+    },
+
+    '& [data-sanity-icon][width="1em"]': {
+      width: rem(iconSize),
+    },
+
+    '& [data-sanity-icon][height="1em"]': {
+      height: rem(iconSize),
     },
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [SAPP-933](https://linear.app/sanity/issue/SAPP-933). The confirmed defect is in this repo’s live `@sanity/icons` source (`packages/icons`; `sanity-io/icons` is archived): every glyph was emitted as `width="1em" height="1em"`. Safari does not scale those attributes with Cmd+/- ([WebKit 199236](https://bugs.webkit.org/show_bug.cgi?id=199236), REOPENED). Chrome does. The Studio mark that already scales is `@sanity/logos` (`height="1em"` only). This is not [DS-101](https://linear.app/sanity/issue/DS-101).

The 22 Aug Linear note that this was “not a Studio App implementation” was only a missing checkout of this repo. It is not a reason to skip the fix.

## Change

1. **`@sanity/icons` (the confirmed defect)** — generator, `<Icon>` fallback, and all 236 generated glyphs now emit the logos shell: `height="1em"` only. Square `viewBox` keeps the used width. Documented `style={{fontSize}}` still sizes via `1em`.
2. **`@sanity/ui`** — `responsiveFont()` no longer sets `font-size` on descendant SVGs (the WebKit 199236 title case). Theme `iconSize` is rem `width`/`height` only while the SVG still has the default `1em` presentation attributes.

Patch on both packages.

## Verification

### Confirmed defect (current checkout, before the generator change)

`packages/icons/scripts/generate.ts` rewrote the 25px shell to both-axis `1em`. Generated `Add.tsx` and the `<Icon>` fallback both had `width="1em" height="1em"`. `SanityMonogram` has `height="1em"` only.

### GREEN after — height-only icons inside `@sanity/ui`

Button WithIcons: **no `width` attribute**, `height="1em"`, used box **21×21**, inherited `font-size: 13px`. Chromium and Playwright WebKit match. If rem height were ignored, these would be 13×13.

[After height-only shell: Button WithIcons 21px icons in Chromium](https://cursor.com/agents/bc-bf1f895b-2afb-49d6-8232-6ffb74c9e87b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_height_only_button_chromium.png)

[After height-only shell: Button WithIcons 21px icons in WebKit](https://cursor.com/agents/bc-bf1f895b-2afb-49d6-8232-6ffb74c9e87b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_height_only_button_webkit.png)

Knock-on Storybook walkthrough (Button, Text, Heading, Dialog, Menu) from the earlier `responsiveFont()` pass:

[storybook_icon_surfaces_after_fix.webm](https://cursor.com/agents/bc-bf1f895b-2afb-49d6-8232-6ffb74c9e87b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_icon_surfaces_after_fix.webm)

Unit tests: `@sanity/icons` 487 passed; `responsiveFont` contract 4 passed.

### Still needs a human

This Linux VM cannot drive Safari Cmd+/- page zoom. Please check 75 / 100 / 150 / 200% on Button+icon, Dialog close, and a `SanityLogo` inside `Text` before merge.

## Linear

https://linear.app/sanity/issue/SAPP-933

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf1f895b-2afb-49d6-8232-6ffb74c9e87b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf1f895b-2afb-49d6-8232-6ffb74c9e87b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

