### PR TITLE
fix: support cross-file transformations in all codemods

### DIFF
--- a/.changeset/sour-olives-cut.md
+++ b/.changeset/sour-olives-cut.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui-codemod': patch
+---
+
+update codemods to support cross-file styled component transformations

--- a/packages/ui-codemod/src/transforms/latest/card/card.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/card/card.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './card'
 
 defineInlineTest(
@@ -204,4 +206,101 @@ defineInlineTest(
   <Card muted />
   `,
   'warns if Card includes muted prop',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Card} from '@sanity/ui'
+
+    export const RootCard = styled(Card)(({theme}) => ({}))
+  `,
+  `
+    import {RootCard} from './Component.styled'
+
+    export function Component() {
+      return <RootCard padding={4} radius={3} border />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootCard density="regular" />')
+  },
+  'transforms attributes on imported styled Card wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Card} from '@sanity/ui'
+
+    export const RootCard = styled(Card)(({theme}) => ({}))
+  `,
+  `
+    import {RootCard} from './Component.styled'
+
+    export function Component() {
+      return <RootCard padding={1} />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('UI-CODEMOD TODO: Please double check styled(Card) migration below')
+    expect(output).toContain('<RootCard padding={1} />')
+  },
+  'adds todo warning when imported styled Card wrapper should be replaced',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Card} from '@sanity/ui'
+
+    export const RootCard = styled(Card)(({theme}) => ({}))
+  `,
+  `
+    import {Card} from 'another-package'
+    import {RootCard} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootCard padding={4} radius={3} border />
+          <Card padding={4} radius={3} border />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootCard density="regular" />')
+    expect(output).toContain('<Card padding={4} radius={3} border />')
+  },
+  'does not rewrite unrelated Card from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Card} from '@sanity/ui'
+
+    export const RootCard = styled(Card)(({theme}) => ({}))
+  `,
+  `
+    import {RootCard} from './index'
+
+    export function Component() {
+      return <RootCard padding={4} radius={3} border />
+    }
+  `,
+  (output) => {
+    expect(output).toContain('<RootCard density="regular" />')
+  },
+  'transforms styled Card wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootCard} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/card/card.ts
+++ b/packages/ui-codemod/src/transforms/latest/card/card.ts
@@ -1,19 +1,22 @@
-import {type API, type FileInfo} from 'jscodeshift'
+import {type API, type FileInfo, type JSXAttribute, type JSXSpreadAttribute} from 'jscodeshift'
 
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {getAttribute} from '../../../utils/getAttribute'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
 import {getStaticAttributeExpression} from '../../../utils/getStaticAttributeExpression'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {replaceElement} from '../../../utils/replaceElement'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {BOX_MODS} from '../box/box.mods'
 import {CARD_MODS} from './card.mods'
 
 const CARD_TODO_WARNING = 'Please double check the Card migration below'
 const BOX_TODO_WARNING = 'Please double check the Box migration below'
+const STYLED_TODO_WARNING = 'Please double check styled(Card) migration below'
 
 /** @internal */
 export default function transform(
@@ -25,8 +28,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Card', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Card',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Card', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Card', localNames, options, styledAliases)) {
       return
     }
 
@@ -34,29 +45,32 @@ export default function transform(
       markChanged()
     }
 
+    const replaceWithBox = (attrs: (JSXAttribute | JSXSpreadAttribute)[]) => {
+      const density = getAttribute(attrs, 'density')
+      const muted = getAttribute(attrs, 'muted')
+      const scheme = getAttribute(attrs, 'scheme')
+      const border = getAttribute(attrs, 'border')
+      const padding = getStaticAttributeExpression(j, attrs, 'padding')
+      const radius = getStaticAttributeExpression(j, attrs, 'radius')
+
+      return !(
+        density ||
+        muted ||
+        scheme ||
+        (border && padding === 3 && radius == 2) ||
+        (border && padding === 4 && radius == 3) ||
+        (border && padding === 5 && radius == 4)
+      )
+    }
+
     if (
       replaceElement(
         j,
         root,
-        (attrs) => {
-          const density = getAttribute(attrs, 'density')
-          const muted = getAttribute(attrs, 'muted')
-          const scheme = getAttribute(attrs, 'scheme')
-          const border = getAttribute(attrs, 'border')
-          const padding = getStaticAttributeExpression(j, attrs, 'padding')
-          const radius = getStaticAttributeExpression(j, attrs, 'radius')
-
-          return !(
-            density ||
-            muted ||
-            scheme ||
-            (border && padding === 3 && radius == 2) ||
-            (border && padding === 4 && radius == 3) ||
-            (border && padding === 5 && radius == 4)
-          )
-        },
+        (attrs) => replaceWithBox(attrs),
         {
           element: 'Card',
+          localNames,
           callback: (path) => transformAttributes(j, path, CARD_MODS, CARD_TODO_WARNING),
         },
         {
@@ -64,6 +78,15 @@ export default function transform(
           callback: (path) => transformAttributes(j, path, BOX_MODS, BOX_TODO_WARNING),
         },
       )
+    ) {
+      markChanged()
+    }
+
+    if (
+      transformStyledComponents(j, root, styledAliases, (attrs) => !replaceWithBox(attrs), {
+        warning: STYLED_TODO_WARNING,
+        callback: (path) => transformAttributes(j, path, CARD_MODS, CARD_TODO_WARNING),
+      })
     ) {
       markChanged()
     }

--- a/packages/ui-codemod/src/transforms/latest/code/code.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/code/code.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './code'
 
 defineInlineTest(
@@ -58,4 +60,85 @@ defineInlineTest(
   }} trim={true} />
   `,
   'moves width props to style and uppdates mapped values',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Code} from '@sanity/ui'
+
+    export const RootCode = styled(Code)(({theme}) => ({}))
+  `,
+  `
+    import {RootCode} from './Component.styled'
+
+    export function RootCode() {
+      return <RootCode flex="auto" />
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootCode style={{ flex: "1 1 auto" }} trim={true} />',
+    )
+  },
+  'transforms attributes on imported styled Code wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Code} from '@sanity/ui'
+
+    export const RootCode = styled(Code)(({theme}) => ({}))
+  `,
+  `
+    import {Code} from 'another-package'
+    import {RootCode} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootCode flex="auto" />
+          <Code flex="auto" />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootCode style={{ flex: "1 1 auto" }} trim={true} />',
+    )
+    expect(output).toContain('<Code flex="auto" />')
+  },
+  'does not transform attributes on unrelated Code from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Code} from '@sanity/ui'
+
+    export const RootCode = styled(Code)(({theme}) => ({}))
+  `,
+  `
+    import {RootCode} from './index'
+
+    export function Component() {
+      return <RootCode flex="auto" />
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootCode style={{ flex: "1 1 auto" }} trim={true} />',
+    )
+  },
+  'transforms styled Code wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootCode} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/code/code.ts
+++ b/packages/ui-codemod/src/transforms/latest/code/code.ts
@@ -3,10 +3,12 @@ import {type API, type FileInfo} from 'jscodeshift'
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {addAttribute} from '../../../utils/addAttribute'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {CODE_MODS} from './code.mods'
 
 const TODO_WARNING = 'Please double check the Code migration below'
@@ -21,8 +23,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Code', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Code',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Code', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Code', localNames, options, styledAliases)) {
       return
     }
 
@@ -30,24 +40,45 @@ export default function transform(
       markChanged()
     }
 
-    root
-      .find(j.JSXOpeningElement, {
-        name: {type: 'JSXIdentifier', name: 'Code'},
+    root.find(j.JSXOpeningElement).forEach((path) => {
+      let changed = false
+      const name = path.node.name
+
+      if (name.type !== 'JSXIdentifier' || !localNames.has(name.name)) {
+        return
+      }
+
+      if (transformAttributes(j, path, CODE_MODS, TODO_WARNING)) {
+        changed = true
+      }
+
+      if (addAttribute(j, path.node, 'trim', true)) {
+        changed = true
+      }
+
+      if (changed) {
+        markChanged()
+      }
+    })
+
+    if (
+      transformStyledComponents(j, root, styledAliases, () => true, {
+        callback: (path) => {
+          let changed = false
+
+          if (transformAttributes(j, path, CODE_MODS, TODO_WARNING)) {
+            changed = true
+          }
+
+          if (addAttribute(j, path.node, 'trim', true)) {
+            changed = true
+          }
+
+          return changed
+        },
       })
-      .forEach((path) => {
-        let changed = false
-
-        if (transformAttributes(j, path, CODE_MODS, TODO_WARNING)) {
-          changed = true
-        }
-
-        if (addAttribute(j, path.node, 'trim', true)) {
-          changed = true
-        }
-
-        if (changed) {
-          markChanged()
-        }
-      })
+    ) {
+      markChanged()
+    }
   })
 }

--- a/packages/ui-codemod/src/transforms/latest/heading/heading.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/heading/heading.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './heading'
 
 defineInlineTest(
@@ -84,4 +86,85 @@ defineInlineTest(
   <Heading trim={true} />
   `,
   'warns if as props is missing',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Heading} from '@sanity/ui'
+
+    export const RootHeading = styled(Heading)(({theme}) => ({}))
+  `,
+  `
+    import {RootHeading} from './Component.styled'
+
+    export function RootCode() {
+      return <RootHeading flex="auto" />
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootHeading style={{ flex: "1 1 auto" }} trim={true} />',
+    )
+  },
+  'transforms attributes on imported styled Heading wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Heading} from '@sanity/ui'
+
+    export const RootHeading = styled(Heading)(({theme}) => ({}))
+  `,
+  `
+    import {Heading} from 'another-package'
+    import {RootHeading} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootHeading flex="auto" />
+          <Heading flex="auto" />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootHeading style={{ flex: "1 1 auto" }} trim={true} />',
+    )
+    expect(output).toContain('<Heading flex="auto" />')
+  },
+  'does not transform attributes on unrelated Heading from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Heading} from '@sanity/ui'
+
+    export const RootHeading = styled(Heading)(({theme}) => ({}))
+  `,
+  `
+    import {RootHeading} from './index'
+
+    export function Component() {
+      return <RootHeading flex="auto" />
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootHeading style={{ flex: "1 1 auto" }} trim={true} />',
+    )
+  },
+  'transforms styled Heading wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootHeading} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/heading/heading.ts
+++ b/packages/ui-codemod/src/transforms/latest/heading/heading.ts
@@ -3,10 +3,12 @@ import {type API, type FileInfo} from 'jscodeshift'
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {addAttribute} from '../../../utils/addAttribute'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {HEADING_MODS} from './heading.mods'
 
 const TODO_WARNING = 'Please double check the Heading migration below'
