### PR TITLE
ci: pin release npm to 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,9 @@ jobs:
           cache: pnpm
           check-latest: true
           node-version: lts/*
+      # npm 12 wraps `pnpm info --json`; @changesets/cli 3.0.1 does not unwrap it (changesets/changesets#2274)
       - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`npm@latest` is now 12. `changeset publish` then crashes on this repo’s pnpm + `@changesets/cli@3.0.1` stack because npm 12 wraps `pnpm info --json` in an array that the Changesets pnpm parser does not unwrap ([changesets/changesets#2274](https://github.com/changesets/changesets/issues/2274)). Same failure: [sanity-io/visual-editing run 33517457076](https://github.com/sanity-io/visual-editing/actions/runs/33517457076).

Pin the OIDC step to `npm@11` (still ≥ 11.5.1 for trusted publishing). No `@changesets/*` bump.

```diff
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44bda637-4c1f-4f52-a8e1-f00d0a326601?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44bda637-4c1f-4f52-a8e1-f00d0a326601&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

