### PR TITLE
feat: add Modal adjustments (polyfill, size prop)

### DIFF
--- a/.changeset/sharp-cloths-stand.md
+++ b/.changeset/sharp-cloths-stand.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui': patch
+---
+
+adds `size` prop for Modal, and polyfill for closedby=any

--- a/apps/storybook/src/stories/Modal.stories.tsx
+++ b/apps/storybook/src/stories/Modal.stories.tsx
@@ -5,7 +5,6 @@ import {Dialog} from 'ui3'
 
 import {Box} from '../../../../packages/ui/src/components/box/Box'
 import {Button} from '../../../../packages/ui/src/components/button/Button'
-import {Container} from '../../../../packages/ui/src/components/container/Container'
 import {Flex} from '../../../../packages/ui/src/components/flex/Flex'
 import {Modal} from '../../../../packages/ui/src/components/modal/Modal'
 import {type ModalProps, modalProps} from '../../../../packages/ui/src/components/modal/modal.props'

--- a/apps/storybook/src/stories/Modal.stories.tsx
+++ b/apps/storybook/src/stories/Modal.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta<typeof Modal> = {
   title: 'Components/Modal',
   args: {
     header: 'Modal heading',
+    size: 0,
   },
   argTypes,
   component: Modal,
@@ -39,36 +40,32 @@ type Story = StoryObj<typeof Modal>
 
 function LongBodyContent() {
   return (
-    <Container size={0}>
-      <VStack gap={3}>
-        <Text>
-          Sanity is a fully customizable all-code backend for all your content-driven websites and
-          apps—their builders and creators.
-        </Text>
-        <Text>
-          It provides the structured foundation, automation layer, and agentic context companies
-          need to move faster, work smarter, and power every content experience—from websites to AI
-          agents.
-        </Text>
-        <Text>
-          Build a content system that matches how your business operates with three interconnected
-          layers.
-        </Text>
-        <Text>
-          Sanity is a fully customizable all-code backend for all your content-driven websites and
-          apps—their builders and creators.
-        </Text>
-        <Text>
-          It provides the structured foundation, automation layer, and agentic context companies
-          need to move faster, work smarter, and power every content experience—from websites to AI
-          agents.
-        </Text>
-        <Text>
-          Build a content system that matches how your business operates with three interconnected
-          layers.
-        </Text>
-      </VStack>
-    </Container>
+    <VStack gap={3}>
+      <Text>
+        Sanity is a fully customizable all-code backend for all your content-driven websites and
+        apps—their builders and creators.
+      </Text>
+      <Text>
+        It provides the structured foundation, automation layer, and agentic context companies need
+        to move faster, work smarter, and power every content experience—from websites to AI agents.
+      </Text>
+      <Text>
+        Build a content system that matches how your business operates with three interconnected
+        layers.
+      </Text>
+      <Text>
+        Sanity is a fully customizable all-code backend for all your content-driven websites and
+        apps—their builders and creators.
+      </Text>
+      <Text>
+        It provides the structured foundation, automation layer, and agentic context companies need
+        to move faster, work smarter, and power every content experience—from websites to AI agents.
+      </Text>
+      <Text>
+        Build a content system that matches how your business operates with three interconnected
+        layers.
+      </Text>
+    </VStack>
   )
 }
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -85,6 +85,7 @@
     "@sanity/icons": "^3.7.4",
     "clsx": "^2.1.1",
     "comment-json": "^5.0.0",
+    "dialog-closedby-polyfill": "^1.3.0",
     "interestfor": "^1.0.8",
     "react-refractor": "^4.0.0"
   },

--- a/packages/ui/src/components/modal/Modal.tsx
+++ b/packages/ui/src/components/modal/Modal.tsx
@@ -14,16 +14,11 @@ const modalClassName = suffixClassName('sui-Modal')
 const modalContentClassName = suffixClassName('sui-ModalContent')
 const modalFooterClassName = suffixClassName('sui-ModalFooter')
 
