### PR TITLE
Fix pkg.pr.new previews to use pnpm packing

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -36,4 +36,4 @@ jobs:
 
       - run: |
           echo "Publishing to pkg.pr.new"
-          pnpm pnpx pkg-pr-new publish ./packages/color ./packages/icons ./packages/logos ./packages/ui
+          pnpm pnpx pkg-pr-new publish --pnpm ./packages/color ./packages/icons ./packages/logos ./packages/ui


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pass `--pnpm` to `pkg-pr-new publish`
- ensure preview tarballs apply each package's `publishConfig` overrides
- avoid exposing source-only exports and unresolved workspace/catalog dependency specs to consumers

## Testing
- `pnpm build`
- `pnpm lint`
- compared `npm pack` and `pnpm pack` manifests for `@sanity/ui`: npm retained `./src/exports/index.ts` plus four workspace/catalog specs, while pnpm produced `./dist/index.js` with no unresolved specs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ab31764-37bc-4e62-a5c0-97a57df2de20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ab31764-37bc-4e62-a5c0-97a57df2de20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

