### PR TITLE
fix(ui): keep animated Popover/Tooltip transform-origin across re-opens

### DIFF
--- a/.changeset/popover-reopen-transform-origin.md
+++ b/.changeset/popover-reopen-transform-origin.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Fix animated `Popover` and `Tooltip` (and thereby `MenuButton`) scaling from the center instead of the reference element every time they are shown after the first. The `transform-origin` computed by the floating-ui `origin` middleware is now applied as a plain CSS property instead of motion's `originX`/`originY` style keys, which motion resets to their initial (unpositioned) values whenever the `Activity`-hidden element re-mounts.

--- a/apps/storybook/tests/popoverTransformOrigin.test.tsx
+++ b/apps/storybook/tests/popoverTransformOrigin.test.tsx
@@ -29,7 +29,7 @@ describe('animated popover transform-origin', () => {
     await userEvent.click(button)
     await expect.poll(() => inlineStyle(popover)?.opacity, POLL).toBe('1')
     const origin = inlineStyle(popover)!.transformOrigin
-    expect(origin).toMatch(/^\S+ 0%$/)
+    expect(origin).toMatch(/^\S+ 0%/)
 
     await userEvent.keyboard('{Escape}')
     await expect.poll(() => inlineStyle(popover)?.display, POLL).toBe('none')
@@ -46,13 +46,12 @@ describe('animated popover transform-origin', () => {
     const button = screen.getByRole('button', {name: 'Hover me'})
     const tooltip = '[data-ui="Tooltip__card"]'
     // `Activity` hides the outer `Layer`, motion animates the card inside it
-    const layerStyle = () =>
-      document.querySelector<HTMLElement>(tooltip)?.parentElement?.style
+    const layerStyle = () => document.querySelector<HTMLElement>(tooltip)?.parentElement?.style
 
     await userEvent.hover(button)
     await expect.poll(() => inlineStyle(tooltip)?.opacity, POLL).toBe('1')
     const origin = inlineStyle(tooltip)!.transformOrigin
-    expect(origin).toMatch(/^\S+ 0%$/)
+    expect(origin).toMatch(/^\S+ 0%/)
 
     await userEvent.unhover(button)
     await expect.poll(() => layerStyle()?.display, POLL).toBe('none')

--- a/apps/storybook/tests/popoverTransformOrigin.test.tsx
+++ b/apps/storybook/tests/popoverTransformOrigin.test.tsx
@@ -1,0 +1,66 @@
+import {composeStories} from '@storybook/react-vite'
+import {describe, expect, test} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {userEvent} from 'vitest/browser'
+
+import * as menuButtonStories from '../stories/components/MenuButton.stories'
+import * as tooltipStories from '../stories/primitives/Tooltip.stories'
+
+const {AnimatedPopover} = composeStories(menuButtonStories)
+const {Animated: AnimatedTooltip} = composeStories(tooltipStories)
+
+const POLL = {timeout: 5000}
+
+function inlineStyle(selector: string): CSSStyleDeclaration | undefined {
+  return document.querySelector<HTMLElement>(selector)?.style
+}
+
+// Animated popovers and tooltips stay mounted while closed (hidden by
+// `Activity`), so motion re-mounts the same element every time they open and
+// resets its motion values to their initial state. The `transform-origin`
+// computed by the `origin` middleware must survive that, or every open after
+// the first scales from the center instead of the reference element.
+describe('animated popover transform-origin', () => {
+  test('MenuButton popover keeps its transform-origin when re-opened', async () => {
+    const screen = await render(<AnimatedPopover />)
+    const button = screen.getByRole('button', {name: 'Open'})
+    const popover = '[data-ui="MenuButton__popover"]'
+
+    await userEvent.click(button)
+    await expect.poll(() => inlineStyle(popover)?.opacity, POLL).toBe('1')
+    const origin = inlineStyle(popover)!.transformOrigin
+    expect(origin).toMatch(/^\S+ 0%$/)
+
+    await userEvent.keyboard('{Escape}')
+    await expect.poll(() => inlineStyle(popover)?.display, POLL).toBe('none')
+
+    await userEvent.click(button)
+    await expect.poll(() => inlineStyle(popover)?.display, POLL).toBe('')
+    expect(inlineStyle(popover)!.transformOrigin).toBe(origin)
+    await expect.poll(() => inlineStyle(popover)?.opacity, POLL).toBe('1')
+    expect(inlineStyle(popover)!.transformOrigin).toBe(origin)
+  })
+
+  test('Tooltip keeps its transform-origin when re-shown', async () => {
+    const screen = await render(<AnimatedTooltip />)
+    const button = screen.getByRole('button', {name: 'Hover me'})
+    const tooltip = '[data-ui="Tooltip__card"]'
+    // `Activity` hides the outer `Layer`, motion animates the card inside it
+    const layerStyle = () =>
+      document.querySelector<HTMLElement>(tooltip)?.parentElement?.style
+
+    await userEvent.hover(button)
+    await expect.poll(() => inlineStyle(tooltip)?.opacity, POLL).toBe('1')
+    const origin = inlineStyle(tooltip)!.transformOrigin
+    expect(origin).toMatch(/^\S+ 0%$/)
+
+    await userEvent.unhover(button)
+    await expect.poll(() => layerStyle()?.display, POLL).toBe('none')
+
+    await userEvent.hover(button)
+    await expect.poll(() => layerStyle()?.display, POLL).toBe('')
+    expect(inlineStyle(tooltip)!.transformOrigin).toBe(origin)
+    await expect.poll(() => inlineStyle(tooltip)?.opacity, POLL).toBe('1')
+    expect(inlineStyle(tooltip)!.transformOrigin).toBe(origin)
+  })
+})

--- a/apps/storybook/tests/popoverTransformOrigin.test.tsx
+++ b/apps/storybook/tests/popoverTransformOrigin.test.tsx
@@ -29,7 +29,7 @@ describe('animated popover transform-origin', () => {
     await userEvent.click(button)
     await expect.poll(() => inlineStyle(popover)?.opacity, POLL).toBe('1')
     const origin = inlineStyle(popover)!.transformOrigin
-    expect(origin).toMatch(/^\S+ 0%/)
+    expect(origin).not.toMatch(/^50% 50%/)
 
     await userEvent.keyboard('{Escape}')
     await expect.poll(() => inlineStyle(popover)?.display, POLL).toBe('none')
@@ -51,7 +51,7 @@ describe('animated popover transform-origin', () => {
     await userEvent.hover(button)
     await expect.poll(() => inlineStyle(tooltip)?.opacity, POLL).toBe('1')
     const origin = inlineStyle(tooltip)!.transformOrigin
-    expect(origin).toMatch(/^\S+ 0%/)
+    expect(origin).not.toMatch(/^50% 50%/)
 
     await userEvent.unhover(button)
     await expect.poll(() => layerStyle()?.display, POLL).toBe('none')

--- a/packages/ui/src/core/middleware/origin.ts
+++ b/packages/ui/src/core/middleware/origin.ts
@@ -42,6 +42,20 @@ export const origin: Middleware = {
   },
 }
 
+/**
+ * Converts the `origin` middleware data into a plain `transform-origin` CSS value.
+ *
+ * The value is intentionally applied as a regular CSS property rather than motion's
+ * `originX`/`originY` style keys: motion turns those into motion values that it resets to
+ * their initial (unpositioned, `undefined`) state whenever the element re-mounts, which is
+ * what happens every time an `Activity`-hidden popover or tooltip is shown again.
+ */
+export function getTransformOrigin(originX?: number, originY?: number): string | undefined {
+  if (originX === undefined || originY === undefined) return undefined
+
+  return `${originX * 100}% ${originY * 100}%`
+}
+
 function clamp(num: number, min: number, max: number) {
   return Math.min(Math.max(num, min), max)
 }

--- a/packages/ui/src/core/primitives/popover/popoverCard.tsx
+++ b/packages/ui/src/core/primitives/popover/popoverCard.tsx
@@ -5,6 +5,7 @@ import {styled} from 'styled-components'
 
 import {ThemeColorSchemeKey} from '../../../theme/system/color/_system'
 import {POPOVER_MOTION_PROPS} from '../../constants'
+import {getTransformOrigin} from '../../middleware/origin'
 import {BoxOverflow} from '../../types/box'
 import {CardTone} from '../../types/card'
 import {Placement} from '../../types/placement'
@@ -99,10 +100,9 @@ export function PopoverCard(
   const rootStyle: CSSProperties = useMemo(
     () => ({
       left: x,
-      originX,
-      originY,
       position: strategy,
       top: y,
+      transformOrigin: getTransformOrigin(originX, originY),
       width,
       zIndex,
       willChange: animate ? 'transform' : undefined,

--- a/packages/ui/src/core/primitives/tooltip/tooltipCard.tsx
+++ b/packages/ui/src/core/primitives/tooltip/tooltipCard.tsx
@@ -4,6 +4,7 @@ import React, {CSSProperties, useMemo} from 'react'
 
 import {ThemeColorSchemeKey} from '../../../theme/system/color/_system'
 import {POPOVER_MOTION_PROPS} from '../../constants'
+import {getTransformOrigin} from '../../middleware/origin'
 import {Placement} from '../../types/placement'
 import {Radius} from '../../types/radius'
 import {Arrow} from '../../utils/arrow/arrow'
@@ -59,8 +60,7 @@ export function TooltipCard(
 
   const rootStyle: CSSProperties = useMemo(
     () => ({
-      originX,
-      originY,
+      transformOrigin: getTransformOrigin(originX, originY),
       willChange: animate ? 'transform' : undefined,
       ...style,
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

An animated `<MenuButton>` (and any animated `Popover`/`Tooltip`) scales in from the reference element the first time it opens, but every subsequent open scales from the center of the popover instead.

## Root cause

`PopoverCard` and `TooltipCard` passed the origin computed by the floating-ui `origin` middleware to motion as `originX`/`originY` style keys. motion treats `origin*` keys as forced motion values and snapshots them into `initialValues` when the visual element is constructed, which is before floating-ui has positioned anything, so the snapshot holds `originX: undefined, originY: undefined`.

Closed animated popovers stay mounted, hidden by React `Activity` (`AnimateActivity`). `Activity` detaches refs while hidden, so motion unmounts and later re-mounts the same visual element on every re-open. Since motion 12.3x, `VisualElement.mount()` re-applies `initialValues` on re-mount so enter animations replay, which resets `originX`/`originY` to `undefined`. Because the `style` prop has not changed, `updateMotionValuesFromProps` never restores them, and `transform-origin` stays at the browser default `50% 50%` forever.

## Fix

Apply the origin as a plain `transform-origin` CSS property (`getTransformOrigin` next to the `origin` middleware) instead of motion's `originX`/`originY`. motion leaves regular CSS properties alone, so React owns the value and it survives the re-mount.

## Testing

- New browser regression test `apps/storybook/tests/popoverTransformOrigin.test.tsx` opens/closes/re-opens the `MenuButton` `AnimatedPopover` story and the `Tooltip` `Animated` story and asserts the inline `transform-origin` is unchanged on re-open. It fails on `main` (`50% 50% 0px` vs `39.457% 0% 0px`) and passes with the fix.
- `pnpm lint`, `pnpm knip`, `pnpm --filter @sanity/ui test`, and the Popover/Tooltip/MenuButton story browser tests pass.
- Changeset included (`@sanity/ui` patch).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94619796-ab02-4ea2-9f00-ce3ac8991695?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94619796-ab02-4ea2-9f00-ce3ac8991695&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

