### PR TITLE
fix(ui): isolate non-animated popover and tooltip cards from ancestor motion variants

### DIFF
--- a/.changeset/nested-popover-variant-inheritance.md
+++ b/.changeset/nested-popover-variant-inheritance.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Fixed non-animated `Popover` and `Tooltip` cards inheriting motion variants from an animated ancestor popover, which left them stuck at `opacity: 0`. `MenuGroup` submenus inside a `MenuButton` with `popover={{animate: true}}` never became visible as a result.

--- a/apps/storybook/stories/components/MenuButton.stories.tsx
+++ b/apps/storybook/stories/components/MenuButton.stories.tsx
@@ -105,6 +105,41 @@ export const WithMenuGroup: Story = {
   },
 }
 
+export const AnimatedWithMenuGroup: Story = {
+  args: {
+    popover: {animate: true},
+    menu: (
+      <Menu>
+        <MenuItem id="menu-item-1" text="Search" />
+        <MenuGroup id="menu-group" text="More">
+          <MenuItem id="submenu-item-1" text="Email link" />
+          <MenuItem id="submenu-item-2" text="Messages" />
+        </MenuGroup>
+      </Menu>
+    ),
+  },
+  parameters: {controls: {include: []}},
+  render: (props) => <MenuButton {...props} id="menu-button" />,
+  play: async ({canvasElement, step}) => {
+    const doc = canvasElement.ownerDocument
+    const opacityOf = (selector: string) => {
+      const el = doc.querySelector(selector)
+
+      return el ? getComputedStyle(el).opacity : undefined
+    }
+
+    await step('the animated menu popover becomes visible', async () => {
+      await userEvent.click(doc.getElementById('menu-button')!)
+      await waitFor(() => expect(opacityOf('[data-ui="MenuButton__popover"]')).toBe('1'))
+    })
+
+    await step('the non-animated submenu popover becomes visible', async () => {
+      await userEvent.click(doc.getElementById('menu-group')!)
+      await waitFor(() => expect(opacityOf('[data-ui="MenuGroup__popover"]')).toBe('1'))
+    })
+  },
+}
+
 export const WithSelectedItem: Story = {
   args: {
     menu: (

--- a/apps/storybook/stories/primitives/Popover.stories.tsx
+++ b/apps/storybook/stories/primitives/Popover.stories.tsx
@@ -134,8 +134,8 @@ export const NestedInAnimated: Story = {
     }
 
     // The nested popovers must open only once the outer enter animation has
-    // settled: a nested card that mounts in the same commit as the outer one
-    // is carried along by the outer animation and hides the bug
+    // settled. A nested card that mounts in the same commit as the outer one
+    // is carried along by the outer animation, which hides the bug.
     await step('the animated popover becomes visible', async () => {
       await userEvent.click(doc.getElementById('animated-popover-reference')!)
       await waitFor(() => expect(opacityOf('[data-testid="animated-popover"]')).toBe('1'))

--- a/apps/storybook/stories/primitives/Popover.stories.tsx
+++ b/apps/storybook/stories/primitives/Popover.stories.tsx
@@ -16,8 +16,10 @@ import {
 } from '@sanity/ui'
 import {Popover, PopoverProps, PopoverUpdateCallback} from '@sanity/ui/popover'
 import {ThemeColorToneKey} from '@sanity/ui/theme'
+import {Tooltip} from '@sanity/ui/tooltip'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {expect, userEvent, waitFor} from 'storybook/test'
 
 import {PLACEMENT_OPTIONS, RADII} from '../constants'
 import {getRadiusControls, getShadowControls, getSpaceControls} from '../controls'
@@ -73,6 +75,82 @@ export const Radius: Story = {
       })}
     </Card>
   ),
+}
+
+function NestedInAnimatedStory() {
+  const [animatedOpen, setAnimatedOpen] = useState(false)
+  const [nestedOpen, setNestedOpen] = useState(false)
+
+  return (
+    <Card padding={6}>
+      <Flex justify="center">
+        <Popover
+          animate
+          content={
+            <Stack gap={2} padding={2}>
+              <Popover
+                content={<Text size={1}>nested popover content</Text>}
+                data-testid="nested-popover"
+                open={nestedOpen}
+                padding={3}
+                placement="right"
+              >
+                <Button
+                  id="nested-popover-reference"
+                  onClick={() => setNestedOpen(true)}
+                  text="Open nested popover"
+                />
+              </Popover>
+
+              <Tooltip content={<Text size={1}>nested tooltip content</Text>} placement="right">
+                <Button id="nested-tooltip-reference" text="Hover for nested tooltip" />
+              </Tooltip>
+            </Stack>
+          }
+          data-testid="animated-popover"
+          open={animatedOpen}
+          padding={3}
+        >
+          <Button
+            id="animated-popover-reference"
+            onClick={() => setAnimatedOpen(true)}
+            text="Open animated popover"
+          />
+        </Popover>
+      </Flex>
+    </Card>
+  )
+}
+
+export const NestedInAnimated: Story = {
+  parameters: {controls: {include: []}},
+  render: () => <NestedInAnimatedStory />,
+  play: async ({canvasElement, step}) => {
+    const doc = canvasElement.ownerDocument
+    const opacityOf = (selector: string) => {
+      const el = doc.querySelector(selector)
+
+      return el ? getComputedStyle(el).opacity : undefined
+    }
+
+    // The nested popovers must open only once the outer enter animation has
+    // settled: a nested card that mounts in the same commit as the outer one
+    // is carried along by the outer animation and hides the bug
+    await step('the animated popover becomes visible', async () => {
+      await userEvent.click(doc.getElementById('animated-popover-reference')!)
+      await waitFor(() => expect(opacityOf('[data-testid="animated-popover"]')).toBe('1'))
+    })
+
+    await step('the nested non-animated popover becomes visible', async () => {
+      await userEvent.click(doc.getElementById('nested-popover-reference')!)
+      await waitFor(() => expect(opacityOf('[data-testid="nested-popover"]')).toBe('1'))
+    })
+
+    await step('the nested non-animated tooltip becomes visible', async () => {
+      await userEvent.hover(doc.getElementById('nested-tooltip-reference')!)
+      await waitFor(() => expect(opacityOf('[data-ui="Tooltip__card"]')).toBe('1'))
+    })
+  },
 }
 
 export const Controlled: Story = {

--- a/packages/ui/src/core/constants.ts
+++ b/packages/ui/src/core/constants.ts
@@ -1,4 +1,4 @@
-import type {Transition, Variant} from 'motion/react'
+import type {MotionProps} from 'motion/react'
 
 /**
  * @internal
@@ -13,20 +13,18 @@ export const EMPTY_RECORD: Record<string, never> = {}
 const POPOVER_MOTION_DURATION = 0.2
 
 /**
- * Shared `framer-motion` variants used by `Popover` and `Tooltip` components.
+ * The `motion` props shared by the `Popover` and `Tooltip` cards.
+ *
+ * Spread as a whole, and only while animating. `motion` treats any component
+ * with `variants` as a variant node and hands it the variant labels of the
+ * nearest animating ancestor, so a card that keeps its `variants` while
+ * dropping `initial`/`animate` mounts on an ancestor popover's `hidden`
+ * variant and never leaves it.
+ *
  * @internal
  */
-export const POPOVER_MOTION_PROPS: {
-  card: {
-    initial: Variant
-    hidden: Variant
-    visible: Variant
-    scaleIn: Variant
-    scaleOut: Variant
-  }
-  transition: Transition
-} = {
-  card: {
+export const POPOVER_MOTION_PROPS = {
+  variants: {
     initial: {
       scale: 0.97,
       willChange: 'transform',
@@ -52,4 +50,7 @@ export const POPOVER_MOTION_PROPS: {
     visualDuration: POPOVER_MOTION_DURATION,
     bounce: 0.25,
   },
-}
+  initial: ['hidden', 'initial'],
+  animate: ['visible', 'scaleIn'],
+  exit: ['hidden', 'scaleOut'],
+} satisfies MotionProps

--- a/packages/ui/src/core/constants.ts
+++ b/packages/ui/src/core/constants.ts
@@ -19,7 +19,8 @@ const POPOVER_MOTION_DURATION = 0.2
  * with `variants` as a variant node and hands it the variant labels of the
  * nearest animating ancestor, so a card that keeps its `variants` while
  * dropping `initial`/`animate` mounts on an ancestor popover's `hidden`
- * variant and never leaves it.
+ * variant. It only leaves that variant if the ancestor changes label again,
+ * which a card mounting after the ancestor's enter animation never sees.
  *
  * @internal
  */

--- a/packages/ui/src/core/primitives/popover/popoverCard.tsx
+++ b/packages/ui/src/core/primitives/popover/popoverCard.tsx
@@ -133,11 +133,7 @@ export function PopoverCard(
       sizing="border"
       style={rootStyle}
       tone={tone}
-      variants={POPOVER_MOTION_PROPS.card}
-      transition={POPOVER_MOTION_PROPS.transition}
-      initial={animate ? ['hidden', 'initial'] : undefined}
-      animate={animate ? ['visible', 'scaleIn'] : undefined}
-      exit={animate ? ['hidden', 'scaleOut'] : undefined}
+      {...(animate ? POPOVER_MOTION_PROPS : undefined)}
     >
       <Flex data-ui="Popover__wrapper" direction="column" flex={1} overflow={overflow}>
         <Flex direction="column" flex={1} padding={padding}>

--- a/packages/ui/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltipCard.tsx
@@ -87,11 +87,7 @@ export function TooltipCard(
       scheme={scheme}
       shadow={shadow}
       style={rootStyle}
-      variants={POPOVER_MOTION_PROPS.card}
-      transition={POPOVER_MOTION_PROPS.transition}
-      initial={animate ? ['hidden', 'initial'] : undefined}
-      animate={animate ? ['visible', 'scaleIn'] : undefined}
-      exit={animate ? ['hidden', 'scaleOut'] : undefined}
+      {...(animate ? POPOVER_MOTION_PROPS : undefined)}
     >
       {children}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was broken

A non-animated `Popover` or `Tooltip` nested inside a popover with `animate: true` mounted at `opacity: 0` and never became visible.

The reported symptom is `MenuGroup` submenus in the Studio `MenuButton`, which forces `animate: true` on its popover. Every submenu in `UploadDropDownMenu`, `PaneMenuButtonItem`, `FieldActionMenuNode` and the release context menus was permanently invisible.

`TooltipCard` carried the identical defect, which gives a second consumer-facing symptom nobody had filed. A tooltip on a menu item inside an animated `MenuButton` popover was invisible for the same reason, because `MotionContext` propagates through the portal.

## Root cause

`motion` treats any component with a `variants` prop as a *variant node*. From `motion-dom/dist/es/render/utils/is-controlling-variants.mjs`:

```js
function isVariantNode(props) {
    return Boolean(isControllingVariants(props) || props.variants);
}
```

`PopoverCard` and `TooltipCard` gated `initial`/`animate`/`exit` on the `animate` prop but passed `variants` unconditionally. So a non-animated card was a variant node that did not control its own variants, and `makeLatestValues` in `framer-motion/dist/es/motion/utils/use-visual-state.mjs` filled in the missing labels from the ancestor's `MotionContext`:

```js
if (context && isVariantNode && !isControllingVariants && props.inherit !== false) {
    if (initial === undefined) initial = context.initial;
    if (animate === undefined) animate = context.animate;
}
```

The card therefore mounted on the animated ancestor's `hidden` variant, at `opacity: 0`. It only leaves that variant if the ancestor changes label again, and a card that mounts after the ancestor's enter animation never sees another change. The mount is late because React's `Activity` defers effects while the nested popover is closed, so the visual element registers as a variant child of the ancestor only once the submenu opens, by which point the enter animation is long finished.

That late mount is why the bug only shows when the nested popover opens *after* the outer one has settled. A nested card that mounts in the same commit as the outer card gets carried along by the outer animation and looks fine.

## The fix

`POPOVER_MOTION_PROPS` now holds every motion prop for the animated case, and both cards spread it as a unit:

```tsx
{...(animate ? POPOVER_MOTION_PROPS : undefined)}
```

A non-animated card now receives no `variants` at all, so `isVariantNode` is false. It neither inherits variant labels at mount nor gets registered as a variant child of an animated ancestor. One object replaces ten conditional lines across two files, so "not animated means no motion participation" can no longer be half-applied.

The all-or-nothing spread is stronger than making only `variants` conditional, because motion gates the whole animation feature on the presence of `animate`/`variants`/`exit`/`while*` (`framer-motion/dist/es/motion/features/definitions.mjs`). With none of them the card has no `animationState` at all and opts out of the animation system rather than just the variant tree. Dropping `transition` is safe for the same reason, and motion only applies the default transition to layout animation when `layout` or `layoutId` is present, which neither card sets.

### Rejected alternatives

- `inherit={false}` on the non-animated card. It blocks the mount-time inheritance in `makeLatestValues`, but `VisualElement.mount` still calls `addVariantChild` because that check reads only `isVariantNode`/`isControllingVariants` and ignores `inherit`. `animateChildren` then walks `variantChildren` on every ancestor label change, so exit and gesture state would still propagate to a supposedly non-animated popover. It is a mount-state patch, not variant-tree isolation.
- Rendering a plain `Card` instead of `MotionCard` when `animate` is false. Fully isolated, but a bigger diff and two styled components to keep visually identical, for no behavioral gain over the spread.
- Making only `variants` conditional. The smallest possible diff, but it leaves the animation-mode decision split across two files, which is how the bug arose.
- A helper that returns the props. Marginally stronger encapsulation, not worth the indirection for two call sites.

### Note for future maintenance

`prefers-reduced-motion` can flip `animate` while a popover is open. That is safe today because the flip swaps `<AnimateActivity>` for `<Activity>`, two different component types at the same position, so React remounts the card subtree and the card is reconstructed with a consistent prop set. It matters because motion computes `isVariantNode` and `isControllingVariants` in the `VisualElement` constructor and `update()` never recomputes them. If popover.tsx or tooltip.tsx is ever simplified to always render `AnimateActivity`, a card flipping `animate` mid-mount would change prop shape without motion noticing. The comment on `POPOVER_MOTION_PROPS` carries that contract, so keep it if `constants.ts` is reorganized.

One upstream inconsistency worth filing against motion: `makeLatestValues` honors `props.inherit` but `VisualElement.mount` and `animateChildren` do not, so `inherit={false}` silently does less than its documentation implies.

## Verification

Two story `play` functions assert computed opacity and both fail without the fix:

- `AnimatedWithMenuGroup` in `apps/storybook/stories/components/MenuButton.stories.tsx` covers the reported `MenuGroup` case.
- `NestedInAnimated` in `apps/storybook/stories/primitives/Popover.stories.tsx` covers a nested `Popover` and a nested `Tooltip`. Reverting the tooltip half alone makes only the tooltip step fail, so each instance is independently proven.

The repro commit lands before the fix, so the history shows red then green.

```
=== RED: packages/ui at 32d938912 (repro commit, fix not yet applied) ===
   × Animated With Menu Group 1167ms
   × Nested In Animated 1131ms
 FAIL  |storybook (chromium)| stories/components/MenuButton.stories.tsx > Animated With Menu Group
Expected: "1"
Received: "0"
 FAIL  |storybook (chromium)| stories/primitives/Popover.stories.tsx > Nested In Animated
Expected: "1"
Received: "0"
 Test Files  2 failed (2)
      Tests  2 failed | 27 passed (29)

=== GREEN: packages/ui at HEAD (fix applied) ===
 Test Files  2 passed (2)
      Tests  29 passed (29)
```

`pnpm lint`, `pnpm test` (106 unit tests), `pnpm test:browser` (247 browser tests) and `pnpm knip` all pass locally, and CI is green on every required check.

Every other `variants=` call site in `packages/ui/src` was audited. `Toast` sets unconditional variant labels so it always controls its own variants and handles reduced motion by zeroing durations rather than dropping props. Its `MotionFlex`/`MotionText`/`MotionLoadingBar` children are deliberate variant children whose nearest controlling ancestor is always `MotionToast`, so its fresh `MotionContext` shadows any outer animated popover. `MotionLoadingBarProgress` animates target objects and has no `variants`, and `Dialog` animates via a styled-components prop rather than motion. Popover and Tooltip were the only two instances.

The same story driven through Playwright against `pnpm dev`, before and after:

[MenuGroup submenu invisible before the fix](https://cursor.com/agents/bc-f21d6cf5-ef38-4828-9e1b-45277dc0c773/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmenugroup_submenu_before.png)

[MenuGroup submenu visible after the fix](https://cursor.com/agents/bc-f21d6cf5-ef38-4828-9e1b-45277dc0c773/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmenugroup_submenu_after.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f21d6cf5-ef38-4828-9e1b-45277dc0c773?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f21d6cf5-ef38-4828-9e1b-45277dc0c773&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