@@ -21,8 +23,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Heading', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Heading',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Heading', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Heading', localNames, options, styledAliases)) {
       return
     }
 
@@ -30,24 +40,45 @@ export default function transform(
       markChanged()
     }
 
-    root
-      .find(j.JSXOpeningElement, {
-        name: {type: 'JSXIdentifier', name: 'Heading'},
+    root.find(j.JSXOpeningElement).forEach((path) => {
+      let changed = false
+      const name = path.node.name
+
+      if (name.type !== 'JSXIdentifier' || !localNames.has(name.name)) {
+        return
+      }
+
+      if (transformAttributes(j, path, HEADING_MODS, TODO_WARNING)) {
+        changed = true
+      }
+
+      if (addAttribute(j, path.node, 'trim', true)) {
+        changed = true
+      }
+
+      if (changed) {
+        markChanged()
+      }
+    })
+
+    if (
+      transformStyledComponents(j, root, styledAliases, () => true, {
+        callback: (path) => {
+          let changed = false
+
+          if (transformAttributes(j, path, HEADING_MODS, TODO_WARNING)) {
+            changed = true
+          }
+
+          if (addAttribute(j, path.node, 'trim', true)) {
+            changed = true
+          }
+
+          return changed
+        },
       })
-      .forEach((path) => {
-        let changed = false
-
-        if (transformAttributes(j, path, HEADING_MODS, TODO_WARNING)) {
-          changed = true
-        }
-
-        if (addAttribute(j, path.node, 'trim', true)) {
-          changed = true
-        }
-
-        if (changed) {
-          markChanged()
-        }
-      })
+    ) {
+      markChanged()
+    }
   })
 }

