### PR TITLE
fix: support cross-file transformations in layout codemods

### DIFF
--- a/packages/ui-codemod/src/constants/latest/layout-mods.ts
+++ b/packages/ui-codemod/src/constants/latest/layout-mods.ts
@@ -411,6 +411,10 @@ export const LAYOUT_MODS: AttributeMods = {
       border: 'border-box',
     },
   },
+  space: {
+    type: 'rename-only',
+    name: 'gap',
+  },
   textAlign: {
     type: 'style-only',
     style: 'textAlign',

--- a/packages/ui-codemod/src/transforms/latest/box/box.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/box/box.test.ts
@@ -255,8 +255,7 @@ defineCrossFileTest(
     }
   `,
   (output) => {
-    expect(output).toContain('alignItems: "center"')
-    expect(output).not.toContain('<RootBox alignItems="center" />')
+    expect(output.replace(/\s+/g, ' ')).toContain('<RootBox style={{ alignItems: "center" }} />')
   },
   'transforms attributes on imported styled Box wrappers',
 )
@@ -279,7 +278,6 @@ defineCrossFileTest(
   (output) => {
     expect(output).toContain('UI-CODEMOD TODO: Please double check styled(Box) migration below')
     expect(output).toContain('<RootBox display="flex" alignItems="center" />')
-    expect(output).not.toContain('const RootBox = styled(Box)')
   },
   'adds todo warning when imported styled Box wrapper should be replaced',
 )
@@ -306,10 +304,8 @@ defineCrossFileTest(
     }
   `,
   (output) => {
-    expect(output).toContain('alignItems: "center"')
-    expect(output).not.toContain('<RootBox alignItems="center" />')
+    expect(output.replace(/\s+/g, ' ')).toContain('<RootBox style={{ alignItems: "center" }} />')
     expect(output).toContain('<Box display="flex" />')
-    expect(output).not.toContain('<Flex')
   },
   'does not rewrite unrelated Box from another package',
 )
@@ -330,8 +326,7 @@ defineCrossFileTest(
     }
   `,
   (output) => {
-    expect(output).toContain('alignItems: "center"')
-    expect(output).not.toContain('<RootBox alignItems="center" />')
+    expect(output.replace(/\s+/g, ' ')).toContain('<RootBox style={{ alignItems: "center" }} />')
   },
   'transforms styled Box wrappers imported through barrel re-exports',
   {

--- a/packages/ui-codemod/src/transforms/latest/container/container.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/container/container.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './container'
 
 defineInlineTest(
@@ -102,4 +104,79 @@ defineInlineTest(
     }} />
   `,
   'moves grid props to style and updates mapped values',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Container} from '@sanity/ui'
+
+    export const RootContainer = styled(Container)(({theme}) => ({}))
+  `,
+  `
+    import {RootContainer} from './Component.styled'
+
+    export function Component() {
+      return <RootContainer width={2} />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootContainer size={2} />')
+  },
+  'transforms attributes on imported styled Container wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Container} from '@sanity/ui'
+
+    export const RootContainer = styled(Container)(({theme}) => ({}))
+  `,
+  `
+    import {Container} from 'another-package'
+    import {RootContainer} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootContainer width={2} />
+          <Container width={2} />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootContainer size={2} />')
+    expect(output).toContain('<Container width={2} />')
+  },
+  'does not transform attributes on unrelated Container from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Container} from '@sanity/ui'
+
+    export const RootContainer = styled(Container)(({theme}) => ({}))
+  `,
+  `
+    import {RootContainer} from './index'
+
+    export function Component() {
+      return <RootContainer width={2} />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootContainer size={2} />')
+  },
+  'transforms styled Container wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootContainer} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/container/container.ts
+++ b/packages/ui-codemod/src/transforms/latest/container/container.ts
@@ -2,10 +2,12 @@ import {type API, type FileInfo} from 'jscodeshift'
 
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {CONTAINER_MODS} from './container.mods'
 
 const TODO_WARNING = 'Please double check the Container migration below'
@@ -20,8 +22,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Container', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Container',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Container', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Container', localNames, options, styledAliases)) {
       return
     }
 
@@ -29,14 +39,24 @@ export default function transform(
       markChanged()
     }
 
