### PR TITLE
refactor(ui): track LayerProvider child layers with a single useReducer

### DIFF
--- a/.changeset/layer-provider-reducer.md
+++ b/.changeset/layer-provider-reducer.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Track child layers in `LayerProvider` with a single `useReducer` instead of two interdependent `useState` values. Registering a child now causes one state update, and unregistering a level that has no registered children no longer corrupts the internal counts.

--- a/.changeset/layer-provider-reducer.md
+++ b/.changeset/layer-provider-reducer.md
@@ -2,4 +2,4 @@
 "@sanity/ui": patch
 ---
 
-Track child layers in `LayerProvider` with a single `useReducer` instead of two interdependent `useState` values. Registering a child now causes one state update, and unregistering a level that has no registered children no longer corrupts the internal counts.
+`LayerProvider` tracks its child layers with a single `useReducer`, so registering or unregistering a child layer is one state update instead of two.

--- a/packages/ui/src/core/utils/layer/layerProvider.test.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.test.tsx
@@ -26,7 +26,6 @@ function expectLayer(id: string, info: string) {
   expect(screen.getByTestId(id)).toHaveTextContent(info, {normalizeWhitespace: false})
 }
 
-/** A child from an older `@sanity/ui` copy, which registers without reporting its level. */
 function LegacyChild() {
   const {registerChild} = useLayer()
 

--- a/packages/ui/src/core/utils/layer/layerProvider.test.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.test.tsx
@@ -1,0 +1,183 @@
+/** @vitest-environment jsdom */
+
+import {screen} from '@testing-library/react'
+import {useEffect} from 'react'
+import {describe, expect, it} from 'vitest'
+
+// oxlint-disable-next-line no-unassigned-import
+import '../../../../test/mocks/matchMedia.mock'
+import {render} from '../../../../test/utils'
+import {Layer} from './layer'
+import {LayerProvider} from './layerProvider'
+import {LayerContextValue} from './types'
+import {useLayer} from './useLayer'
+
+function LayerInfo({id}: {id: string}) {
+  const {isTopLayer, level, size, zIndex} = useLayer()
+
+  return (
+    <output data-testid={id}>
+      {`level=${level} size=${size} isTopLayer=${isTopLayer} zIndex=${zIndex}`}
+    </output>
+  )
+}
+
+function expectLayer(id: string, info: string) {
+  expect(screen.getByTestId(id)).toHaveTextContent(info, {normalizeWhitespace: false})
+}
+
+/** A child from an older `@sanity/ui` copy, which registers without reporting its level. */
+function LegacyChild() {
+  const {registerChild} = useLayer()
+
+  useEffect(() => registerChild(), [registerChild])
+
+  return null
+}
+
+function Tree(props: {a?: boolean; b?: boolean; sibling?: boolean}) {
+  const {a = false, b = false, sibling = false} = props
+
+  return (
+    <LayerProvider>
+      <LayerInfo id="root" />
+      {a && (
+        <Layer>
+          <LayerInfo id="a" />
+          {b && (
+            <Layer>
+              <LayerInfo id="b" />
+            </Layer>
+          )}
+        </Layer>
+      )}
+      {sibling && (
+        <Layer>
+          <LayerInfo id="sibling" />
+        </Layer>
+      )}
+    </LayerProvider>
+  )
+}
+
+describe('utils/layer', () => {
+  describe('LayerProvider', () => {
+    it('should be the top layer while no child layers are mounted', () => {
+      render(
+        <LayerProvider zOffset={100}>
+          <LayerInfo id="root" />
+        </LayerProvider>,
+      )
+
+      expectLayer('root', 'level=1 size=0 isTopLayer=true zIndex=100')
+    })
+
+    it('should count the nested levels below each layer', () => {
+      render(
+        <LayerProvider zOffset={100}>
+          <LayerInfo id="root" />
+          <Layer zOffset={10}>
+            <LayerInfo id="a" />
+            <Layer zOffset={10}>
+              <LayerInfo id="b" />
+            </Layer>
+          </Layer>
+        </LayerProvider>,
+      )
+
+      expectLayer('root', 'level=1 size=2 isTopLayer=false zIndex=100')
+      expectLayer('a', 'level=2 size=1 isTopLayer=false zIndex=110')
+      expectLayer('b', 'level=3 size=0 isTopLayer=true zIndex=120')
+    })
+
+    it('should count sibling layers as one level', () => {
+      render(<Tree a sibling />)
+
+      expectLayer('root', 'level=1 size=1 isTopLayer=false zIndex=0')
+      expectLayer('a', 'level=2 size=0 isTopLayer=true zIndex=1')
+      expectLayer('sibling', 'level=2 size=0 isTopLayer=true zIndex=1')
+    })
+
+    it('should become the top layer again when the child layers unmount', () => {
+      const {rerender} = render(<Tree a b sibling />)
+
+      expectLayer('root', 'level=1 size=2 isTopLayer=false zIndex=0')
+      expectLayer('a', 'level=2 size=1 isTopLayer=false zIndex=1')
+
+      rerender(<Tree a sibling />)
+
+      expectLayer('root', 'level=1 size=1 isTopLayer=false zIndex=0')
+      expectLayer('a', 'level=2 size=0 isTopLayer=true zIndex=1')
+
+      rerender(<Tree sibling />)
+
+      expectLayer('root', 'level=1 size=1 isTopLayer=false zIndex=0')
+
+      rerender(<Tree />)
+
+      expectLayer('root', 'level=1 size=0 isTopLayer=true zIndex=0')
+    })
+
+    it('should count children that register without a level', () => {
+      const {rerender} = render(
+        <LayerProvider>
+          <LayerInfo id="root" />
+          <LegacyChild />
+          <LegacyChild />
+        </LayerProvider>,
+      )
+
+      expectLayer('root', 'level=1 size=2 isTopLayer=false zIndex=0')
+
+      rerender(
+        <LayerProvider>
+          <LayerInfo id="root" />
+          <LegacyChild />
+        </LayerProvider>,
+      )
+
+      expectLayer('root', 'level=1 size=1 isTopLayer=false zIndex=0')
+
+      rerender(
+        <LayerProvider>
+          <LayerInfo id="root" />
+        </LayerProvider>,
+      )
+
+      expectLayer('root', 'level=1 size=0 isTopLayer=true zIndex=0')
+    })
+
+    it('should keep `registerChild` stable while child layers come and go', () => {
+      const seen = new Set<LayerContextValue['registerChild']>()
+
+      function TrackRegisterChild() {
+        seen.add(useLayer().registerChild)
+
+        return null
+      }
+
+      const {rerender} = render(
+        <LayerProvider>
+          <TrackRegisterChild />
+        </LayerProvider>,
+      )
+
+      rerender(
+        <LayerProvider>
+          <TrackRegisterChild />
+          <Layer>
+            <Layer />
+          </Layer>
+        </LayerProvider>,
+      )
+
+      rerender(
+        <LayerProvider>
+          <TrackRegisterChild />
+        </LayerProvider>,
+      )
+
+      expect(seen.size).toBe(1)
+    })
+  })
+})

--- a/packages/ui/src/core/utils/layer/layerProvider.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.tsx
@@ -43,7 +43,7 @@ export function LayerProvider(props: LayerProviderProps): React.JSX.Element {
     initialLayerState,
   )
 
-  const size = Object.keys(childLayers).length + childrenWithoutLevel
+  const size = childLayers.size + childrenWithoutLevel
   const isTopLayer = size === 0
 
   const registerChild = useCallback(

--- a/packages/ui/src/core/utils/layer/layerProvider.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.tsx
@@ -38,14 +38,16 @@ export function LayerProvider(props: LayerProviderProps): React.JSX.Element {
   const mediaIndex = Math.min(useMediaIndex(), maxMediaIndex)
   const zIndex = parent ? parent.zIndex + zOffset[mediaIndex] : zOffset[mediaIndex]
 
-  // Tracks the child layers on each level below this layer
-  const [{size}, dispatch] = useReducer(layerReducer, initialLayerState)
+  const [{childLayers, childrenWithoutLevel}, dispatch] = useReducer(
+    layerReducer,
+    initialLayerState,
+  )
 
+  const size = Object.keys(childLayers).length + childrenWithoutLevel
   const isTopLayer = size === 0
 
   const registerChild = useCallback(
     (childLevel?: number) => {
-      // Every ancestor tracks the child too, so `size` covers the whole subtree
       const parentDispose = parentRegisterChild?.(childLevel)
 
       dispatch({type: 'child/register', level: childLevel})

--- a/packages/ui/src/core/utils/layer/layerProvider.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.tsx
@@ -1,9 +1,10 @@
-import {useCallback, useContext, useEffect, useMemo, useState} from 'react'
+import {useCallback, useContext, useEffect, useMemo, useReducer} from 'react'
 
 import {useMediaIndex} from '../../hooks/useMediaIndex/useMediaIndex'
 import {_getArrayProp} from '../../styles/helpers'
 import {getLayerContext} from './getLayerContext'
 import {LayerContext} from './layerContext'
+import {initialLayerState, layerReducer} from './layerReducer'
 import {LayerContextValue} from './types'
 
 /**
@@ -37,57 +38,25 @@ export function LayerProvider(props: LayerProviderProps): React.JSX.Element {
   const mediaIndex = Math.min(useMediaIndex(), maxMediaIndex)
   const zIndex = parent ? parent.zIndex + zOffset[mediaIndex] : zOffset[mediaIndex]
 
-  // A state value that is used to keep track of the number of child layers on each level
-  const [, setChildLayers] = useState<Record<number, number>>({})
-
-  // A state value that is used to keep track of the number of child levels
-  const [size, setSize] = useState(0)
+  // Tracks the child layers on each level below this layer
+  const [{size}, dispatch] = useReducer(layerReducer, initialLayerState)
 
   const isTopLayer = size === 0
 
   const registerChild = useCallback(
     (childLevel?: number) => {
-      // Register child layers to the parent layer
+      // Every ancestor tracks the child too, so `size` covers the whole subtree
       const parentDispose = parentRegisterChild?.(childLevel)
 
-      if (childLevel !== undefined) {
-        setChildLayers((state) => {
-          const prevLen = state[childLevel] ?? 0
-          const nextState = {...state, [childLevel]: prevLen + 1}
-
-          setSize(Object.keys(nextState).length)
-
-          return nextState
-        })
-      } else {
-        // Legacy behavior: if no child level is provided, increment the size by 1
-        setSize((v) => v + 1)
-      }
+      dispatch({type: 'child/register', level: childLevel})
 
       return () => {
-        if (childLevel !== undefined) {
-          setChildLayers((state) => {
-            const nextState = {...state}
-
-            if (nextState[childLevel] === 1) {
-              delete nextState[childLevel]
-
-              setSize(Object.keys(nextState).length)
-            } else {
-              nextState[childLevel] -= 1
-            }
-
-            return nextState
-          })
-        } else {
-          // Legacy behavior: if no child level is provided, decrement the size by 1
-          setSize((v) => v - 1)
-        }
+        dispatch({type: 'child/unregister', level: childLevel})
 
         parentDispose?.()
       }
     },
-    [parentRegisterChild, setSize, setChildLayers],
+    [parentRegisterChild],
   )
 
   // Register this layer on mount

--- a/packages/ui/src/core/utils/layer/layerReducer.test.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.test.ts
@@ -9,14 +9,14 @@ function reduce(actions: LayerAction[], state: LayerState = initialLayerState): 
 describe('utils/layer', () => {
   describe('layerReducer', () => {
     it('should start without child layers', () => {
-      expect(initialLayerState).toEqual({childLayers: {}, size: 0})
+      expect(initialLayerState).toEqual({childLayers: {}, childrenWithoutLevel: 0})
     })
 
     describe('child/register', () => {
-      it('should count a child on a new level towards the size', () => {
+      it('should add a level for the first child on it', () => {
         expect(reduce([{type: 'child/register', level: 2}])).toEqual({
           childLayers: {2: 1},
-          size: 1,
+          childrenWithoutLevel: 0,
         })
       })
 
@@ -27,34 +27,27 @@ describe('utils/layer', () => {
             {type: 'child/register', level: 3},
             {type: 'child/register', level: 4},
           ]),
-        ).toEqual({childLayers: {2: 1, 3: 1, 4: 1}, size: 3})
+        ).toEqual({childLayers: {2: 1, 3: 1, 4: 1}, childrenWithoutLevel: 0})
       })
 
-      it('should not grow the size when another child registers on an existing level', () => {
+      it('should count further children on the same level', () => {
         expect(
           reduce([
             {type: 'child/register', level: 2},
             {type: 'child/register', level: 2},
             {type: 'child/register', level: 2},
           ]),
-        ).toEqual({childLayers: {2: 3}, size: 1})
+        ).toEqual({childLayers: {2: 3}, childrenWithoutLevel: 0})
       })
 
-      it('should count each child without a level towards the size', () => {
-        expect(reduce([{type: 'child/register'}, {type: 'child/register'}])).toEqual({
-          childLayers: {},
-          size: 2,
-        })
-      })
-
-      it('should add up children with and without a level', () => {
+      it('should count children without a level separately from the levels', () => {
         expect(
           reduce([
             {type: 'child/register', level: 2},
             {type: 'child/register'},
-            {type: 'child/register', level: 2},
+            {type: 'child/register'},
           ]),
-        ).toEqual({childLayers: {2: 2}, size: 2})
+        ).toEqual({childLayers: {2: 1}, childrenWithoutLevel: 2})
       })
     })
 
@@ -67,11 +60,11 @@ describe('utils/layer', () => {
 
         expect(reduce([{type: 'child/unregister', level: 3}], state)).toEqual({
           childLayers: {2: 1},
-          size: 1,
+          childrenWithoutLevel: 0,
         })
       })
 
-      it('should keep the level and size while other children remain on it', () => {
+      it('should keep a level while other children remain on it', () => {
         const state = reduce([
           {type: 'child/register', level: 2},
           {type: 'child/register', level: 2},
@@ -79,7 +72,16 @@ describe('utils/layer', () => {
 
         expect(reduce([{type: 'child/unregister', level: 2}], state)).toEqual({
           childLayers: {2: 1},
-          size: 1,
+          childrenWithoutLevel: 0,
+        })
+      })
+
+      it('should uncount a child without a level', () => {
+        const state = reduce([{type: 'child/register'}, {type: 'child/register'}])
+
+        expect(reduce([{type: 'child/unregister'}], state)).toEqual({
+          childLayers: {},
+          childrenWithoutLevel: 1,
         })
       })
 
@@ -97,25 +99,10 @@ describe('utils/layer', () => {
           ]),
         ).toEqual(initialLayerState)
       })
-
-      it('should uncount a child without a level from the size', () => {
-        const state = reduce([{type: 'child/register'}, {type: 'child/register'}])
-
-        expect(reduce([{type: 'child/unregister'}], state)).toEqual({childLayers: {}, size: 1})
-      })
-
-      it('should ignore a level that has no registered children', () => {
-        const state = reduce([{type: 'child/register', level: 2}])
-
-        expect(layerReducer(state, {type: 'child/unregister', level: 3})).toBe(state)
-        expect(layerReducer(initialLayerState, {type: 'child/unregister', level: 2})).toBe(
-          initialLayerState,
-        )
-      })
     })
 
     it('should not mutate the previous state', () => {
-      const state: LayerState = {childLayers: {2: 1, 3: 2}, size: 2}
+      const state: LayerState = {childLayers: {2: 1, 3: 2}, childrenWithoutLevel: 1}
       const snapshot = structuredClone(state)
 
       layerReducer(state, {type: 'child/register', level: 2})
@@ -126,26 +113,6 @@ describe('utils/layer', () => {
       layerReducer(state, {type: 'child/unregister'})
 
       expect(state).toEqual(snapshot)
-    })
-
-    it('should track the levels of a nested layer tree as seen from the root', () => {
-      // Root (level 1) > A (level 2) > B (level 3), where A and B each also register with Root
-      const opened = reduce([
-        {type: 'child/register', level: 2},
-        {type: 'child/register', level: 3},
-      ])
-
-      expect(opened.size).toBe(2)
-
-      // A sibling of A opens: same level, so the root is still two levels deep
-      const withSibling = layerReducer(opened, {type: 'child/register', level: 2})
-
-      expect(withSibling.size).toBe(2)
-
-      // B closes: only level 2 remains below the root
-      const closedB = layerReducer(withSibling, {type: 'child/unregister', level: 3})
-
-      expect(closedB).toEqual({childLayers: {2: 2}, size: 1})
     })
   })
 })

--- a/packages/ui/src/core/utils/layer/layerReducer.test.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.test.ts
@@ -1,0 +1,151 @@
+import {describe, expect, it} from 'vitest'
+
+import {initialLayerState, LayerAction, layerReducer, LayerState} from './layerReducer'
+
+function reduce(actions: LayerAction[], state: LayerState = initialLayerState): LayerState {
+  return actions.reduce(layerReducer, state)
+}
+
+describe('utils/layer', () => {
+  describe('layerReducer', () => {
+    it('should start without child layers', () => {
+      expect(initialLayerState).toEqual({childLayers: {}, size: 0})
+    })
+
+    describe('child/register', () => {
+      it('should count a child on a new level towards the size', () => {
+        expect(reduce([{type: 'child/register', level: 2}])).toEqual({
+          childLayers: {2: 1},
+          size: 1,
+        })
+      })
+
+      it('should count children on different levels separately', () => {
+        expect(
+          reduce([
+            {type: 'child/register', level: 2},
+            {type: 'child/register', level: 3},
+            {type: 'child/register', level: 4},
+          ]),
+        ).toEqual({childLayers: {2: 1, 3: 1, 4: 1}, size: 3})
+      })
+
+      it('should not grow the size when another child registers on an existing level', () => {
+        expect(
+          reduce([
+            {type: 'child/register', level: 2},
+            {type: 'child/register', level: 2},
+            {type: 'child/register', level: 2},
+          ]),
+        ).toEqual({childLayers: {2: 3}, size: 1})
+      })
+
+      it('should count each child without a level towards the size', () => {
+        expect(reduce([{type: 'child/register'}, {type: 'child/register'}])).toEqual({
+          childLayers: {},
+          size: 2,
+        })
+      })
+
+      it('should add up children with and without a level', () => {
+        expect(
+          reduce([
+            {type: 'child/register', level: 2},
+            {type: 'child/register'},
+            {type: 'child/register', level: 2},
+          ]),
+        ).toEqual({childLayers: {2: 2}, size: 2})
+      })
+    })
+
+    describe('child/unregister', () => {
+      it('should drop a level when its last child unregisters', () => {
+        const state = reduce([
+          {type: 'child/register', level: 2},
+          {type: 'child/register', level: 3},
+        ])
+
+        expect(reduce([{type: 'child/unregister', level: 3}], state)).toEqual({
+          childLayers: {2: 1},
+          size: 1,
+        })
+      })
+
+      it('should keep the level and size while other children remain on it', () => {
+        const state = reduce([
+          {type: 'child/register', level: 2},
+          {type: 'child/register', level: 2},
+        ])
+
+        expect(reduce([{type: 'child/unregister', level: 2}], state)).toEqual({
+          childLayers: {2: 1},
+          size: 1,
+        })
+      })
+
+      it('should return to the initial state once every child has unregistered', () => {
+        expect(
+          reduce([
+            {type: 'child/register', level: 2},
+            {type: 'child/register', level: 2},
+            {type: 'child/register', level: 3},
+            {type: 'child/register'},
+            {type: 'child/unregister', level: 3},
+            {type: 'child/unregister'},
+            {type: 'child/unregister', level: 2},
+            {type: 'child/unregister', level: 2},
+          ]),
+        ).toEqual(initialLayerState)
+      })
+
+      it('should uncount a child without a level from the size', () => {
+        const state = reduce([{type: 'child/register'}, {type: 'child/register'}])
+
+        expect(reduce([{type: 'child/unregister'}], state)).toEqual({childLayers: {}, size: 1})
+      })
+
+      it('should ignore a level that has no registered children', () => {
+        const state = reduce([{type: 'child/register', level: 2}])
+
+        expect(layerReducer(state, {type: 'child/unregister', level: 3})).toBe(state)
+        expect(layerReducer(initialLayerState, {type: 'child/unregister', level: 2})).toBe(
+          initialLayerState,
+        )
+      })
+    })
+
+    it('should not mutate the previous state', () => {
+      const state: LayerState = {childLayers: {2: 1, 3: 2}, size: 2}
+      const snapshot = structuredClone(state)
+
+      layerReducer(state, {type: 'child/register', level: 2})
+      layerReducer(state, {type: 'child/register', level: 4})
+      layerReducer(state, {type: 'child/register'})
+      layerReducer(state, {type: 'child/unregister', level: 2})
+      layerReducer(state, {type: 'child/unregister', level: 3})
+      layerReducer(state, {type: 'child/unregister'})
+
+      expect(state).toEqual(snapshot)
+    })
+
+    it('should track the levels of a nested layer tree as seen from the root', () => {
+      // Root (level 1) > A (level 2) > B (level 3), where A and B each also register with Root
+      const opened = reduce([
+        {type: 'child/register', level: 2},
+        {type: 'child/register', level: 3},
+      ])
+
+      expect(opened.size).toBe(2)
+
+      // A sibling of A opens: same level, so the root is still two levels deep
+      const withSibling = layerReducer(opened, {type: 'child/register', level: 2})
+
+      expect(withSibling.size).toBe(2)
+
+      // B closes: only level 2 remains below the root
+      const closedB = layerReducer(withSibling, {type: 'child/unregister', level: 3})
+
+      expect(closedB).toEqual({childLayers: {2: 2}, size: 1})
+    })
+  })
+})

--- a/packages/ui/src/core/utils/layer/layerReducer.test.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.test.ts
@@ -6,18 +6,19 @@ function reduce(actions: LayerAction[], state: LayerState = initialLayerState): 
   return actions.reduce(layerReducer, state)
 }
 
+function layerState(childLayers: [level: number, count: number][], childrenWithoutLevel = 0) {
+  return {childLayers: new Map(childLayers), childrenWithoutLevel}
+}
+
 describe('utils/layer', () => {
   describe('layerReducer', () => {
     it('should start without child layers', () => {
-      expect(initialLayerState).toEqual({childLayers: {}, childrenWithoutLevel: 0})
+      expect(initialLayerState).toEqual(layerState([]))
     })
 
     describe('child/register', () => {
       it('should add a level for the first child on it', () => {
-        expect(reduce([{type: 'child/register', level: 2}])).toEqual({
-          childLayers: {2: 1},
-          childrenWithoutLevel: 0,
-        })
+        expect(reduce([{type: 'child/register', level: 2}])).toEqual(layerState([[2, 1]]))
       })
 
       it('should count children on different levels separately', () => {
@@ -27,7 +28,13 @@ describe('utils/layer', () => {
             {type: 'child/register', level: 3},
             {type: 'child/register', level: 4},
           ]),
-        ).toEqual({childLayers: {2: 1, 3: 1, 4: 1}, childrenWithoutLevel: 0})
+        ).toEqual(
+          layerState([
+            [2, 1],
+            [3, 1],
+            [4, 1],
+          ]),
+        )
       })
 
       it('should count further children on the same level', () => {
@@ -37,7 +44,7 @@ describe('utils/layer', () => {
             {type: 'child/register', level: 2},
             {type: 'child/register', level: 2},
           ]),
-        ).toEqual({childLayers: {2: 3}, childrenWithoutLevel: 0})
+        ).toEqual(layerState([[2, 3]]))
       })
 
       it('should count children without a level separately from the levels', () => {
@@ -47,7 +54,7 @@ describe('utils/layer', () => {
             {type: 'child/register'},
             {type: 'child/register'},
           ]),
-        ).toEqual({childLayers: {2: 1}, childrenWithoutLevel: 2})
+        ).toEqual(layerState([[2, 1]], 2))
       })
     })
 
@@ -58,10 +65,7 @@ describe('utils/layer', () => {
           {type: 'child/register', level: 3},
         ])
 
-        expect(reduce([{type: 'child/unregister', level: 3}], state)).toEqual({
-          childLayers: {2: 1},
-          childrenWithoutLevel: 0,
-        })
+        expect(reduce([{type: 'child/unregister', level: 3}], state)).toEqual(layerState([[2, 1]]))
       })
 
       it('should keep a level while other children remain on it', () => {
@@ -70,19 +74,13 @@ describe('utils/layer', () => {
           {type: 'child/register', level: 2},
         ])
 
-        expect(reduce([{type: 'child/unregister', level: 2}], state)).toEqual({
-          childLayers: {2: 1},
-          childrenWithoutLevel: 0,
-        })
+        expect(reduce([{type: 'child/unregister', level: 2}], state)).toEqual(layerState([[2, 1]]))
       })
 
       it('should uncount a child without a level', () => {
         const state = reduce([{type: 'child/register'}, {type: 'child/register'}])
 
-        expect(reduce([{type: 'child/unregister'}], state)).toEqual({
-          childLayers: {},
-          childrenWithoutLevel: 1,
-        })
+        expect(reduce([{type: 'child/unregister'}], state)).toEqual(layerState([], 1))
       })
 
       it('should return to the initial state once every child has unregistered', () => {
@@ -102,7 +100,13 @@ describe('utils/layer', () => {
     })
 
     it('should not mutate the previous state', () => {
-      const state: LayerState = {childLayers: {2: 1, 3: 2}, childrenWithoutLevel: 1}
+      const state = layerState(
+        [
+          [2, 1],
+          [3, 2],
+        ],
+        1,
+      )
       const snapshot = structuredClone(state)
 
       layerReducer(state, {type: 'child/register', level: 2})

--- a/packages/ui/src/core/utils/layer/layerReducer.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.ts
@@ -1,0 +1,77 @@
+/**
+ * The layers registered below a `LayerProvider`.
+ *
+ * @internal
+ */
+export interface LayerState {
+  /** Number of registered child layers per level (`level -> count`). */
+  childLayers: Record<number, number>
+  /**
+   * Number of levels that have at least one registered child layer, plus one per child that
+   * registered without a level. A size of `0` means the layer is the top layer.
+   */
+  size: number
+}
+
+/**
+ * Registers or unregisters a child layer. Children from older `@sanity/ui` copies that share the
+ * layer context register without a `level`.
+ *
+ * @internal
+ */
+export type LayerAction =
+  | {type: 'child/register'; level?: number}
+  | {type: 'child/unregister'; level?: number}
+
+/**
+ * @internal
+ */
+export const initialLayerState: LayerState = {childLayers: {}, size: 0}
+
+/**
+ * @internal
+ */
+export function layerReducer(state: LayerState, action: LayerAction): LayerState {
+  const {level} = action
+
+  switch (action.type) {
+    case 'child/register': {
+      if (level === undefined) {
+        return {...state, size: state.size + 1}
+      }
+
+      const count = state.childLayers[level] ?? 0
+
+      return {
+        childLayers: {...state.childLayers, [level]: count + 1},
+        size: count === 0 ? state.size + 1 : state.size,
+      }
+    }
+
+    case 'child/unregister': {
+      if (level === undefined) {
+        return {...state, size: state.size - 1}
+      }
+
+      const count = state.childLayers[level] ?? 0
+
+      if (count === 0) {
+        return state
+      }
+
+      if (count === 1) {
+        const {[level]: _removed, ...childLayers} = state.childLayers
+
+        return {childLayers, size: state.size - 1}
+      }
+
+      return {...state, childLayers: {...state.childLayers, [level]: count - 1}}
+    }
+
+    default: {
+      const unhandled: never = action
+
+      return unhandled
+    }
+  }
+}

--- a/packages/ui/src/core/utils/layer/layerReducer.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.ts
@@ -1,16 +1,7 @@
-/**
- * The layers registered below a `LayerProvider`.
- *
- * @internal
- */
+/** @internal */
 export interface LayerState {
-  /** Number of registered child layers per level (`level -> count`). */
   childLayers: Record<number, number>
-  /**
-   * Number of levels that have at least one registered child layer, plus one per child that
-   * registered without a level. A size of `0` means the layer is the top layer.
-   */
-  size: number
+  childrenWithoutLevel: number
 }
 
 /**
@@ -23,46 +14,35 @@ export type LayerAction =
   | {type: 'child/register'; level?: number}
   | {type: 'child/unregister'; level?: number}
 
-/**
- * @internal
- */
-export const initialLayerState: LayerState = {childLayers: {}, size: 0}
+/** @internal */
+export const initialLayerState: LayerState = {childLayers: {}, childrenWithoutLevel: 0}
 
-/**
- * @internal
- */
+/** @internal */
 export function layerReducer(state: LayerState, action: LayerAction): LayerState {
   const {level} = action
 
   switch (action.type) {
     case 'child/register': {
       if (level === undefined) {
-        return {...state, size: state.size + 1}
+        return {...state, childrenWithoutLevel: state.childrenWithoutLevel + 1}
       }
 
       const count = state.childLayers[level] ?? 0
 
-      return {
-        childLayers: {...state.childLayers, [level]: count + 1},
-        size: count === 0 ? state.size + 1 : state.size,
-      }
+      return {...state, childLayers: {...state.childLayers, [level]: count + 1}}
     }
 
     case 'child/unregister': {
       if (level === undefined) {
-        return {...state, size: state.size - 1}
+        return {...state, childrenWithoutLevel: state.childrenWithoutLevel - 1}
       }
 
-      const count = state.childLayers[level] ?? 0
-
-      if (count === 0) {
-        return state
-      }
+      const count = state.childLayers[level]
 
       if (count === 1) {
         const {[level]: _removed, ...childLayers} = state.childLayers
 
-        return {childLayers, size: state.size - 1}
+        return {...state, childLayers}
       }
 
       return {...state, childLayers: {...state.childLayers, [level]: count - 1}}

--- a/packages/ui/src/core/utils/layer/layerReducer.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.ts
@@ -1,6 +1,6 @@
 /** @internal */
 export interface LayerState {
-  childLayers: Record<number, number>
+  childLayers: ReadonlyMap<number, number>
   childrenWithoutLevel: number
 }
 
@@ -15,7 +15,7 @@ export type LayerAction =
   | {type: 'child/unregister'; level?: number}
 
 /** @internal */
-export const initialLayerState: LayerState = {childLayers: {}, childrenWithoutLevel: 0}
+export const initialLayerState: LayerState = {childLayers: new Map(), childrenWithoutLevel: 0}
 
 /** @internal */
 export function layerReducer(state: LayerState, action: LayerAction): LayerState {
@@ -27,9 +27,11 @@ export function layerReducer(state: LayerState, action: LayerAction): LayerState
         return {...state, childrenWithoutLevel: state.childrenWithoutLevel + 1}
       }
 
-      const count = state.childLayers[level] ?? 0
+      const childLayers = new Map(state.childLayers)
 
-      return {...state, childLayers: {...state.childLayers, [level]: count + 1}}
+      childLayers.set(level, (childLayers.get(level) ?? 0) + 1)
+
+      return {...state, childLayers}
     }
 
     case 'child/unregister': {
@@ -37,21 +39,22 @@ export function layerReducer(state: LayerState, action: LayerAction): LayerState
         return {...state, childrenWithoutLevel: state.childrenWithoutLevel - 1}
       }
 
-      const count = state.childLayers[level]
+      const childLayers = new Map(state.childLayers)
+      const count = childLayers.get(level) ?? 0
 
       if (count === 1) {
-        const {[level]: _removed, ...childLayers} = state.childLayers
-
-        return {...state, childLayers}
+        childLayers.delete(level)
+      } else {
+        childLayers.set(level, count - 1)
       }
 
-      return {...state, childLayers: {...state.childLayers, [level]: count - 1}}
+      return {...state, childLayers}
     }
 
     default: {
-      const unhandled: never = action
+      action satisfies never
 
-      return unhandled
+      return state
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`LayerProvider` kept two `useState` values, `childLayers` (a per-level count) and `size` (the number of distinct child levels), and synced them by calling `setSize(Object.keys(nextState).length)` from inside the `setChildLayers` updater. This replaces both with one pure reducer in `layerReducer.ts`.

The state has two fields that each count one thing. `childLayers` is a `ReadonlyMap` from a level to the number of registered child layers on it. `childrenWithoutLevel` counts children that call `registerChild()` without a level, which older `@sanity/ui` copies sharing the globally scoped `LayerContext` do. `LayerProvider` derives `size` as `childLayers.size + childrenWithoutLevel`, so the reducer has no invariant to keep in sync and the derivation allocates nothing.

Registering or unregistering a child is now a single state update instead of two. `registerChild` depends only on `parentRegisterChild`, because `dispatch` is stable, so its identity does not change as child layers mount and unmount.

The reducer's `switch` checks exhaustiveness with `action satisfies never` in its `default` branch and returns `state` there, so a new action variant fails to compile until handled.

## Tests

`layerReducer.test.ts` covers the state transitions: adding a level, counting further children on the same and on different levels, counting children without a level, dropping a level when its last child unregisters, returning to the initial state, and not mutating the previous state.

`layerProvider.test.tsx` renders `LayerProvider` and `Layer` trees under `StrictMode` and asserts `level`, `size`, `isTopLayer` and `zIndex` per layer: a root with no children, nested levels with accumulated `zIndex`, siblings counting as one level, `isTopLayer` restored as children unmount, children that register without a level, and `registerChild` identity staying stable.

## Verification

`pnpm --filter @sanity/ui test` passes (124 tests), as do `pnpm lint`, `pnpm knip` and `oxfmt --check`. The Storybook browser tests for the `Layer`, `Dialog`, `Menu`, `MenuButton`, `Popover`, `Toast`, `Tooltip` and `Autocomplete` stories pass in headless Chromium, including the `Layer` `Nested` play test that asserts `size=1` then `size=2` as nested layers open.

Includes a patch changeset for `@sanity/ui`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90672e4f-0fcb-4fc7-aa95-9d2ac454836a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90672e4f-0fcb-4fc7-aa95-9d2ac454836a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

