### PR TITLE
feat(docs): add sitemap derived from the nav tree

### DIFF
--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type {MetadataRoute} from 'next'
+
+import type {NavNode} from '@/lib/nav/types'
+
+import {navTree} from './(website)/navTree'
+
+// Served at /ui/sitemap.xml (the basePath applies to the route, but not to
+// the entry URLs, so the base path must be part of the origin here). Every
+// routable page is included — `hidden` only excludes a page from the navbar
+// and sidebar, not from indexing.
+const ORIGIN = 'https://www.sanity.io/ui'
+
+function collectPageUrls(node: NavNode, urls: string[]): string[] {
+  if (node.hasPage) urls.push(`${ORIGIN}${node.href}`)
+  for (const child of node.children ?? []) collectPageUrls(child, urls)
+  return urls
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return collectPageUrls(navTree, []).map((url) => ({url}))
+}


### PR DESCRIPTION
## What

Adds a sitemap to the docs app at `/ui/sitemap.xml` using the Next.js `app/sitemap.ts` metadata convention.

## How

Instead of hardcoding routes, the sitemap walks the existing `navTree` (already derived from the colocated `nav.ts`/`page.tsx` files via `import.meta.glob`), so new docs pages are included automatically. All routable pages are included — `hidden` only excludes a page from the navbar/sidebar, not from indexing.

Because the app runs under the `/ui` basePath, the sitemap route is served at `/ui/sitemap.xml`, while entry URLs are built from the production origin `https://www.sanity.io/ui`.

## Verification

- `pnpm typecheck` passes
- Fetched `/ui/sitemap.xml` from the dev server: valid sitemap XML with 53 URLs, matching the 53 `page.tsx` files under `(website)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive docs metadata only; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Adds `/ui/sitemap.xml` for the docs app via Next.js `sitemap.ts`.
> 
> URLs are collected by walking `navTree` and including every node with `hasPage`, so new pages are indexed automatically. Hidden nav items still appear in the sitemap. Entry URLs use the production origin `https://www.sanity.io/ui` because `basePath` applies to the sitemap route but not to listed URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbcf5069d51755f84e78274ae76745db987e9f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->