--- a/packages/ui-codemod/src/transforms/latest/label/label.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/label/label.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './label'
 
 defineInlineTest(
@@ -110,4 +112,85 @@ defineInlineTest(
     trim={true} />
   `,
   'moves width props to style and updates mapped value',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Label} from '@sanity/ui'
+
+    export const RootLabel = styled(Label)(({theme}) => ({}))
+  `,
+  `
+    import {RootLabel} from './Component.styled'
+
+    export function RootCode() {
+      return <RootLabel flex="auto" />
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootLabel style={{ flex: "1 1 auto" }} as="div" trim={true} />',
+    )
+  },
+  'transforms attributes on imported styled Label wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Label} from '@sanity/ui'
+
+    export const RootLabel = styled(Label)(({theme}) => ({}))
+  `,
+  `
+    import {Label} from 'another-package'
+    import {RootLabel} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootLabel flex="auto" />
+          <Label flex="auto" />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootLabel style={{ flex: "1 1 auto" }} as="div" trim={true} />',
+    )
+    expect(output).toContain('<Label flex="auto" />')
+  },
+  'does not transform attributes on unrelated Label from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Label} from '@sanity/ui'
+
+    export const RootLabel = styled(Label)(({theme}) => ({}))
+  `,
+  `
+    import {RootLabel} from './index'
+
+    export function Component() {
+      return <RootLabel flex="auto" />
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootLabel style={{ flex: "1 1 auto" }} as="div" trim={true} />',
+    )
+  },
+  'transforms styled Label wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootLabel} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/label/label.ts
+++ b/packages/ui-codemod/src/transforms/latest/label/label.ts
@@ -3,11 +3,13 @@ import {type API, type FileInfo} from 'jscodeshift'
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {addAttribute} from '../../../utils/addAttribute'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {replaceElement} from '../../../utils/replaceElement'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {LABEL_MODS} from './label.mods'
 
 const TODO_WARNING = 'Please double check the Label migration below'
@@ -22,8 +24,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Label', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Label',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Label', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Label', localNames, options, styledAliases)) {
       return
     }
 
@@ -38,6 +48,7 @@ export default function transform(
         () => true,
         {
           element: 'Label',
+          localNames,
         },
         {
           element: 'Eyebrow',
@@ -60,6 +71,30 @@ export default function transform(
           },
         },
       )
+    ) {
+      markChanged()
+    }
+
+    if (
+      transformStyledComponents(j, root, styledAliases, () => true, {
+        callback: (path) => {
+          let changed = false
+
+          if (transformAttributes(j, path, LABEL_MODS, TODO_WARNING)) {
+            changed = true
+          }
+
+          if (addAttribute(j, path.node, 'as', 'div')) {
+            changed = true
+          }
+
+          if (addAttribute(j, path.node, 'trim', true)) {
+            changed = true
+          }
+
+          return changed
+        },
+      })
     ) {
       markChanged()
     }

--- a/packages/ui-codemod/src/transforms/latest/stack/stack.ts
+++ b/packages/ui-codemod/src/transforms/latest/stack/stack.ts
@@ -17,7 +17,7 @@ const STACK_TODO_WARNING = 'Please double check the Stack migration below'
 const FLEX_TODO_WARNING = 'Please double check the Flex migration below'
 const STYLED_TODO_WARNING = 'Please double check styled(Stack) migration below'
 
-function hasFlexAttrs(attrs: JSXElement['openingElement']['attributes']) {
+function replaceWithFlex(attrs: JSXElement['openingElement']['attributes']) {
   if (!attrs) {
     return false
   }
@@ -66,9 +66,7 @@ export default function transform(
       replaceElement(
         j,
         root,
-        (attrs) => {
-          return hasFlexAttrs(attrs)
-        },
+        (attrs) => replaceWithFlex(attrs),
         {
           element: 'Stack',
           localNames,
@@ -99,7 +97,7 @@ export default function transform(
         j,
         root,
         (attrs) => {
-          return !hasFlexAttrs(attrs)
+          return !replaceWithFlex(attrs)
         },
         {
           element: 'Stack',
@@ -115,7 +113,7 @@ export default function transform(
     }
 
     if (
-      transformStyledComponents(j, root, styledAliases, (attrs) => !hasFlexAttrs(attrs), {
+      transformStyledComponents(j, root, styledAliases, (attrs) => !replaceWithFlex(attrs), {
         warning: STYLED_TODO_WARNING,
         callback: (path) => transformAttributes(j, path, STACK_MODS, STACK_TODO_WARNING),
       })

--- a/packages/ui-codemod/src/transforms/latest/text/text.test.ts
+++ b/packages/ui-codemod/src/transforms/latest/text/text.test.ts
@@ -1,4 +1,6 @@
-import {defineInlineTest} from '../../../utils/testUtils'
+import {expect} from 'vitest'
+
+import {defineCrossFileTest, defineInlineTest} from '../../../utils/testUtils'
 import transform from './text'
 
 defineInlineTest(
@@ -110,4 +112,85 @@ defineInlineTest(
     trim={true} />
   `,
   'moves width props to style and updates mapped value',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Text} from '@sanity/ui'
+
+    export const RootText = styled(Text)(({theme}) => ({}))
+  `,
+  `
+    import {RootText} from './Component.styled'
+
+    export function RootCode() {
+      return <RootText flex="auto" />
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootText style={{ flex: "1 1 auto" }} as="div" trim={true} />',
+    )
+  },
+  'transforms attributes on imported styled Text wrappers',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Text} from '@sanity/ui'
+
+    export const RootText = styled(Text)(({theme}) => ({}))
+  `,
+  `
+    import {Text} from 'another-package'
+    import {RootText} from './Component.styled'
+
+    export function Component() {
+      return (
+        <>
+          <RootText flex="auto" />
+          <Text flex="auto" />
+        </>
+      )
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootText style={{ flex: "1 1 auto" }} as="div" trim={true} />',
+    )
+    expect(output).toContain('<Text flex="auto" />')
+  },
+  'does not transform attributes on unrelated Text from another package',
+)
+
+defineCrossFileTest(
+  transform,
+  {},
+  `
+    import {Text} from '@sanity/ui'
+
+    export const RootText = styled(Text)(({theme}) => ({}))
+  `,
+  `
+    import {RootText} from './index'
+
+    export function Component() {
+      return <RootText flex="auto" />
+    }
+  `,
+  (output) => {
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      '<RootText style={{ flex: "1 1 auto" }} as="div" trim={true} />',
+    )
+  },
+  'transforms styled Text wrappers imported through barrel re-exports',
+  {
+    extraFiles: {
+      'index.ts': `export {RootText} from './Component.styled'`,
+    },
+  },
 )

