### PR TITLE
fix: wobbly spinner in safari

### DIFF
--- a/packages/ui/src/core/primitives/spinner/spinner.css.ts
+++ b/packages/ui/src/core/primitives/spinner/spinner.css.ts
@@ -5,6 +5,10 @@ const rotate = keyframes({
   to: {transform: 'rotate(360deg)'},
 })
 
+const size = 'round(1em, 2px)'
 export const spinnerIcon = style({
   animation: `${rotate} 500ms linear infinite`,
+  // Prevents a wobbly spinner on Safari
+  height: size,
+  width: size,
 })


### PR DESCRIPTION
### Description

The video shows the before/after

https://github.com/user-attachments/assets/8f0f5710-d7ab-4417-99da-39132cfca64c



### What to review

Should work fine in other browsers too.

### Testing

Tested in Safari as shown in the above video

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only sizing tweak on the shared spinner primitive with no auth, data, or API impact.
> 
> **Overview**
> Fixes Safari’s **wobbly spinner** during rotation by giving `spinnerIcon` explicit **height and width** via `round(1em, 2px)`, so the animated icon stays square and stable while still scaling with font size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a98d2b314a81e161a04010985efab6b85b6e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->