### PR TITLE
fix(ui): set color-scheme inline on Card from its resolved scheme

### DIFF
--- a/.changeset/card-color-scheme-node.md
+++ b/.changeset/card-color-scheme-node.md
@@ -1,0 +1,5 @@
+---
+"@sanity/ui": patch
+---
+
+`Card` now sets `color-scheme` inline on its own element from the scheme it resolves (the `scheme` prop, falling back to the closest `ThemeProvider`), instead of through its generated stylesheet, and `data-scheme` reports that same resolved scheme rather than the parent scheme. `light-dark()` colors and native form controls inside a card follow the card's scheme regardless of the document `color-scheme` or the operating system.

--- a/packages/ui/src/core/primitives/card/card.test.tsx
+++ b/packages/ui/src/core/primitives/card/card.test.tsx
@@ -1,0 +1,51 @@
+/** @vitest-environment jsdom */
+
+import {screen} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+
+import {render} from '../../../../test/utils'
+import {Card} from './card'
+
+describe('<Card />', () => {
+  it('applies the inherited scheme as `color-scheme` on its own element', () => {
+    render(<Card data-testid="card" />, {scheme: 'dark'})
+
+    const card = screen.getByTestId('card')
+
+    expect(card).toHaveAttribute('data-scheme', 'dark')
+    expect(card).toHaveStyle({colorScheme: 'dark'})
+  })
+
+  it('applies the `scheme` prop rather than the parent scheme', () => {
+    render(<Card data-testid="card" scheme="dark" />, {scheme: 'light'})
+
+    const card = screen.getByTestId('card')
+
+    expect(card).toHaveAttribute('data-scheme', 'dark')
+    expect(card).toHaveStyle({colorScheme: 'dark'})
+  })
+
+  it('passes its scheme on to nested cards', () => {
+    render(
+      <Card scheme="dark">
+        <Card data-testid="inherited" />
+        <Card data-testid="overridden" scheme="light" />
+      </Card>,
+      {scheme: 'light'},
+    )
+
+    const inherited = screen.getByTestId('inherited')
+    const overridden = screen.getByTestId('overridden')
+
+    expect(inherited).toHaveAttribute('data-scheme', 'dark')
+    expect(inherited).toHaveStyle({colorScheme: 'dark'})
+    expect(overridden).toHaveAttribute('data-scheme', 'light')
+    expect(overridden).toHaveStyle({colorScheme: 'light'})
+  })
+
+  it('keeps consumer inline styles alongside `color-scheme`', () => {
+    render(<Card data-testid="card" style={{width: 100}} />)
+
+    expect(screen.getByTestId('card')).toHaveStyle({colorScheme: 'light', width: '100px'})
+  })
+})

--- a/packages/ui/src/core/primitives/card/card.tsx
+++ b/packages/ui/src/core/primitives/card/card.tsx
@@ -36,6 +36,13 @@ export interface CardOwnProps
   disabled?: boolean
   muted?: boolean
   pressed?: boolean
+  /**
+   * Overrides the color scheme inherited from the closest `ThemeProvider`.
+   *
+   * The resolved scheme is applied as the CSS `color-scheme` of the rendered element (and exposed
+   * as `data-scheme`), so `light-dark()` colors and native form controls inside the card follow
+   * the card rather than the operating system.
+   */
   scheme?: ThemeColorSchemeKey
   selected?: boolean
   tone?: CardTone
@@ -69,15 +76,17 @@ function CardComponent(
     pressed,
     radius = 0,
     ref,
-    scheme,
+    scheme: schemeProp,
     selected,
     shadow,
+    style,
     tone: toneProp = 'default',
     ...restProps
   } = props
 
   const as = isValidElementType(asProp) ? asProp : 'div'
   const rootTheme = useRootTheme()
+  const scheme = schemeProp ?? rootTheme.scheme
   const tone = toneProp === 'inherit' ? rootTheme.tone : toneProp
 
   // todo: Consider adding the wrapper approach for nested cards in which the tones are not changing, avoid unnecessary ThemeColorProvider
