### PR TITLE
Fix dialog interface export

### DIFF
--- a/packages/ui/src/components/dialog/dialog.props.ts
+++ b/packages/ui/src/components/dialog/dialog.props.ts
@@ -3,7 +3,7 @@ import {type PropDef} from '../../types/PropDef'
 import type {Responsive} from '../../types/Responsive'
 
 /** @beta */
-export interface ModalProps extends Omit<React.ComponentProps<'dialog'>, 'open'> {
+export interface DialogProps extends Omit<React.ComponentProps<'dialog'>, 'open'> {
   /**
    * Text for the dialog heading.
    * @remarks Recommended for accessibility. The component sets `aria-labelledby` to the heading when you give this prop.


### PR DESCRIPTION
Fix for the name of `DialogProps`, got missed in #2780 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single exported type rename for naming consistency; no runtime behavior change.
> 
> **Overview**
> Completes the **Modal → Dialog** rename from #2780 by renaming the exported props interface from `ModalProps` to **`DialogProps`** in `dialog.props.ts`, matching `Dialog.tsx` and the public `DialogProps` export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b376a6943fe5b106ef42231280c643f885c123e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->