### PR TITLE
chore: add Storybook MCP skills from storybookjs/mcp

### DIFF
--- a/.agents/skills/stories/SKILL.md
+++ b/.agents/skills/stories/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: stories
+description: Invoke FIRST, before creating, editing, or deleting components, stories, styles, CSS, themes, colors, or design tokens — anything that changes how the UI looks, no exceptions. Also for starting or previewing Storybook to verify UI, requests to show, browse, or list components, stories, or UI states, and docs, props, or usage lookups.
+---
+
+Prerequisites:
+
+1. Storybook must be installed in the project. Invoke the `/storybook-init` skill to set up Storybook, but only if the user explicitly invoked this skill and approves a Storybook installation.
+2. Storybook must be at least 10.5 (or `next` while 10.5 is not yet released). Invoke the `/storybook-upgrade` skill to upgrade it, but only if the user
+   explicitly approved a Storybook upgrade.
+3. Ensure `@storybook/addon-mcp` is installed. If it is missing, install it with `npx storybook add @storybook/addon-mcp`.
+
+Run the Storybook dev server and every `storybook ai` command from the same working directory: the package where Storybook is installed (in a monorepo often a leaf package such as `packages/ui`).
+
+Run `STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai --help` and read the output in its **entirety** to get the **mandatory, ordered workflow** for working on UI changes, writing stories, and keeping stories in sync with every frontend component you create, modify, or delete. This workflow explains how to write stories, preview stories, and display a curated Storybook review.
+
+Before invoking any `storybook ai` command for the first time in a session, run `STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai <command> --help` and read it fully. The top-level help only lists the commands; each command's payload shape and usage rules (which fields to include when) live in its own help output. Never guess a `--json` payload from the command name — a validation error only reports missing required fields, not the optional fields the workflow expects you to provide.
+
+Some commands require a running Storybook dev server. When Claude preview tooling is available, start the dev server through that tooling:
+
+1. Ensure there is a Storybook launch entry in `.claude/launch.json` (the `preview_start` tool description documents the file format) with `autoPort: true` and `port: 6006`. Use the project's preferred package manager and existing `package.json` Storybook script instead of inventing a new command whenever possible.
+2. Start the Storybook launch entry with the `preview_start` tool.

--- a/.agents/skills/storybook-init/SKILL.md
+++ b/.agents/skills/storybook-init/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: storybook-init
+description: Use when adding Storybook to a project that does not have Storybook configured yet.
+---
+
+1. Run `npm create storybook@latest` inside your project's root directory to install the latest version of Storybook. Use the matching package-manager command when appropriate, such as `pnpm create storybook@latest` or `yarn create storybook`.
+2. After initialization succeeds, run `npx storybook add @storybook/addon-mcp`.
+3. Invoke the `/storybook-setup` skill to help the user set up project-specific Storybook configuration, such as the `.storybook/preview.ts` file.

--- a/.agents/skills/storybook-setup/SKILL.md
+++ b/.agents/skills/storybook-setup/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: storybook-setup
+description: Use this skill when Storybook is already installed and the user wants a working `preview` file and stories for real components.
+---
+
+Prerequisites:
+
+1. Confirm Storybook exists (`package.json`, `.storybook/`). If not, switch to `/storybook-init`.
+2. Storybook must be at least 10.5 (or `next` while 10.5 is not yet released). If it is older, or upgrade/repair is needed first, switch to `/storybook-upgrade`.
+
+Run `npx storybook ai setup` from the project root (or the Storybook package in a monorepo).
+
+**Follow the printed Markdown precisely.** Do not substitute your own plan.

--- a/.agents/skills/storybook-upgrade/SKILL.md
+++ b/.agents/skills/storybook-upgrade/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: storybook-upgrade
+description: Use this skill when Storybook exists but needs an upgrade.
+---
+
+Storybook must end up at version 10.5 or later (or `next` while 10.5 is not yet released).
+
+Read https://storybook.js.org/docs/releases/upgrading.md in its **entirety** to get the latest Storybook upgrade instructions.
+
+If the latest stable release is still below 10.5, upgrade to the prerelease instead with `npx storybook@next upgrade`.

--- a/.claude/skills/stories
+++ b/.claude/skills/stories
@@ -1,0 +1,1 @@
+../../.agents/skills/stories

--- a/.claude/skills/storybook-init
+++ b/.claude/skills/storybook-init
@@ -1,0 +1,1 @@
+../../.agents/skills/storybook-init

--- a/.claude/skills/storybook-setup
+++ b/.claude/skills/storybook-setup
@@ -1,0 +1,1 @@
+../../.agents/skills/storybook-setup

--- a/.claude/skills/storybook-upgrade
+++ b/.claude/skills/storybook-upgrade
@@ -1,0 +1,1 @@
+../../.agents/skills/storybook-upgrade

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,6 +13,30 @@
       "skillPath": "skills/sanity-live-cache-components/SKILL.md",
       "computedHash": "354498f97fd57877d48f4cfe6e8838de610995a6d53bef0cee3fe5b5ef9fad7e"
     },
+    "stories": {
+      "source": "storybookjs/mcp",
+      "sourceType": "github",
+      "skillPath": "packages/claude-plugin/skills/stories/SKILL.md",
+      "computedHash": "0b56c8ef1f2d6df827c70ff2bbccc8b63ac35010f8c1685b5130d75c7f5747fc"
+    },
+    "storybook-init": {
+      "source": "storybookjs/mcp",
+      "sourceType": "github",
+      "skillPath": "packages/claude-plugin/skills/storybook-init/SKILL.md",
+      "computedHash": "0496ed0e8a3dac63832b592b27b2e9d239cf682d6e42c6fb1ac78762974fb897"
+    },
+    "storybook-setup": {
+      "source": "storybookjs/mcp",
+      "sourceType": "github",
+      "skillPath": "packages/claude-plugin/skills/storybook-setup/SKILL.md",
+      "computedHash": "385b4025a7d06e93bac71fe250df689385584d165a1baf2c146595db9c191742"
+    },
+    "storybook-upgrade": {
+      "source": "storybookjs/mcp",
+      "sourceType": "github",
+      "skillPath": "packages/claude-plugin/skills/storybook-upgrade/SKILL.md",
+      "computedHash": "4561acb46bf2e3537393e925c58122d8cc940a45a51906173212e2cf40f1c882"
+    },
     "ui-demo": {
       "source": "affaan-m/everything-claude-code",
       "sourceType": "github",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Install the official Storybook agent skills so Cursor and Claude Code can follow Storybook AI workflows for this repo.

## What changed

Ran `npx skills add storybookjs/mcp` (all four skills, Cursor + Claude Code, matching existing project skill layout):

- `stories` — Storybook AI CLI workflow for UI/story work
- `storybook-init` — add Storybook to a project that does not have it yet
- `storybook-setup` — `storybook ai setup` for preview + real-component stories
- `storybook-upgrade` — upgrade existing Storybook to 10.5+ (or `next`)

Canonical copies live in `.agents/skills/`; `.claude/skills/` has the same symlinks as `deslop` / `ui-demo`. `skills-lock.json` records the GitHub sources and hashes.

No application or published-package code changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09d3db68-3e6b-4f20-b1b8-91c40d4fa926?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09d3db68-3e6b-4f20-b1b8-91c40d4fa926&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

