### PR TITLE
fix(ui): make layer disposal idempotent

### DIFF
--- a/.changeset/layer-dispose-twice.md
+++ b/.changeset/layer-dispose-twice.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+Keep `LayerProvider` state correct when a child disposer is called more than once.

--- a/.changeset/layer-dispose-twice.md
+++ b/.changeset/layer-dispose-twice.md
@@ -2,4 +2,5 @@
 "@sanity/ui": patch
 ---
 
-Keep `LayerProvider` state correct when a child disposer is called more than once.
+Calling the disposer returned by `useLayer().registerChild()` more than once no longer corrupts the
+parent layer's `size` and `isTopLayer`.

--- a/packages/ui/src/core/utils/layer/layerProvider.test.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.test.tsx
@@ -34,6 +34,19 @@ function LegacyChild() {
   return null
 }
 
+function DisposeTwiceChild() {
+  const {registerChild} = useLayer()
+
+  useEffect(() => {
+    const dispose = registerChild(2)
+
+    dispose()
+    dispose()
+  }, [registerChild])
+
+  return null
+}
+
 function Tree(props: {a?: boolean; b?: boolean; sibling?: boolean}) {
   const {a = false, b = false, sibling = false} = props
 
@@ -140,6 +153,17 @@ describe('utils/layer', () => {
       rerender(
         <LayerProvider>
           <LayerInfo id="root" />
+        </LayerProvider>,
+      )
+
+      expectLayer('root', 'level=1 size=0 isTopLayer=true zIndex=0')
+    })
+
+    it('should ignore a repeated child disposer call', () => {
+      render(
+        <LayerProvider>
+          <LayerInfo id="root" />
+          <DisposeTwiceChild />
         </LayerProvider>,
       )
 

--- a/packages/ui/src/core/utils/layer/layerProvider.test.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.test.tsx
@@ -47,6 +47,14 @@ function DisposeTwiceChild() {
   return null
 }
 
+function RegisteredChild() {
+  const {registerChild} = useLayer()
+
+  useEffect(() => registerChild(2), [registerChild])
+
+  return null
+}
+
 function Tree(props: {a?: boolean; b?: boolean; sibling?: boolean}) {
   const {a = false, b = false, sibling = false} = props
 
@@ -163,11 +171,12 @@ describe('utils/layer', () => {
       render(
         <LayerProvider>
           <LayerInfo id="root" />
+          <RegisteredChild />
           <DisposeTwiceChild />
         </LayerProvider>,
       )
 
-      expectLayer('root', 'level=1 size=0 isTopLayer=true zIndex=0')
+      expectLayer('root', 'level=1 size=1 isTopLayer=false zIndex=0')
     })
 
     it('should keep `registerChild` stable while child layers come and go', () => {

--- a/packages/ui/src/core/utils/layer/layerProvider.test.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import {screen} from '@testing-library/react'
+import {act, screen} from '@testing-library/react'
 import {useEffect} from 'react'
 import {describe, expect, it} from 'vitest'
 
@@ -34,23 +34,17 @@ function LegacyChild() {
   return null
 }
 
-function DisposeTwiceChild() {
+function DisposableChild(props: {level: number; onRegister: (dispose: () => void) => void}) {
+  const {level, onRegister} = props
   const {registerChild} = useLayer()
 
   useEffect(() => {
-    const dispose = registerChild(2)
+    const dispose = registerChild(level)
 
-    dispose()
-    dispose()
-  }, [registerChild])
+    onRegister(dispose)
 
-  return null
-}
-
-function RegisteredChild() {
-  const {registerChild} = useLayer()
-
-  useEffect(() => registerChild(2), [registerChild])
+    return dispose
+  }, [level, onRegister, registerChild])
 
   return null
 }
@@ -167,12 +161,30 @@ describe('utils/layer', () => {
       expectLayer('root', 'level=1 size=0 isTopLayer=true zIndex=0')
     })
 
-    it('should ignore a repeated child disposer call', () => {
-      render(
+    it('should keep counting a sibling layer when a child disposer is called twice', () => {
+      let dispose: (() => void) | undefined
+      const onRegister = (fn: () => void) => {
+        dispose = fn
+      }
+
+      const {rerender} = render(
         <LayerProvider>
           <LayerInfo id="root" />
-          <RegisteredChild />
-          <DisposeTwiceChild />
+          <Layer />
+          <DisposableChild level={2} onRegister={onRegister} />
+        </LayerProvider>,
+      )
+
+      expectLayer('root', 'level=1 size=1 isTopLayer=false zIndex=0')
+
+      act(() => dispose?.())
+
+      expectLayer('root', 'level=1 size=1 isTopLayer=false zIndex=0')
+
+      rerender(
+        <LayerProvider>
+          <LayerInfo id="root" />
+          <Layer />
         </LayerProvider>,
       )
 

--- a/packages/ui/src/core/utils/layer/layerProvider.tsx
+++ b/packages/ui/src/core/utils/layer/layerProvider.tsx
@@ -49,10 +49,15 @@ export function LayerProvider(props: LayerProviderProps): React.JSX.Element {
   const registerChild = useCallback(
     (childLevel?: number) => {
       const parentDispose = parentRegisterChild?.(childLevel)
+      let disposed = false
 
       dispatch({type: 'child/register', level: childLevel})
 
       return () => {
+        if (disposed) return
+
+        disposed = true
+
         dispatch({type: 'child/unregister', level: childLevel})
 
         parentDispose?.()

--- a/packages/ui/src/core/utils/layer/layerReducer.test.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.test.ts
@@ -83,6 +83,18 @@ describe('utils/layer', () => {
         expect(reduce([{type: 'child/unregister'}], state)).toEqual(layerState([], 1))
       })
 
+      it('should ignore a level that is not registered', () => {
+        const state = layerState([[2, 1]])
+
+        expect(layerReducer(state, {type: 'child/unregister', level: 3})).toBe(state)
+      })
+
+      it('should ignore a child without a level when none are registered', () => {
+        const state = layerState([[2, 1]])
+
+        expect(layerReducer(state, {type: 'child/unregister'})).toBe(state)
+      })
+
       it('should return to the initial state once every child has unregistered', () => {
         expect(
           reduce([

--- a/packages/ui/src/core/utils/layer/layerReducer.test.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.test.ts
@@ -83,18 +83,6 @@ describe('utils/layer', () => {
         expect(reduce([{type: 'child/unregister'}], state)).toEqual(layerState([], 1))
       })
 
-      it('should ignore a level that is not registered', () => {
-        const state = layerState([[2, 1]])
-
-        expect(layerReducer(state, {type: 'child/unregister', level: 3})).toBe(state)
-      })
-
-      it('should ignore a child without a level when none are registered', () => {
-        const state = layerState([[2, 1]])
-
-        expect(layerReducer(state, {type: 'child/unregister'})).toBe(state)
-      })
-
       it('should return to the initial state once every child has unregistered', () => {
         expect(
           reduce([

--- a/packages/ui/src/core/utils/layer/layerReducer.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.ts
@@ -5,8 +5,7 @@ export interface LayerState {
 }
 
 /**
- * Registers or unregisters a child layer. Children from older `@sanity/ui` copies that share the
- * layer context register without a `level`.
+ * Children from older `@sanity/ui` copies that share the layer context register without a `level`.
  *
  * @internal
  */

--- a/packages/ui/src/core/utils/layer/layerReducer.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.ts
@@ -36,11 +36,16 @@ export function layerReducer(state: LayerState, action: LayerAction): LayerState
 
     case 'child/unregister': {
       if (level === undefined) {
+        if (state.childrenWithoutLevel === 0) return state
+
         return {...state, childrenWithoutLevel: state.childrenWithoutLevel - 1}
       }
 
+      const count = state.childLayers.get(level)
+
+      if (count === undefined) return state
+
       const childLayers = new Map(state.childLayers)
-      const count = childLayers.get(level) ?? 0
 
       if (count === 1) {
         childLayers.delete(level)

--- a/packages/ui/src/core/utils/layer/layerReducer.ts
+++ b/packages/ui/src/core/utils/layer/layerReducer.ts
@@ -35,16 +35,11 @@ export function layerReducer(state: LayerState, action: LayerAction): LayerState
 
     case 'child/unregister': {
       if (level === undefined) {
-        if (state.childrenWithoutLevel === 0) return state
-
         return {...state, childrenWithoutLevel: state.childrenWithoutLevel - 1}
       }
 
-      const count = state.childLayers.get(level)
-
-      if (count === undefined) return state
-
       const childLayers = new Map(state.childLayers)
+      const count = childLayers.get(level) ?? 0
 
       if (count === 1) {
         childLayers.delete(level)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Each `registerChild` call increments a count for its child level and returns a disposer. A consumer can dispose on close and invoke the same disposer again during effect cleanup. With another child still mounted at that level, the second call consumed the sibling's count. `LayerProvider` then incorrectly reported `size=0` and `isTopLayer=true`.

## Fix

Each returned disposer now owns one registration and unregisters it at most once. The guard lives in the disposer closure because the reducer only knows level totals and cannot distinguish two registrations on the same level.

## Red-green proof

- `29856d2ed` adds the initial failing repeated-disposal regression.
- The final regression models close followed by unmount while a sibling remains mounted.
- Before the fix, it fails with expected `size=1 isTopLayer=false` and received `size=0 isTopLayer=true`.
- `932475446` makes each disposer idempotent. The same close-then-unmount scenario passes.

## Validation

- Targeted layer tests: 2 files, 17 tests passed.
- Full unit suite: `@sanity/ui` 184 passed and 1 skipped; all package suites passed.
- `pnpm lint` passed, including type checking.
- `pnpm knip` passed.
- Independent investigation confirmed the disposer closure is the root-cause boundary. The earlier reducer clamps were removed because they could not prevent one registration from consuming a sibling's count.
- Comment audit completed; the single accepted cleanup is included.

A patch changeset is included.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a881e015-846f-48d8-8d56-8d6f53a994cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a881e015-846f-48d8-8d56-8d6f53a994cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