-    root
-      .find(j.JSXOpeningElement, {
-        name: {type: 'JSXIdentifier', name: 'Container'},
+    root.find(j.JSXOpeningElement).forEach((path) => {
+      const name = path.node.name
+
+      if (name.type !== 'JSXIdentifier' || !localNames.has(name.name)) {
+        return
+      }
+
+      if (transformAttributes(j, path, CONTAINER_MODS, TODO_WARNING)) {
+        markChanged()
+      }
+    })
+
+    if (
+      transformStyledComponents(j, root, styledAliases, () => true, {
+        callback: (path) => transformAttributes(j, path, CONTAINER_MODS, TODO_WARNING),
       })
-      .forEach((path) => {
-        if (transformAttributes(j, path, CONTAINER_MODS, TODO_WARNING)) {
-          markChanged()
-        }
-      })
+    ) {
+      markChanged()
+    }
   })
 }

--- a/packages/ui-codemod/src/transforms/latest/grid/grid.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/grid/grid.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './grid'
 
 defineInlineTest(
@@ -94,4 +96,79 @@ defineInlineTest(
   />
   `,
   'updates v3 grid props mapped values',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Grid} from '@sanity/ui'
+
+    export const RootGrid = styled(Grid)(({theme}) => ({}))
+  `,
+  `
+    import {RootGrid} from './Component.styled'
+
+    export function Component() {
+      return <RootGrid autoCols="auto" />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootGrid gridAutoColumns="auto" />')
+  },
+  'transforms attributes on imported styled Grid wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Grid} from '@sanity/ui'
+
+    export const RootGrid = styled(Grid)(({theme}) => ({}))
+  `,
+  `
+    import {Grid} from 'another-package'
+    import {RootGrid} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootGrid autoCols="auto" />
+          <Grid autoCols="auto" />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootGrid gridAutoColumns="auto" />')
+    expect(output).toContain('<Grid autoCols="auto" />')
+  },
+  'does not transform attributes on unrelated Grid from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Grid} from '@sanity/ui'
+
+    export const RootGrid = styled(Grid)(({theme}) => ({}))
+  `,
+  `
+    import {RootGrid} from './index'
+
+    export function Component() {
+      return <RootGrid autoCols="auto" />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootGrid gridAutoColumns="auto" />')
+  },
+  'transforms styled Grid wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootGrid} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/grid/grid.ts
+++ b/packages/ui-codemod/src/transforms/latest/grid/grid.ts
@@ -2,10 +2,12 @@ import {type API, type FileInfo} from 'jscodeshift'
 
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {GRID_MODS} from './grid.mods'
 
 const TODO_WARNING = 'Please double check the Grid migration below'
@@ -20,8 +22,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Grid', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Grid',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Grid', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Grid', localNames, options, styledAliases)) {
       return
     }
 
@@ -29,14 +39,24 @@ export default function transform(
       markChanged()
     }
 
-    root
-      .find(j.JSXOpeningElement, {
-        name: {type: 'JSXIdentifier', name: 'Grid'},
+    root.find(j.JSXOpeningElement).forEach((path) => {
+      const name = path.node.name
+
+      if (name.type !== 'JSXIdentifier' || !localNames.has(name.name)) {
+        return
+      }
+
+      if (transformAttributes(j, path, GRID_MODS, TODO_WARNING)) {
+        markChanged()
+      }
+    })
+
+    if (
+      transformStyledComponents(j, root, styledAliases, () => true, {
+        callback: (path) => transformAttributes(j, path, GRID_MODS, TODO_WARNING),
       })
-      .forEach((path) => {
-        if (transformAttributes(j, path, GRID_MODS, TODO_WARNING)) {
-          markChanged()
-        }
-      })
+    ) {
+      markChanged()
+    }
   })
 }

--- a/packages/ui-codemod/src/transforms/latest/inline/inline.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/inline/inline.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './inline'
 
 defineInlineTest(
@@ -54,4 +56,79 @@ defineInlineTest(
   <Inline margin={2} />
   `,
   'warns if margin prop is present',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Inline} from '@sanity/ui'
+
+    export const RootInline = styled(Inline)(({theme}) => ({}))
+  `,
+  `
+    import {RootInline} from './Component.styled'
+
+    export function Component() {
+      return <RootInline space={2} />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootInline gap={2} />')
+  },
+  'transforms attributes on imported styled Inline wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Inline} from '@sanity/ui'
+
+    export const RootInline = styled(Inline)(({theme}) => ({}))
+  `,
+  `
+    import {Inline} from 'another-package'
+    import {RootInline} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootInline space={2} />
+          <Inline space={2} />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootInline gap={2} />')
+    expect(output).toContain('<Inline space={2} />')
+  },
+  'does not transform attributes on unrelated Inline from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Inline} from '@sanity/ui'
+
+    export const RootInline = styled(Inline)(({theme}) => ({}))
+  `,
+  `
+    import {RootInline} from './index'
+
+    export function Component() {
+      return <RootInline space={2} />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootInline gap={2} />')
+  },
+  'transforms styled Inline wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootInline} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/inline/inline.ts
+++ b/packages/ui-codemod/src/transforms/latest/inline/inline.ts
@@ -2,10 +2,12 @@ import {type API, type FileInfo} from 'jscodeshift'
 
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {INLINE_MODS} from './inline.mods'
 
 const TODO_WARNING = 'Please double check the Inline migration below'
