### PR TITLE
fix: add all codemods to package.json for build

### DIFF
--- a/.changeset/proud-drinks-lick.md
+++ b/.changeset/proud-drinks-lick.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui-codemod': patch
+---
+
+add missing codemods to package.json for build

--- a/packages/ui-codemod/package.json
+++ b/packages/ui-codemod/package.json
@@ -71,6 +71,30 @@
       "source": "./src/commands/latest/heading.ts",
       "default": "./dist/commands/latest/heading.js"
     },
+    "./transforms/latest/inline": {
+      "source": "./src/transforms/latest/inline/inline.ts",
+      "default": "./dist/transforms/latest/inline/inline.js"
+    },
+    "./latest/inline": {
+      "source": "./src/commands/latest/inline.ts",
+      "default": "./dist/commands/latest/inline.js"
+    },
+    "./transforms/latest/label": {
+      "source": "./src/transforms/latest/label/label.ts",
+      "default": "./dist/transforms/latest/label/label.js"
+    },
+    "./latest/label": {
+      "source": "./src/commands/latest/label.ts",
+      "default": "./dist/commands/latest/label.js"
+    },
+    "./transforms/latest/stack": {
+      "source": "./src/transforms/latest/stack/stack.ts",
+      "default": "./dist/transforms/latest/stack/stack.js"
+    },
+    "./latest/stack": {
+      "source": "./src/commands/latest/stack.ts",
+      "default": "./dist/commands/latest/stack.js"
+    },
     "./transforms/latest/text": {
       "source": "./src/transforms/latest/text/text.ts",
       "default": "./dist/transforms/latest/text/text.js"

--- a/packages/ui-codemod/package.json
+++ b/packages/ui-codemod/package.json
@@ -121,6 +121,12 @@
       "./latest/grid": "./dist/commands/latest/grid.js",
       "./transforms/latest/heading": "./dist/transforms/latest/heading/heading.js",
       "./latest/heading": "./dist/commands/latest/heading.js",
+      "./transforms/latest/inline": "./dist/transforms/latest/inline/inline.js",
+      "./latest/inline": "./dist/commands/latest/inline.js",
+      "./transforms/latest/label": "./dist/transforms/latest/label/label.js",
+      "./latest/label": "./dist/commands/latest/label.js",
+      "./transforms/latest/stack": "./dist/transforms/latest/stack/stack.js",
+      "./latest/stack": "./dist/commands/latest/stack.js",
       "./transforms/latest/text": "./dist/transforms/latest/text/text.js",
       "./latest/text": "./dist/commands/latest/text.js",
       "./package.json": "./package.json"


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

I forgot to include a few of the codemods in the build process by adding them to  `package.json`. This should add `inline`, `label`, and `stack`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure there are no typos in the names.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

This should be good as long as `pnpm build` runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime logic; it fixes missing build/publish surface area for codemods that already exist in source.
> 
> **Overview**
> Registers the **inline**, **label**, and **stack** codemods in `@sanity/ui-codemod`’s `package.json` so they participate in the strict build and are published like the other `latest/*` transforms and commands.
> 
> For each codemod, the PR adds matching `./transforms/latest/*` and `./latest/*` entries under both `exports` and `publishConfig.exports`, pointing at the existing `src` and `dist` paths. A patch changeset documents the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d4bfd41d2a2ffca66f5efe7915e49a69765e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->