### PR TITLE
feat: add topAnchor prop for Dialog

### DIFF
--- a/.changeset/spotty-bananas-work.md
+++ b/.changeset/spotty-bananas-work.md
@@ -1,0 +1,5 @@
+---
+'@sanity/ui': patch
+---
+
+add topAnchor prop for Dialog

--- a/apps/storybook/src/stories/Dialog.stories.tsx
+++ b/apps/storybook/src/stories/Dialog.stories.tsx
@@ -122,12 +122,33 @@ function DialogWithFooterStory(props: DialogProps) {
   )
 }
 
+function DialogTopAnchorStory(props: DialogProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  return (
+    <Box padding={4}>
+      <Button text="Open dialog" onClick={() => setDialogOpen(true)} />
+      <Dialog
+        {...props}
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        topAnchor="clamp(1rem, 10dvh, 4rem)"
+      >
+        <Dialog.Content>
+          <Text>Dialog body content</Text>
+        </Dialog.Content>
+      </Dialog>
+    </Box>
+  )
+}
+
 export const Basic: Story = {
   render: (props) => <DialogBasicStory {...props} />,
   play: async ({canvas}) => {
     const dialog = await canvas.findByRole('dialog', {hidden: true})
 
     await expect(dialog.dataset.ui).toBe('Dialog')
+    await expect(dialog.classList).not.toContain('sui-top-anchor')
 
     await userEvent.click(await canvas.findByRole('button', {name: 'Open dialog'}))
 
@@ -162,5 +183,15 @@ export const WithFooter: Story = {
     await expect(dialog.dataset.ui).toBe('Dialog')
     await expect(dialog.querySelector('[data-ui="DialogContent"]')).toBeInTheDocument()
     await expect(dialog.querySelector('[data-ui="DialogFooter"]')).toBeInTheDocument()
+  },
+}
+
+export const TopAnchor: Story = {
+  name: 'With top anchor',
+  render: (props) => <DialogTopAnchorStory {...props} />,
+  play: async ({canvas}) => {
+    await expect((await canvas.findByRole('dialog', {hidden: true})).classList).toContain(
+      'sui-top-anchor',
+    )
   },
 }

--- a/packages/ui/src/components/dialog/Dialog.tsx
+++ b/packages/ui/src/components/dialog/Dialog.tsx
@@ -25,7 +25,7 @@ function DialogRoot({open = false, size = 0, ...props}: DialogProps) {
 
   const dialogClasses = clsx(
     dialogClassName,
-    'sui-inset0 sui-m-auto sui-radius5 sui-shadow3 sui-p4 sui-flex-direction-column sui-gap4 sui-overflow-y-auto',
+    `${props.topAnchor ? 'sui-mx-auto' : 'sui-m-auto'} sui-radius5 sui-shadow3 sui-p4 sui-flex-direction-column sui-gap4 sui-overflow-y-auto`,
   )
 
   useEffect(() => {

--- a/packages/ui/src/components/dialog/dialog.props.ts
+++ b/packages/ui/src/components/dialog/dialog.props.ts
@@ -21,6 +21,8 @@ export interface DialogProps extends Omit<React.ComponentProps<'dialog'>, 'open'
   open?: boolean
   /** Sets the max width of the dialog */
   size?: Responsive<ContainerSize>
+  /** CSS length value used to set the Dialog’s distance from the top of the viewport; Dialog is centered if not provided */
+  topAnchor?: string
 }
 
 export const dialogProps: Record<string, PropDef> = {
@@ -34,5 +36,10 @@ export const dialogProps: Record<string, PropDef> = {
     type: 'union',
     className: 'container',
     values: CONTAINER_SIZE,
+  },
+  topAnchor: {
+    type: 'string',
+    className: 'top-anchor',
+    variable: '--top-anchor',
   },
 }

--- a/packages/ui/src/css/classes/local/index.css
+++ b/packages/ui/src/css/classes/local/index.css
@@ -3,3 +3,4 @@
 @import './text-overflow.css';
 @import './text-trim.css';
 @import './tone.css';
+@import './top-anchor.css';

--- a/packages/ui/src/css/classes/local/top-anchor.css
+++ b/packages/ui/src/css/classes/local/top-anchor.css
@@ -1,4 +1,4 @@
 .sui-top-anchor {
   inset-block-start: var(--top-anchor);
-  max-height: calc(100dvh - var(--top-anchor) * 2);
+  max-block-size: calc(100dvh - var(--top-anchor) * 2);
 }

--- a/packages/ui/src/css/classes/local/top-anchor.css
+++ b/packages/ui/src/css/classes/local/top-anchor.css
@@ -1,0 +1,4 @@
+.sui-top-anchor {
+  inset-block-start: var(--top-anchor);
+  max-height: calc(100dvh - var(--top-anchor) * 2);
+}


### PR DESCRIPTION
### Description

@georgedoescode recently requested the ability to anchor Dialogs with an offset from the top of the viewport rather than centre them, given several instances in Media Library where this is currently done.

This PR implements that feature via the optional `topAnchor` prop. If the prop is not provided, Dialogs remain centred on the viewport. When provided, the Dialog will be positioned the provided length from the top of the viewport, remaining centred on the inline axis. We also set a complementary max height on the Dialog, so that it cannot grow taller than `100dvh - (topAnchor * 2)`) which effectively means a Dialog maxed out in height would have the same offset from the bottom of the viewport as the top.

### What to review

- New topAnchor prop + CSS, plus propDef on Dialog
- New + updated stories for coverage

### Testing

- Verified in Storybook and added Storybook tests to ensure the class is added when the prop is provided, and that it's not when the prop is undeclared

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional layout prop and CSS with no changes to open/close or modal behavior when `topAnchor` is omitted.
> 
> **Overview**
> Adds an optional **`topAnchor`** prop on `Dialog` so consumers can pin the modal a fixed distance from the top of the viewport instead of vertically centering it. When `topAnchor` is set, horizontal centering is preserved (`sui-mx-auto`) and a new **`sui-top-anchor`** class applies `inset-block-start` via `--top-anchor`, plus a **`max-block-size`** so tall dialogs keep symmetric spacing from the bottom.
> 
> Default behavior is unchanged: without the prop, dialogs stay centered as before. Storybook gains a **With top anchor** story and play tests assert **`sui-top-anchor`** is present only when the prop is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f12d8b88a945135cc412af0fd8fe6aa971a17f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->