--- a/packages/ui-codemod/src/transforms/latest/text/text.ts
+++ b/packages/ui-codemod/src/transforms/latest/text/text.ts
@@ -3,10 +3,12 @@ import {type API, type FileInfo} from 'jscodeshift'
 import type {BaseOptions} from '../../../types/BaseOptions'
 import {addAttribute} from '../../../utils/addAttribute'
 import {getComponentLocalNames} from '../../../utils/getComponentLocalNames'
+import {getStyledComponentAliases} from '../../../utils/getStyledComponentAliases'
 import {shouldTransformComponent} from '../../../utils/shouldTransformComponent'
 import {transformAttributes} from '../../../utils/transformAttributes'
 import {transformComponent} from '../../../utils/transformComponent'
 import {transformImport} from '../../../utils/transformImport'
+import {transformStyledComponents} from '../../../utils/transformStyledComponents'
 import {TEXT_MODS} from './text.mods'
 
 const TODO_WARNING = 'Please double check the Text migration below'
@@ -21,8 +23,16 @@ export default function transform(
 
   return transformComponent(fileInfo, api, ({j, root, markChanged}) => {
     const localNames = getComponentLocalNames(j, root, 'Text', options)
+    const styledAliases = getStyledComponentAliases(
+      j,
+      root,
+      'Text',
+      fileInfo.path,
+      localNames,
+      options,
+    )
 
-    if (!shouldTransformComponent(j, root, 'Text', localNames, options)) {
+    if (!shouldTransformComponent(j, root, 'Text', localNames, options, styledAliases)) {
       return
     }
 
@@ -30,28 +40,57 @@ export default function transform(
       markChanged()
     }
 
-    root
-      .find(j.JSXOpeningElement, {
-        name: {type: 'JSXIdentifier', name: 'Text'},
+    root.find(j.JSXOpeningElement).forEach((path) => {
+      let changed = false
+      const name = path.node.name
+
+      if (name.type !== 'JSXIdentifier' || !localNames.has(name.name)) {
+        return
+      }
+
+      if (transformAttributes(j, path, TEXT_MODS, TODO_WARNING)) {
+        changed = true
+      }
+
+      if (addAttribute(j, path.node, 'as', 'div')) {
+        changed = true
+      }
+
+      if (addAttribute(j, path.node, 'trim', true)) {
+        changed = true
+      }
+
+      if (changed) {
+        markChanged()
+      }
+    })
+
+    if (
+      transformStyledComponents(j, root, styledAliases, () => true, {
+        callback: (path) => {
+          let changed = false
+
+          if (transformAttributes(j, path, TEXT_MODS, TODO_WARNING)) {
+            changed = true
+          }
+
+          if (addAttribute(j, path.node, 'as', 'div')) {
+            changed = true
+          }
+
+          if (addAttribute(j, path.node, 'trim', true)) {
+            changed = true
+          }
+
+          if (changed) {
+            markChanged()
+          }
+
+          return changed
+        },
       })
-      .forEach((path) => {
-        let changed = false
-
-        if (transformAttributes(j, path, TEXT_MODS, TODO_WARNING)) {
-          changed = true
-        }
-
-        if (addAttribute(j, path.node, 'as', 'div')) {
-          changed = true
-        }
-
-        if (addAttribute(j, path.node, 'trim', true)) {
-          changed = true
-        }
-
-        if (changed) {
-          markChanged()
-        }
-      })
+    ) {
+      markChanged()
+    }
   })
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR updates the all the remaining codemods to support cross-file styled component transformations. Again, there's some repetition, especially in the tests, but for now I'm not sure if it's worth a major refactor.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the logic across the files seems consistent.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I updated the tests for each codemod to include the cross-file transformations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to @sanity/ui-codemod test and transform logic with no runtime app impact; incorrect alias resolution could mis-migrate consumer code during upgrades.
> 
> **Overview**
> Extends **cross-file styled-component migration** to the remaining typography/layout codemods (**Card**, **Code**, **Heading**, **Label**, **Text**), matching the approach already used for **Stack**.
> 
> Each transform now resolves **`styled(Component)` aliases** via `getStyledComponentAliases`, treats those usages in `shouldTransformComponent`, and runs **`transformStyledComponents`** so JSX on imported wrappers (including **barrel re-exports**) gets the same attribute mods, TODO comments, and **trim/as** additions as direct component usage. **Card** and **Label** also pass **`localNames`** into `replaceElement` and share a **`replaceWithBox`** helper so styled wrappers follow the same Card→Box rules; **Stack** only renames **`hasFlexAttrs`** to **`replaceWithFlex`** for consistency.
> 
> **`defineCrossFileTest`** coverage was added per codemod, including cases that **skip homonymous components from other packages**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b5d3753792e7c2e816ca90dd22d5053463797da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->