-function ModalRoot(props: ModalProps) {
-  const {
-    children,
-    className,
-    style,
-    header,
-    open = false,
-    onClose,
-    ...rest
-  } = getProps(props, modalProps)
+function ModalRoot({open = false, size = 0, ...props}: ModalProps) {
+  const {children, className, style, header, onClose, ...rest} = getProps(
+    {size, ...props},
+    modalProps,
+  )
 
   const modalRef = useRef<HTMLDialogElement>(null)
   const headerId = useId()

--- a/packages/ui/src/components/modal/modal.css
+++ b/packages/ui/src/components/modal/modal.css
@@ -1,7 +1,7 @@
 .sui-Modal {
-  min-width: 320px;
-  max-width: 80dvw;
-  max-height: 80dvh;
+  /* Computed width is moderated by Modal's size prop, which controls max-width */
+  width: calc(100dvw - 2rem);
+  max-height: calc(100dvh - 2rem);
   transition:
     display 150ms allow-discrete,
     overlay 150ms allow-discrete,

--- a/packages/ui/src/components/modal/modal.props.ts
+++ b/packages/ui/src/components/modal/modal.props.ts
@@ -1,4 +1,6 @@
+import {CONTAINER_SIZE, type ContainerSize} from '../../types/Container'
 import {type PropDef} from '../../types/PropDef'
+import type {Responsive} from '../../types/Responsive'
 
 /** @beta */
 export interface ModalProps extends Omit<React.ComponentProps<'dialog'>, 'open'> {
@@ -8,6 +10,8 @@ export interface ModalProps extends Omit<React.ComponentProps<'dialog'>, 'open'>
   onClose: React.ReactEventHandler<HTMLDialogElement>
   /** Whether the modal is open; defaults to false. */
   open?: boolean
+  /** Max width of the modal */
+  size?: Responsive<ContainerSize>
 }
 
 export const modalProps: Record<string, PropDef> = {
@@ -16,5 +20,10 @@ export const modalProps: Record<string, PropDef> = {
   },
   open: {
     type: 'boolean',
+  },
+  size: {
+    type: 'union',
+    className: 'container',
+    values: CONTAINER_SIZE,
   },
 }

--- a/packages/ui/src/polyfills.ts
+++ b/packages/ui/src/polyfills.ts
@@ -10,6 +10,6 @@ if (
   void import('interestfor')
 }
 
-if (!isClosedBySupported()) {
+if (typeof HTMLDialogElement !== 'undefined' && !isClosedBySupported()) {
   applyClosedByPolyfill()
 }

--- a/packages/ui/src/polyfills.ts
+++ b/packages/ui/src/polyfills.ts
@@ -1,6 +1,15 @@
+import {
+  apply as applyClosedByPolyfill,
+  isSupported as isClosedBySupported,
+} from 'dialog-closedby-polyfill'
+
 if (
   typeof HTMLButtonElement !== 'undefined' &&
   !('interestForElement' in HTMLButtonElement.prototype)
 ) {
   void import('interestfor')
+}
+
+if (!isClosedBySupported()) {
+  applyClosedByPolyfill()
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,6 +453,9 @@ importers:
       comment-json:
         specifier: ^5.0.0
         version: 5.0.0
+      dialog-closedby-polyfill:
+        specifier: ^1.3.0
+        version: 1.3.0
       interestfor:
         specifier: ^1.0.8
         version: 1.0.8
@@ -4004,6 +4007,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dialog-closedby-polyfill@1.3.0:
+    resolution: {integrity: sha512-II3pxe/zr5OLhbqrkjQgXDFp61ICPlGZspNIgERwUUCLLHgQzPjv3VTStGD4W+ujwR5zMCZAdcWgu5nTmOIUYQ==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
@@ -9104,8 +9110,8 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
@@ -10094,6 +10100,8 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
+
+  dialog-closedby-polyfill@1.3.0: {}
 
   diff@4.0.4: {}
 


### PR DESCRIPTION
### Description

- Polyfills `closedby=any` for Safari
- Adds `size` prop to Modal to control max width

### What to review

- The two implementations noted above

### Testing

- Tested polyfill by clicking Modal backdrop on Safari — it closed!
- Tested `size` prop in Storybook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modal dimensions change for all consumers by default, and the closedby polyfill alters native dialog close behavior where the feature is missing.
> 
> **Overview**
> **Modal** now accepts a **`size`** prop (`Responsive<ContainerSize>`, default **`0`**) that applies the same **container** max-width utilities as **`Container`**, so width caps align with the design system instead of a fixed **`80dvw`** ceiling.
> 
> Modal **layout CSS** shifts to **`width: calc(100dvw - 2rem)`** and **`max-height: calc(100dvh - 2rem)`**, with max width driven by **`size`**; the old **`min-width: 320px`** / **`max-width: 80dvw`** rules are removed.
> 
> **Safari** (and other browsers without native support) get **`dialog-closedby-polyfill`** wired in **`polyfills.ts`**, so the existing **`closedby="any"`** on the dialog element allows **backdrop click to close**, matching behavior already expected from the **`onClose`** API.
> 
> Storybook adds **`size`** to default args and drops an extra **`Container`** wrapper in long-content demos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c627327a78e64ff55671f0023bdaa08e4eb7047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->