### PR TITLE
Keep `data-ui` identifiers on all rendered components

### DIFF
--- a/.changeset/bright-lions-explain.md
+++ b/.changeset/bright-lions-explain.md
@@ -2,4 +2,4 @@
 "@sanity/ui": patch
 ---
 
-Stop `Layer` from overwriting `data-ui` on `Dialog` and `Tooltip`, and add identifiers on remaining component roots (`ThemeProvider` fallback, `Popover` overlay, `Button` loading state, `Toast` loading bar, `Dialog` regions, and text overflow).
+Stop `Layer` from overwriting `data-ui` on `Dialog` and `Tooltip`, and add identifiers on remaining component roots (`PopoverOverlay`, `ButtonLoading`, `ToastLoadingBar`, dialog regions, and `SpanWithTextOverflow`).

--- a/.changeset/bright-lions-explain.md
+++ b/.changeset/bright-lions-explain.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Stop `Layer` from overwriting `data-ui` on `Dialog` and `Tooltip`, and add identifiers on remaining component roots (`ThemeProvider` fallback, `Popover` overlay, `Button` loading state, `Toast` loading bar, `Dialog` regions, and text overflow).

--- a/apps/storybook/tests/toast.test.tsx
+++ b/apps/storybook/tests/toast.test.tsx
@@ -23,7 +23,7 @@ function opacityOf(element: Element): number {
 async function sampleOpacities(): Promise<Sample[]> {
   const container = document.querySelector('[data-ui="Toast"]')!
   const content = container.querySelector(':scope > [data-ui="Flex"]')!
-  const loadingBar = container.querySelector(':scope > [data-ui="Toast__loadingBar"]')!
+  const loadingBar = container.querySelector(':scope > [data-ui="ToastLoadingBar"]')!
   const samples: Sample[] = []
   const deadline = performance.now() + 2_000
 

--- a/apps/storybook/tests/toast.test.tsx
+++ b/apps/storybook/tests/toast.test.tsx
@@ -23,7 +23,7 @@ function opacityOf(element: Element): number {
 async function sampleOpacities(): Promise<Sample[]> {
   const container = document.querySelector('[data-ui="Toast"]')!
   const content = container.querySelector(':scope > [data-ui="Flex"]')!
-  const loadingBar = container.querySelector(':scope > div:not([data-ui])')!
+  const loadingBar = container.querySelector(':scope > [data-ui="Toast__loadingBar"]')!
   const samples: Sample[] = []
   const deadline = performance.now() + 2_000
 

--- a/packages/ui/src/core/components/dialog/dialog.tsx
+++ b/packages/ui/src/core/components/dialog/dialog.tsx
@@ -219,7 +219,7 @@ function DialogCard(props: DialogCardProps) {
       >
         <Flex className={dialogLayout} direction="column" flex={1}>
           {showHeader && (
-            <Box className={dialogHeader}>
+            <Box className={dialogHeader} data-ui="Dialog__header">
               <Flex align="flex-start" padding={3}>
                 <Box flex={1} padding={2}>
                   {header && (
@@ -244,11 +244,21 @@ function DialogCard(props: DialogCardProps) {
             </Box>
           )}
 
-          <Box className={dialogContent} flex={1} ref={contentRef} tabIndex={-1}>
+          <Box
+            className={dialogContent}
+            data-ui="Dialog__content"
+            flex={1}
+            ref={contentRef}
+            tabIndex={-1}
+          >
             {children}
           </Box>
 
-          {footer && <Box className={dialogFooter}>{footer}</Box>}
+          {footer && (
+            <Box className={dialogFooter} data-ui="Dialog__footer">
+              {footer}
+            </Box>
+          )}
         </Flex>
       </Card>
     </Container>

--- a/packages/ui/src/core/components/dialog/dialog.tsx
+++ b/packages/ui/src/core/components/dialog/dialog.tsx
@@ -219,7 +219,7 @@ function DialogCard(props: DialogCardProps) {
       >
         <Flex className={dialogLayout} direction="column" flex={1}>
           {showHeader && (
-            <Box className={dialogHeader} data-ui="Dialog__header">
+            <Box className={dialogHeader} data-ui="DialogHeader">
               <Flex align="flex-start" padding={3}>
                 <Box flex={1} padding={2}>
                   {header && (
@@ -246,7 +246,7 @@ function DialogCard(props: DialogCardProps) {
 
           <Box
             className={dialogContent}
-            data-ui="Dialog__content"
+            data-ui="DialogContent"
             flex={1}
             ref={contentRef}
             tabIndex={-1}
@@ -255,7 +255,7 @@ function DialogCard(props: DialogCardProps) {
           </Box>
 
           {footer && (
-            <Box className={dialogFooter} data-ui="Dialog__footer">
+            <Box className={dialogFooter} data-ui="DialogFooter">
               {footer}
             </Box>
           )}

--- a/packages/ui/src/core/components/toast/toast.tsx
+++ b/packages/ui/src/core/components/toast/toast.tsx
@@ -141,7 +141,7 @@ export function Toast(
       {hasDuration && (
         <motion.div
           className={loadingBar}
-          data-ui="Toast__loadingBar"
+          data-ui="ToastLoadingBar"
           variants={content}
           transition={transition}
         >

--- a/packages/ui/src/core/components/toast/toast.tsx
+++ b/packages/ui/src/core/components/toast/toast.tsx
@@ -139,7 +139,12 @@ export function Toast(
         )}
       </MotionFlex>
       {hasDuration && (
-        <motion.div className={loadingBar} variants={content} transition={transition}>
+        <motion.div
+          className={loadingBar}
+          data-ui="Toast__loadingBar"
+          variants={content}
+          transition={transition}
+        >
           <Card className={loadingBarMask} tone={cardTone} radius={radius} />
           <LoadingBarProgress
             key={`progress-${updatedAt}`}

--- a/packages/ui/src/core/dataUi.test.tsx
+++ b/packages/ui/src/core/dataUi.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import {describe, expect, it, vi} from 'vitest'
+import {afterEach, describe, expect, it, vi} from 'vitest'
 
 // oxlint-disable-next-line no-unassigned-import
 import '../../test/mocks/matchMedia.mock'
@@ -136,6 +136,18 @@ function Boom(): React.JSX.Element {
   throw new Error('boom')
 }
 
+function isExpectedErrorBoundaryLog(args: unknown[]): boolean {
+  const hasBoomError = args.some((arg) => arg instanceof Error && arg.message === 'boom')
+
+  if (hasBoomError) return true
+
+  const strings = args.filter((arg): arg is string => typeof arg === 'string')
+  const mentionsBoom = strings.some((arg) => arg === 'Boom' || arg.includes('<Boom>'))
+  const isReactBoundaryLog = strings.some((arg) => arg.includes('The above error occurred'))
+
+  return mentionsBoom && isReactBoundaryLog
+}
+
 function expectIdentifiers(names: readonly string[]) {
   for (const name of names) {
     expect(document.querySelector(`[data-ui="${name}"]`), `data-ui="${name}"`).not.toBeNull()
@@ -143,8 +155,19 @@ function expectIdentifiers(names: readonly string[]) {
 }
 
 describe('component identifiers', () => {
+  const originalError = console.error.bind(console)
+  let consoleError: {mockRestore: () => void} | undefined
+
+  afterEach(() => {
+    consoleError?.mockRestore()
+    consoleError = undefined
+  })
+
   it('identifies exported components with data-ui attributes', {timeout: 15_000}, () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    consoleError = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (isExpectedErrorBoundaryLog(args)) return
+      originalError(...args)
+    })
 
     render(
       <>
@@ -234,7 +257,5 @@ describe('component identifiers', () => {
 
     expectIdentifiers(PUBLIC_IDENTIFIERS)
     expectIdentifiers(COMPOSITE_IDENTIFIERS)
-
-    consoleError.mockRestore()
   })
 })

--- a/packages/ui/src/core/dataUi.test.tsx
+++ b/packages/ui/src/core/dataUi.test.tsx
@@ -1,42 +1,248 @@
 /** @vitest-environment jsdom */
 
-import {describe, expect, it} from 'vitest'
+import {render as testingLibraryRender} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
 
+// oxlint-disable-next-line no-unassigned-import
+import '../../test/mocks/matchMedia.mock'
+// oxlint-disable-next-line no-unassigned-import
+import '../../test/mocks/resizeObserver.mock'
 import {render} from '../../test/utils'
 import {
   Arrow,
+  Avatar,
+  AvatarCounter,
+  AvatarStack,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
   CodeSkeleton,
+  Container,
+  Dialog,
+  ElementQuery,
+  ErrorBoundary,
+  Flex,
+  Grid,
+  Heading,
   HeadingSkeleton,
+  Hotkeys,
+  Inline,
+  KBD,
+  Label,
   LabelSkeleton,
+  Layer,
+  LayerProvider,
+  Radio,
+  Select,
   Skeleton,
+  Spinner,
+  SrOnly,
+  Stack,
+  Switch,
+  Tab,
+  TabList,
+  TabPanel,
+  Text,
+  TextArea,
+  TextInput,
   TextSkeleton,
+  ThemeProvider,
+  Tree,
+  TreeItem,
+  VirtualList,
 } from '../exports'
-import {MenuDivider} from '../exports/menu'
+import {Autocomplete} from '../exports/autocomplete'
+import {Breadcrumbs} from '../exports/breadcrumbs'
+import {Code} from '../exports/code'
+import {Menu, MenuButton, MenuDivider, MenuGroup, MenuItem} from '../exports/menu'
+import {Popover} from '../exports/popover'
+import {Toast, ToastProvider} from '../exports/toast'
+import {Tooltip} from '../exports/tooltip'
+
+const PUBLIC_IDENTIFIERS = [
+  'Arrow',
+  'Autocomplete',
+  'Avatar',
+  'AvatarCounter',
+  'AvatarStack',
+  'Badge',
+  'Box',
+  'Breadcrumbs',
+  'Button',
+  'Card',
+  'Checkbox',
+  'Code',
+  'CodeSkeleton',
+  'Container',
+  'Dialog',
+  'ElementQuery',
+  'ErrorBoundary',
+  'Flex',
+  'Grid',
+  'Heading',
+  'HeadingSkeleton',
+  'Hotkeys',
+  'Inline',
+  'KBD',
+  'Label',
+  'LabelSkeleton',
+  'Layer',
+  'Menu',
+  'MenuButton',
+  'MenuDivider',
+  'MenuGroup',
+  'MenuItem',
+  'Popover',
+  'Radio',
+  'Select',
+  'Skeleton',
+  'Spinner',
+  'SrOnly',
+  'Stack',
+  'Switch',
+  'Tab',
+  'TabList',
+  'TabPanel',
+  'Text',
+  'TextArea',
+  'TextInput',
+  'TextSkeleton',
+  'Toast',
+  'ToastProvider',
+  'Tooltip',
+  'Tree',
+  'TreeItem',
+  'VirtualList',
+] as const
+
+const COMPOSITE_IDENTIFIERS = [
+  'Button__loading',
+  'Dialog__content',
+  'Dialog__footer',
+  'Dialog__header',
+  'DialogCard',
+  'MenuButton__popover',
+  'MenuGroup__popover',
+  'Popover__overlay',
+  'Popover__wrapper',
+  'TextOverflow',
+  'Toast__loadingBar',
+  'Tooltip__card',
+  'TreeGroup',
+  'TreeItem__box',
+] as const
+
+function Boom(): React.JSX.Element {
+  throw new Error('boom')
+}
+
+function expectIdentifiers(names: readonly string[]) {
+  for (const name of names) {
+    expect(document.querySelector(`[data-ui="${name}"]`), `data-ui="${name}"`).not.toBeNull()
+  }
+}
 
 describe('component identifiers', () => {
-  it('identifies exported components with data-ui attributes', () => {
-    const {container} = render(
+  it('identifies exported components with data-ui attributes', {timeout: 15_000}, () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
       <>
         <Arrow height={5} width={10} />
-        <Skeleton />
-        <TextSkeleton />
-        <LabelSkeleton />
-        <HeadingSkeleton />
+        <Autocomplete id="autocomplete" />
+        <Avatar initials="AB" />
+        <AvatarCounter count={3} />
+        <AvatarStack>
+          <Avatar initials="AB" />
+        </AvatarStack>
+        <Badge>Badge</Badge>
+        <Box>Box</Box>
+        <Breadcrumbs>
+          <Text>Home</Text>
+          <Text>Docs</Text>
+        </Breadcrumbs>
+        <Button loading text="Loading" />
+        <Card>Card</Card>
+        <Checkbox />
+        <Code>const x = 1</Code>
         <CodeSkeleton />
-        <MenuDivider />
+        <Container>Container</Container>
+        <Dialog footer="Footer" header="Header" id="dialog" onClose={() => {}}>
+          Dialog
+        </Dialog>
+        <ElementQuery>ElementQuery</ElementQuery>
+        <ErrorBoundary onCatch={() => {}}>
+          <Boom />
+        </ErrorBoundary>
+        <Flex>Flex</Flex>
+        <Grid>Grid</Grid>
+        <Heading>Heading</Heading>
+        <HeadingSkeleton />
+        <Hotkeys keys={['Mod', 'K']} />
+        <Inline>Inline</Inline>
+        <KBD>K</KBD>
+        <Label>Label</Label>
+        <LabelSkeleton />
+        <Layer>Layer</Layer>
+        <LayerProvider>
+          <Menu>
+            <MenuItem text="Item" />
+            <MenuDivider />
+            <MenuGroup text="Group">
+              <MenuItem text="Nested" />
+            </MenuGroup>
+          </Menu>
+        </LayerProvider>
+        <MenuButton button={<Button text="Open" />} id="menu-button" menu={<Menu />} />
+        <Popover content="Popover" modal open>
+          <Button text="Reference" />
+        </Popover>
+        <Radio />
+        <Select>
+          <option value="a">A</option>
+        </Select>
+        <Skeleton />
+        <Spinner />
+        <SrOnly>SrOnly</SrOnly>
+        <Stack>Stack</Stack>
+        <Switch />
+        <Tab aria-controls="panel" id="tab" label="Tab" />
+        <TabList>
+          <Tab aria-controls="panel" id="tab-list-tab" label="Listed" />
+          <Tab aria-controls="panel-2" id="tab-list-tab-2" label="Listed 2" />
+        </TabList>
+        <TabPanel aria-labelledby="tab" id="panel">
+          Panel
+        </TabPanel>
+        <Text textOverflow="ellipsis">Text</Text>
+        <TextArea />
+        <TextInput />
+        <TextSkeleton />
+        <Toast duration={100} onClose={() => {}} title="Toast" />
+        <ToastProvider>ToastProvider</ToastProvider>
+        <Tooltip content="Tooltip">
+          <Button text="Hint" />
+        </Tooltip>
+        <Tree>
+          <TreeItem expanded text="Root">
+            <TreeItem text="Child" />
+          </TreeItem>
+        </Tree>
+        <VirtualList />
       </>,
     )
 
-    for (const componentName of [
-      'Arrow',
-      'Skeleton',
-      'TextSkeleton',
-      'LabelSkeleton',
-      'HeadingSkeleton',
-      'CodeSkeleton',
-      'MenuDivider',
-    ]) {
-      expect(container.querySelector(`[data-ui="${componentName}"]`)).not.toBeNull()
-    }
+    expectIdentifiers(PUBLIC_IDENTIFIERS)
+    expectIdentifiers(COMPOSITE_IDENTIFIERS)
+
+    consoleError.mockRestore()
+  })
+
+  it('identifies ThemeProvider when it renders a fallback', () => {
+    testingLibraryRender(<ThemeProvider />)
+
+    expect(document.querySelector('[data-ui="ThemeProvider"]')).not.toBeNull()
   })
 })

--- a/packages/ui/src/core/dataUi.test.tsx
+++ b/packages/ui/src/core/dataUi.test.tsx
@@ -1,6 +1,5 @@
 /** @vitest-environment jsdom */
 
-import {render as testingLibraryRender} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 
 // oxlint-disable-next-line no-unassigned-import
@@ -48,7 +47,6 @@ import {
   TextArea,
   TextInput,
   TextSkeleton,
-  ThemeProvider,
   Tree,
   TreeItem,
   VirtualList,
@@ -118,17 +116,17 @@ const PUBLIC_IDENTIFIERS = [
 ] as const
 
 const COMPOSITE_IDENTIFIERS = [
-  'Button__loading',
-  'Dialog__content',
-  'Dialog__footer',
-  'Dialog__header',
+  'ButtonLoading',
+  'DialogContent',
+  'DialogFooter',
+  'DialogHeader',
   'DialogCard',
   'MenuButton__popover',
   'MenuGroup__popover',
-  'Popover__overlay',
+  'PopoverOverlay',
   'Popover__wrapper',
-  'TextOverflow',
-  'Toast__loadingBar',
+  'SpanWithTextOverflow',
+  'ToastLoadingBar',
   'Tooltip__card',
   'TreeGroup',
   'TreeItem__box',
@@ -238,11 +236,5 @@ describe('component identifiers', () => {
     expectIdentifiers(COMPOSITE_IDENTIFIERS)
 
     consoleError.mockRestore()
-  })
-
-  it('identifies ThemeProvider when it renders a fallback', () => {
-    testingLibraryRender(<ThemeProvider />)
-
-    expect(document.querySelector('[data-ui="ThemeProvider"]')).not.toBeNull()
   })
 })

--- a/packages/ui/src/core/primitives/button/button.tsx
+++ b/packages/ui/src/core/primitives/button/button.tsx
@@ -135,7 +135,7 @@ function ButtonComponent(
       $width={width}
     >
       {Boolean(loading) && (
-        <div className={buttonLoadingBox}>
+        <div className={buttonLoadingBox} data-ui="Button__loading">
           <Spinner />
         </div>
       )}

--- a/packages/ui/src/core/primitives/button/button.tsx
+++ b/packages/ui/src/core/primitives/button/button.tsx
@@ -135,7 +135,7 @@ function ButtonComponent(
       $width={width}
     >
       {Boolean(loading) && (
-        <div className={buttonLoadingBox} data-ui="Button__loading">
+        <div className={buttonLoadingBox} data-ui="ButtonLoading">
           <Spinner />
         </div>
       )}

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -135,7 +135,7 @@ const ViewportOverlay = () => {
 
   return (
     <div
-      data-ui="Popover__overlay"
+      data-ui="PopoverOverlay"
       style={{height: '100vh', inset: 0, position: 'fixed', width: '100vw', zIndex}}
     />
   )

--- a/packages/ui/src/core/primitives/popover/popover.tsx
+++ b/packages/ui/src/core/primitives/popover/popover.tsx
@@ -133,7 +133,12 @@ export interface PopoverProps
 const ViewportOverlay = () => {
   const {zIndex} = useLayer()
 
-  return <div style={{height: '100vh', inset: 0, position: 'fixed', width: '100vw', zIndex}} />
+  return (
+    <div
+      data-ui="Popover__overlay"
+      style={{height: '100vh', inset: 0, position: 'fixed', width: '100vw', zIndex}}
+    />
+  )
 }
 
 /**

--- a/packages/ui/src/core/theme/themeProvider.tsx
+++ b/packages/ui/src/core/theme/themeProvider.tsx
@@ -48,7 +48,7 @@ export function ThemeProvider(props: ThemeProviderProps): React.JSX.Element {
   }, [scheme, rootTheme, tone])
 
   if (!theme) {
-    return <pre>ThemeProvider: no "theme" property provided</pre>
+    return <pre data-ui="ThemeProvider">ThemeProvider: no "theme" property provided</pre>
   }
 
   return (

--- a/packages/ui/src/core/theme/themeProvider.tsx
+++ b/packages/ui/src/core/theme/themeProvider.tsx
@@ -48,7 +48,7 @@ export function ThemeProvider(props: ThemeProviderProps): React.JSX.Element {
   }, [scheme, rootTheme, tone])
 
   if (!theme) {
-    return <pre data-ui="ThemeProvider">ThemeProvider: no "theme" property provided</pre>
+    return <pre>ThemeProvider: no "theme" property provided</pre>
   }
 
   return (

--- a/packages/ui/src/core/utils/layer/layer.tsx
+++ b/packages/ui/src/core/utils/layer/layer.tsx
@@ -80,9 +80,9 @@ function LayerChildren(props: LayerChildrenProps & Omit<React.HTMLProps<HTMLDivE
 
   return (
     <Component
+      data-ui="Layer"
       {...restProps}
       className={clsx(layer, className)}
-      data-ui="Layer"
       onFocus={handleFocus}
       ref={ref}
       style={{...style, zIndex}}

--- a/packages/ui/src/core/utils/spanWithTextOverflow.tsx
+++ b/packages/ui/src/core/utils/spanWithTextOverflow.tsx
@@ -2,5 +2,9 @@ import {spanWithTextOverflow} from './spanWithTextOverflow.css'
 
 /** @internal */
 export function SpanWithTextOverflow(props: {children?: React.ReactNode}): React.JSX.Element {
-  return <span className={spanWithTextOverflow}>{props.children}</span>
+  return (
+    <span className={spanWithTextOverflow} data-ui="TextOverflow">
+      {props.children}
+    </span>
+  )
 }

--- a/packages/ui/src/core/utils/spanWithTextOverflow.tsx
+++ b/packages/ui/src/core/utils/spanWithTextOverflow.tsx
@@ -3,7 +3,7 @@ import {spanWithTextOverflow} from './spanWithTextOverflow.css'
 /** @internal */
 export function SpanWithTextOverflow(props: {children?: React.ReactNode}): React.JSX.Element {
   return (
-    <span className={spanWithTextOverflow} data-ui="TextOverflow">
+    <span className={spanWithTextOverflow} data-ui="SpanWithTextOverflow">
       {props.children}
     </span>
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Every public `@sanity/ui` component that renders a DOM node now keeps a stable `data-ui` identifier.

`Layer` was applying `data-ui="Layer"` after spreading props, which overwrote `Dialog` and `Tooltip`. Those now win, matching `Box`/`Card`/`Button`.

Also added identifiers on:

- `PopoverOverlay`
- `ButtonLoading`
- `ToastLoadingBar`
- `DialogHeader` / `DialogContent` / `DialogFooter`
- `SpanWithTextOverflow`

The `dataUi.test.tsx` regression now renders every public export (plus those composite regions) instead of only Arrow/skeletons/`MenuDivider`.

## Testing

- `pnpm --filter @sanity/ui exec vitest run src/core/dataUi.test.tsx`
- `pnpm --filter sanity-ui-storybook exec vitest run --project tests tests/toast.test.tsx`
- `pnpm lint` on the touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd07e34e-3aae-4477-99ba-38c649fc6efc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd07e34e-3aae-4477-99ba-38c649fc6efc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

