### PR TITLE
chore: update sanity/icons

### DIFF
--- a/.changeset/tidy-icons-subpaths.md
+++ b/.changeset/tidy-icons-subpaths.md
@@ -1,0 +1,14 @@
+---
+'@sanity/ui': patch
+---
+
+bump `@sanity/icons` to v5 and import each icon from its own subpath
+
+`@sanity/icons` v5 removed the individual icon exports from its root entry. The icons themselves are unchanged. Import each one from its own subpath instead:
+
+```diff
+-import {AddIcon} from '@sanity/icons'
++import {AddIcon} from '@sanity/icons/Add'
+```
+
+The root entry now exports the dynamic `Icon` component and the `icons` map only. Use those when the icon name is known at runtime only.

--- a/apps/mount-testing/package.json
+++ b/apps/mount-testing/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@sanity/icons": "^3.7.4",
+    "@sanity/icons": "^5.2.1",
     "@sanity/ui": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/apps/mount-testing/src/pages/ui3.tsx
+++ b/apps/mount-testing/src/pages/ui3.tsx
@@ -1,4 +1,4 @@
-import {AddIcon} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons/Add'
 import {Profiler} from 'react'
 import {
   Box,

--- a/apps/mount-testing/src/pages/ui4.tsx
+++ b/apps/mount-testing/src/pages/ui4.tsx
@@ -1,5 +1,5 @@
 import 'ui4/css/index.css'
-import {AddIcon} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons/Add'
 import {Profiler} from 'react'
 import {
   Box,

--- a/apps/mount-testing/src/pages/ui5.tsx
+++ b/apps/mount-testing/src/pages/ui5.tsx
@@ -1,5 +1,6 @@
 import '@sanity/ui/styles.css'
-import {AddIcon, EditIcon} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons/Add'
+import {EditIcon} from '@sanity/icons/Edit'
 import {
   Box,
   Button,

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -10,7 +10,7 @@
     "test": "vitest --project=storybook"
   },
   "dependencies": {
-    "@sanity/icons": "^3.7.4",
+    "@sanity/icons": "^5.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-refractor": "^4.0.0",

--- a/apps/storybook/src/stories/Button.stories.tsx
+++ b/apps/storybook/src/stories/Button.stories.tsx
@@ -1,4 +1,4 @@
-import {EditIcon} from '@sanity/icons'
+import {EditIcon} from '@sanity/icons/Edit'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import {expect} from 'storybook/test'
 import {Button as ButtonV3} from 'ui3'

--- a/apps/storybook/src/stories/Icon.stories.tsx
+++ b/apps/storybook/src/stories/Icon.stories.tsx
@@ -1,11 +1,9 @@
-import {
-  AddIcon,
-  CheckmarkIcon,
-  CloseIcon,
-  EditIcon,
-  SearchIcon,
-  WarningOutlineIcon,
-} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons/Add'
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {CloseIcon} from '@sanity/icons/Close'
+import {EditIcon} from '@sanity/icons/Edit'
+import {SearchIcon} from '@sanity/icons/Search'
+import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import {expect} from 'storybook/test'
 

--- a/apps/storybook/src/stories/IconButton.stories.tsx
+++ b/apps/storybook/src/stories/IconButton.stories.tsx
@@ -1,11 +1,9 @@
-import {
-  AddIcon,
-  CheckmarkIcon,
-  CloseIcon,
-  EditIcon,
-  SearchIcon,
-  WarningOutlineIcon,
-} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons/Add'
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {CloseIcon} from '@sanity/icons/Close'
+import {EditIcon} from '@sanity/icons/Edit'
+import {SearchIcon} from '@sanity/icons/Search'
+import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import {expect} from 'storybook/test'
 

--- a/apps/storybook/src/stories/List.stories.tsx
+++ b/apps/storybook/src/stories/List.stories.tsx
@@ -1,4 +1,7 @@
-import {ComposeIcon, EditIcon, ImageIcon, SparkleIcon} from '@sanity/icons'
+import {ComposeIcon} from '@sanity/icons/Compose'
+import {EditIcon} from '@sanity/icons/Edit'
+import {ImageIcon} from '@sanity/icons/Image'
+import {SparkleIcon} from '@sanity/icons/Sparkle'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import type {ComponentProps} from 'react'
 import {expect} from 'storybook/test'

--- a/apps/storybook/src/stories/ListButtonItem.stories.tsx
+++ b/apps/storybook/src/stories/ListButtonItem.stories.tsx
@@ -1,4 +1,4 @@
-import {EditIcon} from '@sanity/icons'
+import {EditIcon} from '@sanity/icons/Edit'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import {expect} from 'storybook/test'
 

--- a/apps/storybook/src/stories/ListItem.stories.tsx
+++ b/apps/storybook/src/stories/ListItem.stories.tsx
@@ -1,4 +1,4 @@
-import {EditIcon} from '@sanity/icons'
+import {EditIcon} from '@sanity/icons/Edit'
 import type {Meta, StoryObj} from '@storybook/react-vite'
 import {expect} from 'storybook/test'
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -24,8 +24,6 @@ npx @sanity/ui@alpha init
 
 `@sanity/icons` is a dependency of this package, so your package manager installs it either way. `init` also adds it to your own `package.json` because you import icons directly to pass to components, and under pnpm an import that isn't declared in your project doesn't resolve.
 
-Import each icon from its own subpath, as in `import {AddIcon} from '@sanity/icons/Add'`. The root entry stopped re-exporting individual icons in `@sanity/icons` v5. It now exports the dynamic `Icon` component and the `icons` map only.
-
 - `--dry` print the plan and exit without changing anything
 - `--yes` accept every prompt with its default (non-interactive, for CI and agents)
 - `--cwd <dir>` run against another directory

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -24,6 +24,8 @@ npx @sanity/ui@alpha init
 
 `@sanity/icons` is a dependency of this package, so your package manager installs it either way. `init` also adds it to your own `package.json` because you import icons directly to pass to components, and under pnpm an import that isn't declared in your project doesn't resolve.
 
+Import each icon from its own subpath, as in `import {AddIcon} from '@sanity/icons/Add'`. The root entry stopped re-exporting individual icons in `@sanity/icons` v5. It now exports the dynamic `Icon` component and the `icons` map only.
+
 - `--dry` print the plan and exit without changing anything
 - `--yes` accept every prompt with its default (non-interactive, for CI and agents)
 - `--cwd <dir>` run against another directory
@@ -46,7 +48,7 @@ import '@sanity/ui/styles.css'
 
 ```tsx
 import {Box, Flex, Card, Heading, Text, Button} from '@sanity/ui'
-import {AddIcon} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons/Add'
 
 export default function App() {
   return (

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@sanity-labs/design-tokens": "0.0.2-alpha.4",
-    "@sanity/icons": "^3.7.4",
+    "@sanity/icons": "^5.2.1",
     "clsx": "^2.1.1",
     "comment-json": "^5.0.0",
     "dialog-closedby-polyfill": "^1.3.0",

--- a/packages/ui/src/cli/install.ts
+++ b/packages/ui/src/cli/install.ts
@@ -36,7 +36,8 @@ function exactFromRange(range: string | undefined): string | null {
  *
  * Icons is already a dependency, so the package manager installs it either way.
  * It is listed explicitly because apps import icons directly to pass to
- * components (`<Button iconStart={AddIcon} />`), and under pnpm an import that
+ * components (`import {AddIcon} from '@sanity/icons/Add'`, then
+ * `<Button iconStart={AddIcon} />`), and under pnpm an import that
  * isn't in the app's own package.json doesn't resolve. Dependencies the app
  * never imports itself (react-refractor, clsx) are left to the package manager.
  * React/react-dom are peers that belong to the host app, so they are left out

--- a/packages/ui/src/components/checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
-import {CheckmarkIcon, RemoveIcon} from '@sanity/icons'
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {RemoveIcon} from '@sanity/icons/Remove'
 import clsx from 'clsx'
 import {useEffect, useRef} from 'react'
 

--- a/packages/ui/src/components/dialog/Dialog.tsx
+++ b/packages/ui/src/components/dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import {CloseIcon} from '@sanity/icons'
+import {CloseIcon} from '@sanity/icons/Close'
 import clsx from 'clsx'
 import {type ComponentProps, useEffect, useId, useRef} from 'react'
 

--- a/packages/ui/src/components/spinner/Spinner.tsx
+++ b/packages/ui/src/components/spinner/Spinner.tsx
@@ -1,4 +1,4 @@
-import {SpinnerIcon} from '@sanity/icons'
+import {SpinnerIcon} from '@sanity/icons/Spinner'
 import clsx from 'clsx'
 
 import {getProps} from '../../utils/getProps'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,8 +302,8 @@ importers:
   apps/mount-testing:
     dependencies:
       '@sanity/icons':
-        specifier: ^3.7.4
-        version: 3.7.4(react@19.2.6)
+        specifier: ^5.2.1
+        version: 5.2.1(react@19.2.6)
       '@sanity/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -360,8 +360,8 @@ importers:
   apps/storybook:
     dependencies:
       '@sanity/icons':
-        specifier: ^3.7.4
-        version: 3.7.4(react@19.2.6)
+        specifier: ^5.2.1
+        version: 5.2.1(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -445,8 +445,8 @@ importers:
         specifier: 0.0.2-alpha.4
         version: 0.0.2-alpha.4
       '@sanity/icons':
-        specifier: ^3.7.4
-        version: 3.7.4(react@19.2.6)
+        specifier: ^5.2.1
+        version: 5.2.1(react@19.2.6)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2796,6 +2796,12 @@ packages:
   '@sanity/icons@3.7.4':
     resolution: {integrity: sha512-O9MnckiDsphFwlRS8Q3kj3n+JYUZ0UzKRujnSikMZOKI0dayucRe4U2XvxikRhJnFhcEJXW2RkWJoBaCoup9Sw==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^19.2.6
+
+  '@sanity/icons@5.2.1':
+    resolution: {integrity: sha512-P5gY1HRungh4RgCcypdIpu/SKoTwRBTttpbHntZjdW1MO3MK6xEOs+pbAzSARyhh22OcN9PkBBEYk2FL34BvfQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^19.2.6
 
@@ -8697,6 +8703,10 @@ snapshots:
   '@sanity/color@3.0.6': {}
 
   '@sanity/icons@3.7.4(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+
+  '@sanity/icons@5.2.1(react@19.2.6)':
     dependencies:
       react: 19.2.6
 


### PR DESCRIPTION
### Description

Updates to the current @sanity/icons package, and updates imports to use per icon import paths as required.

### What to review

Changes are limited to import paths and relevant readme updates.

### Testing

- Tests pass locally
- Verified components that use icons are rendering as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical dependency and import-path updates with unchanged icon components; risk is mainly consumers still importing from `@sanity/icons` root after upgrading.
> 
> **Overview**
> Upgrades **`@sanity/icons`** from v3 to **^5.2.1** across `@sanity/ui`, mount-testing, and Storybook, and switches every static icon import to **per-icon subpaths** (e.g. `@sanity/icons/Add`) because v5 no longer exports named icons from the package root.
> 
> Internal components (**Checkbox**, **Dialog**, **Spinner**) and all story/demo pages follow the same pattern. The **README** usage example and the **init install** CLI comment now show the subpath import style apps need under pnpm. A **changeset** patch note documents the migration for `@sanity/ui` consumers.
> 
> Runtime-only icon names should keep using the root entry’s dynamic **`Icon`** / **`icons`** map (called out in the changeset); this PR does not change that API usage in code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cbf1aa113419858805d6ab925256ca5efea91e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->