@@ -20,8 +22,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Inline', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Inline',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Inline', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Inline', localNames, options, styledAliases)) {
       return
     }
 
@@ -29,14 +39,24 @@ export default function transform(
       markChanged()
     }
 
-    root
-      .find(j.JSXOpeningElement, {
-        name: {type: 'JSXIdentifier', name: 'Inline'},
+    root.find(j.JSXOpeningElement).forEach((path) => {
+      const name = path.node.name
+
+      if (name.type !== 'JSXIdentifier' || !localNames.has(name.name)) {
+        return
+      }
+
+      if (transformAttributes(j, path, INLINE_MODS, TODO_WARNING)) {
+        markChanged()
+      }
+    })
+
+    if (
+      transformStyledComponents(j, root, styledAliases, () => true, {
+        callback: (path) => transformAttributes(j, path, INLINE_MODS, TODO_WARNING),
       })
-      .forEach((path) => {
-        if (transformAttributes(j, path, INLINE_MODS, TODO_WARNING)) {
-          markChanged()
-        }
-      })
+    ) {
+      markChanged()
+    }
   })
 }

--- a/packages/ui-codemod/src/transforms/latest/stack/stack.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/stack/stack.test.ts
@@ -248,7 +248,7 @@ defineCrossFileTest(
     }
   `,
   (output) => {
-    expect(output).not.toContain('<RootStack space={2} />')
+    expect(output).toContain('<RootStack gap={2} />')
   },
   'transforms styled Stack wrappers imported through barrel re-exports',
   {

--- a/packages/ui-codemod/src/transforms/latest/stack/stack.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/stack/stack.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './stack'
 
 defineInlineTest(
@@ -157,4 +159,101 @@ defineInlineTest(
   <Flex padding={1} width="100%" flexDirection="column" />
   `,
   'replaces Stack with Flex and transforms attributes',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Stack} from '@sanity/ui'