@@ -85,7 +94,7 @@ function CardComponent(
     <ThemeColorProvider scheme={scheme} tone={tone}>
       <StyledCard
         data-as={typeof as === 'string' ? as : undefined}
-        data-scheme={rootTheme.scheme}
+        data-scheme={scheme}
         data-ui="Card"
         data-tone={tone}
         {...restProps}
@@ -106,6 +115,7 @@ function CardComponent(
         forwardedAs={as}
         ref={ref}
         selected={selected}
+        style={{colorScheme: scheme, ...style}}
       />
     </ThemeColorProvider>
   )

--- a/packages/ui/src/core/primitives/card/styles.ts
+++ b/packages/ui/src/core/primitives/card/styles.ts
@@ -57,8 +57,6 @@ function cardColorStyle(props: CardStyleProps & ThemeProps): ReturnType<typeof c
   const border = {width: card.border.width, color: 'var(--card-border-color)'}
 
   return css`
-    color-scheme: ${color._dark ? 'dark' : 'light'};
-
     ${_cardColorStyle(color, color, $checkered)}
 
     background-color: ${$muted ? 'var(--card-muted-bg-color)' : 'var(--card-bg-color)'};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to the discussion around [sanity-io/sanity#14727](https://github.com/sanity-io/sanity/pull/14727): `Card` owns its scheme, so it should be the thing that puts `color-scheme` on its own element.

`Card` now resolves its scheme once (`scheme` prop, falling back to the closest `ThemeProvider`) and:

- applies it as an inline `style="color-scheme: light|dark"` on the rendered element, replacing the `color-scheme: ${color._dark ? 'dark' : 'light'}` rule that lived in the generated stylesheet (`cardColorStyle`). The node itself now carries the scheme, next to `data-scheme`, independent of stylesheet injection order or `styled(Card)` overrides.
- sets `data-scheme` to that same resolved scheme. Previously it was `rootTheme.scheme`, i.e. the *parent* scheme, so `<Card scheme="dark">` inside a light theme rendered `data-scheme="light"` while its CSS said `color-scheme: dark`. The two now agree.
- passes the resolved scheme to `ThemeColorProvider` (no behavioural change, it did the same fallback internally).

Consumer `style` is merged after `colorScheme`, so an explicit inline override still wins.

### What this does and does not cover

`light-dark()` tokens (e.g. ui5's `:root { --foreground-high: light-dark(...) }` under `:root { color-scheme: light dark }`) resolve against the *using* element's inherited `color-scheme`, so anything rendered inside a v4 `Card` already followed the card's scheme — the stylesheet rule has been there since 2022 (0c15c7d). Probing the running Studio (`apps/studio`, `sanity@6.13.1` / `ui5` alpha.9) with Studio appearance dark and OS light confirmed that ui5 nodes inside the tool `Card` and the `Navbar` card resolve dark, while the ui5 root `Flex` (`data-ui="ToolScreen"`) and ui5 `Popover`/`Tooltip` content portalled to `document.body` still resolve light, because there is no `Card` above them. This PR makes `Card`'s ownership explicit and consistent, but on its own it cannot reach those surfaces — that still needs either a `Card` above the ui5 root (and a scheme-carrying portal), or the document-level write from sanity#14727.

### Testing

- New `card.test.tsx`: inherited scheme, `scheme` prop overriding the parent, nested cards, consumer `style` merging. The two `data-scheme` assertions fail on `main`.
- `pnpm lint` (incl. type check), `pnpm test`, `pnpm knip`, `pnpm --filter @sanity/ui build`, and the full Storybook browser suite (`pnpm test:browser`, 255 tests) all pass.
- Browser probe against the live Storybook `Card` stories: every card reports matching `data-scheme` / inline `color-scheme`, and a `light-dark()` custom property declared on `:root { color-scheme: light dark }` resolves per card under both `prefers-color-scheme: light` and `dark`.

[Nested scheme story annotated with each card](https://cursor.com/agents/bc-b4c0b94a-b5cd-49e2-83b9-08fe36811e0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_card_nested_schemes_after.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4c0b94a-b5cd-49e2-83b9-08fe36811e0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4c0b94a-b5cd-49e2-83b9-08fe36811e0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