+
+    export const RootStack = styled(Stack)(({theme}) => ({}))
+  `,
+  `
+    import {RootStack} from './Component.styled'
+
+    export function Component() {
+      return <RootStack space={2} />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootStack gap={2} />')
+  },
+  'transforms attributes on imported styled Stack wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Stack} from '@sanity/ui'
+
+    export const RootStack = styled(Stack)(({theme}) => ({}))
+  `,
+  `
+    import {RootStack} from './Component.styled'
+
+    export function Component() {
+      return <RootStack padding={2} />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('UI-CODEMOD TODO: Please double check styled(Stack) migration below')
+    expect(output).toContain('<RootStack padding={2} />')
+  },
+  'adds todo warning when imported styled Stack wrapper should be replaced',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Stack} from '@sanity/ui'
+
+    export const RootStack = styled(Stack)(({theme}) => ({}))
+  `,
+  `
+    import {Stack} from 'another-package'
+    import {RootStack} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootStack space={2} />
+          <Stack space={2} />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootStack gap={2} />')
+    expect(output).toContain('<Stack space={2} />')
+  },
+  'does not rewrite unrelated Stack from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Stack} from '@sanity/ui'
+
+    export const RootStack = styled(Stack)(({theme}) => ({}))
+  `,
+  `
+    import {RootStack} from './index'
+
+    export function Component() {
+      return <RootStack space={2} />
+    }
+  `,
+  (output) => {
+    expect(output).not.toContain('<RootStack space={2} />')
+  },
+  'transforms styled Stack wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootStack} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/stack/stack.ts
+++ b/packages/ui-codemod/src/transforms/latest/stack/stack.ts
@@ -3,16 +3,19 @@ import {type API, type FileInfo, type JSXElement} from 'jscodeshift'
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {addAttribute} from '../../../utils/addAttribute'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {replaceElement} from '../../../utils/replaceElement'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {FLEX_MODS} from '../flex/flex.mods'
 import {STACK_MODS} from './stack.mods'
 
 const STACK_TODO_WARNING = 'Please double check the Stack migration below'
 const FLEX_TODO_WARNING = 'Please double check the Flex migration below'
+const STYLED_TODO_WARNING = 'Please double check styled(Stack) migration below'
 
 function hasFlexAttrs(attrs: JSXElement['openingElement']['attributes']) {
   if (!attrs) {
@@ -26,7 +29,9 @@ function hasFlexAttrs(attrs: JSXElement['openingElement']['attributes']) {
       (attr.name.name.startsWith('padding') ||
         attr.name.name.startsWith('margin') ||
         attr.name.name.startsWith('overflow') ||
-        attr.name.name.startsWith('flex')),
+        attr.name.name.startsWith('flex') ||
+        attr.name.name.endsWith('height') ||
+        attr.name.name.endsWith('width')),
   )
 }
 
@@ -40,8 +45,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Stack', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Stack',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Stack', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Stack', localNames, options, styledAliases)) {
       return
     }
 
@@ -58,6 +71,7 @@ export default function transform(
         },
         {
           element: 'Stack',
+          localNames,
         },
         {
           element: 'Flex',
@@ -89,12 +103,22 @@ export default function transform(
         },
         {
           element: 'Stack',
+          localNames,
         },
         {
           element: 'VStack',
           callback: (path) => transformAttributes(j, path, STACK_MODS, STACK_TODO_WARNING),
         },
       )
+    ) {
+      markChanged()
+    }
+
+    if (
+      transformStyledComponents(j, root, styledAliases, (attrs) => !hasFlexAttrs(attrs), {
+        warning: STYLED_TODO_WARNING,
+        callback: (path) => transformAttributes(j, path, STACK_MODS, STACK_TODO_WARNING),
+      })
     ) {
       markChanged()
     }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR updates the layout component codemods to support cross-file styled component transformations. This is something that needs to be done across all codemods but I figured it would be easier to split the changes into batches. 

There is some repetition, especially in the tests. I might try to refactor later but, since some codemods (Box and Stack for example) have unique transformations, I haven't tried to split running `transformComponents` and `transformStyledComponents` into a separate function yet.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the logic across files seems consistent.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Each codemod includes tests for the crossfile transformations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to ui-codemod migration tooling and tests; runtime app behavior is unaffected, with moderate risk only if codemods mis-transform consumer code.
> 
> **Overview**
> Layout codemods (**Container**, **Grid**, **Inline**, **Stack**) now follow the same cross-file pattern as **Box**: they resolve `styled(Component)` aliases via `getStyledComponentAliases`, match JSX by import-local names (not hardcoded tags), and run `transformStyledComponents` so usages like `<RootStack />` imported from another file get prop migrations.
> 
> Shared layout mods gain **`space` → `gap`**. **Stack** treats width/height-style props as flex-layout signals in `hasFlexAttrs`, passes `localNames` into `replaceElement`, and emits a TODO when a styled **Stack** wrapper needs manual replacement instead of auto **Flex**/**VStack** rewrites.
> 
> Tests add `defineCrossFileTest` coverage (barrel re-exports, unrelated packages) and **Box** expectations now assert inline `style` props on styled wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f25d72b6dc1bd015b78dcdea08203a07c3fa78bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->